### PR TITLE
chore: fix Style/HashSyntax rubocop violations

### DIFF
--- a/spec/helpers/tag_entries_grouper_spec.rb
+++ b/spec/helpers/tag_entries_grouper_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe TagEntriesGrouper do
       grouped_entries = grouper.grouped_by_learning_state
 
       expect(grouped_entries).to eq({
-          :learning => [],
-          :mastered => [],
-        :new_entries => [],
-        :not_learned => [],
-          :suspended => []
+          learning: [],
+          mastered: [],
+        new_entries: [],
+        not_learned: [],
+          suspended: []
       })
     end
   end


### PR DESCRIPTION
## Summary

Fixes 5 `Style/HashSyntax` offenses in `spec/helpers/tag_entries_grouper_spec.rb` — hashrocket syntax (`key => value`) converted to Ruby 1.9 symbol key syntax (`key:  value`).

Applied with:
```bash
bin/rubocop --autocorrect --only Style/HashSyntax
```

Closes #17

## Test plan

- [x] `bin/rubocop --only Style/HashSyntax` — 0 offenses
- [x] `bundle exec rspec` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)