### PR TITLE
chore: fix Layout/SpaceInsideParens rubocop violations

### DIFF
--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Passwords", type: :request do
       let(:token) { "valid_token" }
 
       before do
-        allow(User).to receive(:find_by_password_reset_token!).with( token).and_return(user)
+        allow(User).to receive(:find_by_password_reset_token!).with(token).and_return(user)
       end
 
       it "returns the update password form" do
@@ -67,7 +67,7 @@ RSpec.describe "Passwords", type: :request do
     let(:token) { "valid_token" }
 
     before do
-      allow(User).to receive(:find_by_password_reset_token!).with( token).and_return(user)
+      allow(User).to receive(:find_by_password_reset_token!).with(token).and_return(user)
     end
 
     context "with valid parameters" do


### PR DESCRIPTION
## Summary

Fixes 2 `Layout/SpaceInsideParens` offenses in `spec/requests/passwords_spec.rb` — spurious space inside parentheses in `.with( token)` calls.

Applied with:
```bash
bin/rubocop --autocorrect --only Layout/SpaceInsideParens
```

Closes #18

## Test plan

- [x] `bin/rubocop --only Layout/SpaceInsideParens` — 0 offenses
- [x] `bundle exec rspec` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)