### PR TITLE
test: add rake spec for anki:migrate_to_models

### DIFF
--- a/spec/support/anki_helper.rb
+++ b/spec/support/anki_helper.rb
@@ -114,41 +114,52 @@ module AnkiHelper
   end
 
   def self.seed_db(db)
-    # Insert test data for "好" to match your test
-    db.execute <<-SQL
-      INSERT INTO notes (id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data)
-      VALUES (1, 'test123', 1, 1234567890, -1, '', '20\u001F好\u001F好\u001Fhǎo\u001Fhao3\u001Fgood; well\u001Fadjective\u001F[sound:hao3.mp3]', '好', 1, 0, '');
-    SQL
+    # Notes: one per queue state variant, plus one with no matching DictionaryEntry
+    notes = [
+      [ 1, "note001", "20\u001F好\u001F好\u001Fhǎo\u001Fhao3\u001Fgood; well\u001Fadjective\u001F[sound:hao3.mp3]", "好" ],
+      [ 2, "note002", "21\u001F很\u001F很\u001Fhěn\u001Fhen3\u001Fvery; quite\u001Fadverb\u001F[sound:hen3.mp3]", "很" ],
+      [ 3, "note003", "30\u001F学\u001F學\u001Fxué\u001Fxue2\u001Fto study\u001Fverb\u001F", "学" ],
+      [ 4, "note004", "40\u001F天\u001F天\u001Ftiān\u001Ftian1\u001Fday; sky\u001Fnoun\u001F", "天" ],
+      [ 5, "note005", "50\u001F人\u001F人\u001Frén\u001Fren2\u001Fperson\u001Fnoun\u001F", "人" ],
+      [ 6, "note006", "60\u001F大\u001F大\u001Fdà\u001Fda4\u001Fbig\u001Fadjective\u001F", "大" ],
+      [ 7, "note007", "70\u001F小\u001F小\u001Fxiǎo\u001Fxiao3\u001Fsmall\u001Fadjective\u001F", "小" ],
+      [ 8, "note008", "80\u001F不\u001F不\u001Fbù\u001Fbu4\u001Fnot\u001Fadverb\u001F", "不" ]
+    ]
+    notes.each do |id, guid, flds, sfld|
+      db.execute(
+        "INSERT INTO notes (id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data) VALUES (?, ?, 1, 1234567890, -1, '', ?, ?, 1, 0, '')",
+        [ id, guid, flds, sfld ]
+      )
+    end
 
-    # Also insert the "很" data for completeness
-    db.execute <<-SQL
-      INSERT INTO notes (id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data)
-      VALUES (2, 'test456', 1, 1234567890, -1, '', '21\u001F很\u001F很\u001Fhěn\u001Fhen3\u001Fvery; quite\u001Fadverb\u001F[sound:hen3.mp3]', '很', 1, 0, '');
-    SQL
+    # Cards: one per note, covering all queue variants
+    # queue: 2=mastered, 2=mastered, 0=new, 1=learning, 3=day-learning, -1=suspended, -2=buried, 2=no-entry
+    cards = [
+      [ 1, 1, 2, 1234567890 ],
+      [ 2, 2, 2, 1234567890 ],
+      [ 3, 3, 0, 0 ],
+      [ 4, 4, 1, 1234567890 ],
+      [ 5, 5, 3, 1234567890 ],
+      [ 6, 6, -1, 1234567890 ],
+      [ 7, 7, -2, 1234567890 ],
+      [ 8, 8, 2, 1234567890 ]
+    ]
+    cards.each do |id, nid, queue, due|
+      db.execute(
+        "INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data) VALUES (?, ?, 1, 0, 1234567890, -1, 2, ?, ?, 250, 2500, 5, 0, 2, 0, 0, 0, '')",
+        [ id, nid, queue, due ]
+      )
+    end
 
