### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -5,7 +5,7 @@ module ImportFilesHelper
   def download_file_to_tmp(url, destination)
     FileUtils.mkdir_p(File.dirname(destination))
     File.open(destination, "wb") do |file|
-      file.write(URI.open(url).read)
+      file.write(URI(url).open.read)
     end
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/huwd/learn_hanzi/security/code-scanning/1](https://github.com/huwd/learn_hanzi/security/code-scanning/1)

In general, the fix is to avoid `URI.open(string_url)` (which can go through `Kernel.open`) and instead create a `URI` object explicitly and call `open` on that, i.e. `URI(url).open`. This prevents the special handling of strings beginning with `|` and thus avoids shell command execution.

Concretely, in `app/helpers/import_files_helper.rb`, within `download_file_to_tmp`, change line 8 from:

```rb
file.write(URI.open(url).read)
```

to:

```rb
file.write(URI(url).open.read)
```

This keeps functionality identical (HTTP(s) requests still work, and local file paths handled via `file://` URIs still work), but ensures we are using the `URI` instance method instead of the potentially dangerous `Kernel.open` path. No new methods, imports, or definitions are required; `require "open-uri"` and the existing `URI` constant are already available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
