### PR TITLE
chore: fix Layout/EmptyLinesAroundBlockBody rubocop violation

### DIFF
--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe "Passwords", type: :request do
         follow_redirect!
         expect(response.body).to include("Password reset link is invalid or has expired.")
       end
-
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes 1 `Layout/EmptyLinesAroundBlockBody` offense in `spec/requests/passwords_spec.rb` — an extra blank line at the end of a block body.

Applied with:
```bash
bin/rubocop --autocorrect --only Layout/EmptyLinesAroundBlockBody
```

Closes #20

## Test plan

- [x] `bin/rubocop --only Layout/EmptyLinesAroundBlockBody` — 0 offenses
- [x] `bundle exec rspec` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)