-    # Insert corresponding cards
-    db.execute <<-SQL
-      INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data)
-      VALUES (1, 1, 1, 0, 1234567890, -1, 2, 2, 100, 250, 2500, 5, 0, 2, 0, 0, 0, '');
-    SQL
+    # Revlogs: one per card
+    (1..8).each do |i|
+      db.execute(
+        "INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type) VALUES (?, ?, -1, 2, 250, 100, 2500, 5000, 1)",
+        [ i, i ]
+      )
+    end
 
-    db.execute <<-SQL
-      INSERT INTO cards (id, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data)
-      VALUES (2, 2, 1, 0, 1234567890, -1, 2, 2, 100, 250, 2500, 5, 0, 2, 0, 0, 0, '');
-    SQL
-
-    # Insert sample revlog for both cards
-    db.execute <<-SQL
-      INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type)
-      VALUES (1, 1, -1, 2, 250, 100, 2500, 5000, 1);
-    SQL
-
-    db.execute <<-SQL
-      INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type)
-      VALUES (2, 2, -1, 2, 250, 100, 2500, 5000, 1);
-    SQL
-
-    # Insert col data with models JSON that includes HSK deck
+    # Col: models JSON defines field names; decks JSON maps deck id → name
     models_json = {
       "1234567890" => {
         "name" => "HSK",
@@ -165,9 +176,13 @@ module AnkiHelper
       }
     }.to_json
 
+    decks_json = {
+      "1" => { "name" => "Mandarin: Vocabulary::a. HSK" }
+    }.to_json
+
     db.execute(
-      "INSERT INTO col (id, crt, mod, scm, ver, dty, usn, ls, conf, models, decks, dconf, tags) VALUES (1, 1234567890, 1234567890, 1234567890, 11, 0, 0, 0, '{}', ?, '{}', '{}', '{}')",
-      [ models_json ]
+      "INSERT INTO col (id, crt, mod, scm, ver, dty, usn, ls, conf, models, decks, dconf, tags) VALUES (1, 1234567890, 1234567890, 1234567890, 11, 0, 0, 0, '{}', ?, ?, '{}', '{}')",
+      [ models_json, decks_json ]
     )
   end
 end

