### PR TITLE
chore: fix Layout/SpaceInsideArrayLiteralBrackets rubocop violations

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -19,6 +19,6 @@ class RegistrationsController < ApplicationController
   private
 
   def user_params
-    params.expect(user: [:email_address, :password, :password_confirmation])
+    params.expect(user: [ :email_address, :password, :password_confirmation ])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,8 @@ Rails.application.routes.draw do
 
   resource :session
   resources :passwords, param: :token
-  resources :tags, only: [:index, :show]
-  resources :dictionary_entries, only: [:show]
+  resources :tags, only: [ :index, :show ]
+  resources :dictionary_entries, only: [ :show ]
   get "signup", to: "registrations#new"
   post "signup", to: "registrations#create"
 end

--- a/spec/mailers/passwords_mailer_spec.rb
+++ b/spec/mailers/passwords_mailer_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe PasswordsMailer, type: :mailer do
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Reset your password')
-      expect(mail.to).to eq([user.email_address])
-      expect(mail.from).to eq([Rails.application.config.action_mailer.default_url_options[:from]])
+      expect(mail.to).to eq([ user.email_address ])
+      expect(mail.from).to eq([ Rails.application.config.action_mailer.default_url_options[:from] ])
     end
 
     it 'renders the body' do


### PR DESCRIPTION
## Summary

Fixes all 10 `Layout/SpaceInsideArrayLiteralBrackets` offenses across 3 files — array literals were missing spaces inside brackets (e.g. `[:foo]` → `[ :foo ]`).

Applied with:
```bash
bin/rubocop --autocorrect --only Layout/SpaceInsideArrayLiteralBrackets
```

Closes #16

## Test plan

- [x] `bin/rubocop --only Layout/SpaceInsideArrayLiteralBrackets` — 0 offenses
- [x] `bundle exec rspec` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)