### PR TITLE
chore: fix Style/StringLiterals rubocop violation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  gem 'simplecov', require: false
+  gem "simplecov", require: false
   gem "selenium-webdriver"
   gem "webmock"
 end


### PR DESCRIPTION
## Summary

Fixes 1 `Style/StringLiterals` offense in `Gemfile` — `simplecov` gem declaration used single quotes instead of double quotes.

Applied with:
```bash
bin/rubocop --autocorrect --only Style/StringLiterals
```

Closes #19

## Test plan

- [x] `bin/rubocop --only Style/StringLiterals` — 0 offenses
- [x] `bundle exec rspec` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)