### PR TITLE
chore: add bin/bootstrap and bin/teardown; fix two download bugs

### DIFF
--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -3,6 +3,7 @@ require "zip"
 
 module ImportFilesHelper
   def download_file_to_tmp(url, destination)
+    FileUtils.mkdir_p(File.dirname(destination))
     File.open(destination, "wb") do |file|
       file.write(URI.open(url).read)
     end

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# bin/bootstrap — full data import pipeline for a fresh development environment.
+#
+# Run this after bin/setup (which installs deps and creates an empty DB) to
+# download and import all reference data: CC-CEDICT dictionary, HSK vocabulary
+# tags, and custom dictionary entries.
+#
+# Safe to re-run — all import tasks are idempotent.
+#
+# Anki learning history is NOT imported here because it requires a personal
+# .colpkg file. See README.md for manual Anki setup instructions.
+
+require "fileutils"
+
+APP_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args, exception: true)
+end
+
+def step(msg)
+  puts "\n== #{msg} =="
+  $stdout.flush
+end
+
+FileUtils.chdir APP_ROOT do
+  step "Installing dependencies"
+  system("bundle check") || system!("bundle install")
+
+  step "Preparing database"
+  system! "bin/rails db:schema:load"
+
+  step "Downloading CC-CEDICT dictionary"
+  system! "bin/rails dictionary_download:cc_cedict"
+
+  step "Importing CC-CEDICT dictionary"
+  system! "bin/rails dictionary_import:cc_cedict"
+
+  step "Importing custom dictionary entries"
+  system! "bin/rails dictionary_import:custom_entries"
+
+  step "Downloading HSK vocabulary files"
+  system! "bin/rails tag_download:hsk_2"
+  system! "bin/rails tag_download:hsk_3"
+
+  step "Importing HSK 2.0 tags"
+  system! "bin/rails tag_import:hsk_2"
+
+  step "Importing HSK 3.0 tags"
+  system! "bin/rails tag_import:hsk_3"
+
+  puts "\n== Bootstrap complete =="
+  puts ""
+  puts "To import your Anki learning history:"
+  puts "  1. Export from Anki: File → Export → Anki Collection Package"
+  puts "  2. unzip -o your_collection.colpkg collection.anki21 -d tmp/anki/"
+  puts "  3. bin/rails \"anki:migrate_to_models[your@email.com]\""
+end

--- a/bin/teardown
+++ b/bin/teardown
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# bin/teardown — removes the development database and all auto-downloaded
+# temporary files, returning the repo to a clean pre-bootstrap state.
+#
+# Safe to follow with bin/bootstrap for a full reseed from scratch.
+#
+# What is removed:
+#   storage/development.sqlite3   — the main app database
+#   tmp/cedict/                   — downloaded CC-CEDICT archive and file
+#   tmp/hsk_2/                    — downloaded HSK 2.0 vocab files
+#   tmp/hsk_3/                    — downloaded HSK 3.0 vocab files
+#
+# What is NOT removed:
+#   tmp/anki/                     — your personal Anki collection (manual copy)
+#   storage/anki-development.sqlite3  — read-only Anki mirror DB
+#   storage/test.sqlite3          — test database (managed by the test suite)
+
+require "fileutils"
+
+APP_ROOT = File.expand_path("..", __dir__)
+
+def remove(path)
+  full = File.join(APP_ROOT, path)
+  if File.exist?(full) || Dir.exist?(full)
+    FileUtils.rm_rf(full)
+    puts "  removed #{path}"
+  else
+    puts "  skipped #{path} (not present)"
+  end
+end
+
+FileUtils.chdir APP_ROOT do
+  puts "== Dropping development database =="
+  # Remove the file directly rather than using db:drop, which in Rails'
+  # multi-DB SQLite setup can also drop the test database.
+  remove "storage/development.sqlite3"
+
+  puts "\n== Removing downloaded data files =="
+  remove "tmp/cedict.zip"
+  remove "tmp/cedict"
+  remove "tmp/hsk_2"
+  remove "tmp/hsk_3"
+
+  puts "\n== Teardown complete =="
+  puts "Run bin/bootstrap to reimport all data from scratch."
+end

--- a/lib/tasks/tag_download.rake
+++ b/lib/tasks/tag_download.rake
@@ -3,9 +3,9 @@ require_relative "../../app/helpers/import_files_helper"
 include ImportFilesHelper
 
 namespace :tag_download do
-  HSK_REPO_ROOT = "https://raw.githubusercontent.com/drkameleon/complete-hsk-vocabulary/refs/heads/main/by-level/"
+  HSK_REPO_ROOT = "https://raw.githubusercontent.com/drkameleon/complete-hsk-vocabulary/main/wordlists/exclusive/"
   HSK_2_FILES = (1..6).to_a.map { |lvl| HSK_REPO_ROOT + "old/#{lvl}.min.json" }
-  HSK_3_FILES = (1..6).to_a.map { |lvl| HSK_REPO_ROOT + "new/#{lvl}.min.json" } << HSK_REPO_ROOT + "new/7+.min.json"
+  HSK_3_FILES = (1..7).to_a.map { |lvl| HSK_REPO_ROOT + "new/#{lvl}.min.json" }
 
   desc "Download HSK 2 files"
   task hsk_2: :environment do


### PR DESCRIPTION
## Summary

- **`bin/bootstrap`** — full data import pipeline from a clean slate: `bundle install` → `db:schema:load` → CEDICT download + import → custom entries → HSK 2 + 3 download + import → Anki instructions
- **`bin/teardown`** — removes `storage/development.sqlite3` and auto-downloaded tmp files (cedict, hsk_2, hsk_3). Leaves `tmp/anki/` and the test database intact. Removes files directly rather than `db:drop` which in Rails' multi-DB SQLite setup also drops the test DB

Two pre-existing bugs fixed during live testing:

1. **`ImportFilesHelper#download_file_to_tmp`** — did not `mkdir_p` the parent directory before writing. Works for `tmp/cedict.zip` (where `tmp/` always exists) but fails for `tmp/hsk_2/1.min.json` when `hsk_2/` is absent after teardown
2. **`tag_download.rake`** — upstream HSK vocabulary repo restructured: `by-level/` → `wordlists/exclusive/`, and HSK 3 level 7 file renamed from `7+.min.json` → `7.min.json`

## Live test results (clean database)

| Task | Entries | Time | Before optimisations |
|---|---|---|---|
| `dictionary_import:cc_cedict` | 111,669 | **25.4s** | ~14 min |
| `tag_import:hsk_2` | 4,991 | **0.49s** | ~5-10s |
| `tag_import:hsk_3` | 10,969 | **0.81s** | ~30s |

## Test plan

- [ ] `bundle exec rspec` — 194 examples, 0 failures
- [ ] `bin/rubocop` — no offenses
- [ ] `bin/teardown` — drops dev DB, removes tmp files, leaves anki and test DB
- [ ] `bin/bootstrap` — full pipeline runs cleanly from scratch

🤖 Generated with [Claude Code](https://claude.com/claude-code)