### PR TITLE
ci: Add tag ruleset to prevent tag deletion

### DIFF
--- a/.github/rulesets/prevent_tag_deletion.json
+++ b/.github/rulesets/prevent_tag_deletion.json
@@ -1,0 +1,26 @@
+{
+  "name": "Prevent tag deletion",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~ALL"]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
Once releases are tagged, we don't want them deleted accidentally. This is a simple, low-cost ruleset with no workflow impact until tags exist.