--- a/spec/tasks/anki_spec.rb
+++ b/spec/tasks/anki_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe "anki:migrate_to_models", type: :task do
+  before do
+    Rake.application.rake_require("tasks/anki")
+    Rake::Task.define_task(:environment)
+  end
+
+  after do
+    Rake::Task["anki:migrate_to_models"].reenable
+  end
+
+  # Captures stdout and rescues SystemExit so error-path tests can
+  # assert on the message without the suite itself exiting.
+  def run_task(*args)
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    begin
+      Rake::Task["anki:migrate_to_models"].invoke(*args)
+    rescue SystemExit
+      # allow task error exits without propagating
+    ensure
+      $stdout = original_stdout
+    end
+    output.string
+  end
+
+  context "when email is not provided" do
+    it "prints a helpful error message" do
+      output = run_task
+      expect(output).to include("Please provide an email parameter")
+    end
+  end
+
+  context "when the user is not found" do
+    it "prints a helpful error message" do
+      output = run_task("nobody@example.com")
+      expect(output).to include("No user found with email: nobody@example.com")
+    end
+  end
+
+  context "when the deck is not found" do
+    it "prints a helpful error message" do
+      user = create(:user)
+      stub_const("Anki::ANKI_DESK_TARGET", "NoSuchDeck")
+      output = run_task(user.email_address)
+      expect(output).to include("No deck found with the name: NoSuchDeck")
+    end
+  end
+
+  context "with a valid user and the target deck present" do
+    # DictionaryEntries matching each seeded Anki note (by Simplified field).
+    # Note 8 ("不") intentionally has no entry to test the skip behaviour.
+    let(:user)        { create(:user) }
+    let!(:entry_hao)  { create(:dictionary_entry, text: "好") }  # card 1, queue 2  → mastered
+    let!(:entry_hen)  { create(:dictionary_entry, text: "很") }  # card 2, queue 2  → mastered
+    let!(:entry_xue)  { create(:dictionary_entry, text: "学") }  # card 3, queue 0  → new
+    let!(:entry_tian) { create(:dictionary_entry, text: "天") }  # card 4, queue 1  → learning
+    let!(:entry_ren)  { create(:dictionary_entry, text: "人") }  # card 5, queue 3  → learning
+    let!(:entry_da)   { create(:dictionary_entry, text: "大") }  # card 6, queue -1 → suspended
+    let!(:entry_xiao) { create(:dictionary_entry, text: "小") }  # card 7, queue -2 → suspended
+
+    before { run_task(user.email_address) }
+
+    describe "queue → state mapping" do
+      it "maps queue 0 to 'new'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_xue)
+        expect(ul.state).to eq("new")
+      end
+
+      it "maps queue 1 to 'learning'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_tian)
+        expect(ul.state).to eq("learning")
+      end
+
+      it "maps queue 2 to 'mastered'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_hao)
+        expect(ul.state).to eq("mastered")
+      end
+
+      it "maps queue 3 (day-learning) to 'learning'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_ren)
+        expect(ul.state).to eq("learning")
+      end
+
+      it "maps queue -1 to 'suspended'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_da)
+        expect(ul.state).to eq("suspended")
+      end
+
+      it "maps queue -2 (buried) to 'suspended'" do
+        ul = UserLearning.find_by!(user: user, dictionary_entry: entry_xiao)
+        expect(ul.state).to eq("suspended")
+      end
+    end
+
+    it "creates ReviewLog records linked to the UserLearning" do
+      ul = UserLearning.find_by!(user: user, dictionary_entry: entry_hao)
+      expect(ul.review_logs).not_to be_empty
+    end
+
+    it "skips cards whose Simplified field has no matching DictionaryEntry" do
+      # 7 entries have matches; card 8 ("不") has none and must be skipped
+      expect(UserLearning.where(user: user).count).to eq(7)
+    end
+
+    describe "idempotency" do
+      it "does not create duplicate UserLearnings on re-run" do
+        Rake::Task["anki:migrate_to_models"].reenable
+        expect { run_task(user.email_address) }.not_to change(UserLearning, :count)
+      end
+
+      it "does not create duplicate ReviewLogs on re-run" do
+        Rake::Task["anki:migrate_to_models"].reenable
+        expect { run_task(user.email_address) }.not_to change(ReviewLog, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #44

## Summary

- Adds `spec/tasks/anki_spec.rb` with 13 examples covering the full behaviour of `rake anki:migrate_to_models`
- Expands `AnkiHelper` seed data to include notes/cards for every Anki queue variant, plus a card intentionally missing a `DictionaryEntry` to exercise the skip path
- Fixes the `decks` JSON in the seeded `col` table — previously `'{}'`, so the deck lookup always failed in tests

## What is tested

| Scenario | Covered |
|---|---|
| No email argument | error message |
| Unknown user email | error message |
| Deck not found | error message |
| queue 0 → `new` | state mapping |
| queue 1 → `learning` | state mapping |
| queue 2 → `mastered` | state mapping |
| queue 3 (day-learning) → `learning` | state mapping |
| queue -1 → `suspended` | state mapping |
| queue -2 (buried) → `suspended` | state mapping |
| ReviewLog created and linked | record creation |
| Card with no DictionaryEntry skipped | skip behaviour |
| Re-run creates no duplicate UserLearnings | idempotency |
| Re-run creates no duplicate ReviewLogs | idempotency |

## Test plan

- [ ] `bundle exec rspec spec/tasks/anki_spec.rb` — 13 examples, 0 failures
- [ ] `bundle exec rspec` — full suite green
- [ ] `bin/rubocop spec/tasks/anki_spec.rb spec/support/anki_helper.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)