### PR TITLE
ci: enforce 95% coverage threshold and upload report as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,11 @@ jobs:
         env:
           RAILS_ENV: test
         run: bin/rails db:test:prepare && bundle exec rspec
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: ignore

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,9 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  minimum_coverage 95
+end
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## Summary

- Adds `minimum_coverage 95` to SimpleCov in `spec/spec_helper.rb` — the test run will fail if line coverage drops below 95%. Current coverage is 95.88% so there is a small buffer.
- Uploads the `coverage/` directory as a CI artifact on every run (pass or fail), making the HTML report accessible from the Actions summary on each PR.

Closes #40

## Test plan

- [x] `bundle exec rspec` passes locally with 95.88% coverage (above threshold)
- [ ] Coverage artifact appears in the Actions summary after CI runs
- [ ] Dropping coverage below 95% causes the test step to exit non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)