### PR TITLE
test: replace hardcoded character with factory value

### DIFF
--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "DictionaryEntries", type: :request do
 
       it "renders the target vocab prominently" do
         get dictionary_entry_path(dictionary_entry)
-        expect(response.body).to include("感动")
+        expect(response.body).to include(dictionary_entry.text)
       end
     end
   end


### PR DESCRIPTION
Closes #45

## Summary

Replaces the literal `"感动"` in `spec/requests/dictionary_entries_spec.rb` with `dictionary_entry.text`.

## Why

Hardcoding the character couples the assertion to the factory's current default. If the factory text changes, the test fails with a confusing message pointing at the response body rather than the factory. Using the factory object directly keeps the test self-consistent and the failure message meaningful.

## Test plan

- [ ] `bundle exec rspec spec/requests/dictionary_entries_spec.rb` — 2 examples, 0 failures
- [ ] `bin/rubocop spec/requests/dictionary_entries_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)