### PR TITLE
test: add unauthenticated redirect specs

### DIFF
--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -4,19 +4,28 @@ RSpec.describe "DictionaryEntries", type: :request do
   let(:user) { create(:user) }
   let(:dictionary_entry) { create(:dictionary_entry) }
 
-  before do
-    sign_in user
-  end
+  context "when authenticated" do
+    before { sign_in user }
 
-  describe "GET /dictionary_entries/:id" do
-    it "returns a successful response" do
-      get dictionary_entry_path(dictionary_entry)
-      expect(response).to have_http_status(:success)
-    end
+    describe "GET /dictionary_entries/:id" do
+      it "returns a successful response" do
+        get dictionary_entry_path(dictionary_entry)
+        expect(response).to have_http_status(:success)
+      end
 
       it "renders the target vocab prominently" do
-      get dictionary_entry_path(dictionary_entry)
-      expect(response.body).to include("感动")
+        get dictionary_entry_path(dictionary_entry)
+        expect(response.body).to include("感动")
+      end
+    end
+  end
+
+  context "when unauthenticated" do
+    describe "GET /dictionary_entries/:id" do
+      it "redirects to the login page" do
+        get dictionary_entry_path(dictionary_entry)
+        expect(response).to redirect_to(new_session_path)
+      end
     end
   end
 end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -6,31 +6,50 @@ RSpec.describe "Tags", type: :request do
   let(:dictionary_entry) { create(:dictionary_entry) }
 
   before do
-    sign_in user
     tag.dictionary_entries << dictionary_entry
   end
 
-  describe "GET /tags" do
-    it "returns a successful response" do
-      get tags_path
-      expect(response).to have_http_status(:success)
+  context "when authenticated" do
+    before { sign_in user }
+
+    describe "GET /tags" do
+      it "returns a successful response" do
+        get tags_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns html containing a link with the Tag name" do
+        get tags_path
+        expect(response.body).to include("#{tag.name}</a>")
+      end
     end
 
-    it "returns html containing a link with the Tag name" do
-      get tags_path
-      expect(response.body).to include("#{tag.name}</a>")
+    describe "GET /tags/:id" do
+      it "returns a successful response" do
+        get tag_path(tag)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns html containing a H1 with the Tag name" do
+        get tag_path(tag)
+        expect(response.body).to include("#{tag.name}</h1>")
+      end
     end
   end
 
-  describe "GET /tags/:id" do
-    it "returns a successful response" do
-      get tag_path(tag)
-      expect(response).to have_http_status(:success)
+  context "when unauthenticated" do
+    describe "GET /tags" do
+      it "redirects to the login page" do
+        get tags_path
+        expect(response).to redirect_to(new_session_path)
+      end
     end
 
-    it "returns html containing a H1 with the Tag name" do
-      get tag_path(tag)
-      expect(response.body).to include("#{tag.name}</h1>")
+    describe "GET /tags/:id" do
+      it "redirects to the login page" do
+        get tag_path(tag)
+        expect(response).to redirect_to(new_session_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #43

## Summary

- Adds `when unauthenticated` contexts to `TagsController` (index, show) and `DictionaryEntriesController` (show), each asserting a redirect to `new_session_path`
- Restructures existing authenticated specs into a `when authenticated` context so sign-in scope is explicit and the two contexts are clearly separated

## Why

All request specs previously called `sign_in` unconditionally in a top-level `before` block. If `allow_unauthenticated_access` were accidentally added to a controller, CI would not have caught it. These tests close that gap.

## Test plan

- [ ] `bundle exec rspec spec/requests/tags_spec.rb spec/requests/dictionary_entries_spec.rb` — all 9 examples pass
- [ ] `bin/rubocop spec/requests/tags_spec.rb spec/requests/dictionary_entries_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)