### PR TITLE
fix: order /learn queue by HSK version then level

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -8,9 +8,9 @@ class LearnController < ApplicationController
   def start
     queue = Current.user.user_learnings
                    .new_learnings
-                   .order(:created_at)
-                   .limit(QUEUE_SIZE)
-                   .to_a
+                   .includes(dictionary_entry: { tags: { parent: :parent } })
+                   .sort_by { |ul| hsk_sort_key(ul) }
+                   .first(QUEUE_SIZE)
 
     if queue.empty?
       render :start
@@ -108,6 +108,38 @@ class LearnController < ApplicationController
   end
 
   private
+
+  # Sort key for ordering new cards by HSK version then level number.
+  # Walks up the tag parent chain to find the version tag (e.g. "HSK 2.0")
+  # and the level tag (e.g. "HSK 1"). Handles both 2-level structures
+  # (entry → level → version) and 3-level (entry → lesson → level → version).
+  # Cards with no recognisable HSK tags sort to the end.
+  def hsk_sort_key(user_learning)
+    best = nil
+
+    user_learning.dictionary_entry.tags.each do |tag|
+      version_tag, level_tag = hsk_version_and_level(tag)
+      next unless version_tag && level_tag
+
+      level_num = level_tag.name.scan(/\d+/).first.to_i
+      key = [ version_tag.name, level_num ]
+      best = key if best.nil? || key < best
+    end
+
+    best || [ "\xff", Float::INFINITY ]
+  end
+
+  def hsk_version_and_level(tag)
+    if tag.parent.nil?
+      [ nil, nil ]
+    elsif tag.parent.parent.nil?
+      # 2-level: tag is the level tag, tag.parent is the version tag
+      tag.parent.name.match?(/HSK \d+\.\d+/) ? [ tag.parent, tag ] : [ nil, nil ]
+    else
+      # 3-level: tag is a lesson tag, tag.parent is the level tag, tag.parent.parent is the version tag
+      tag.parent.parent.name.match?(/HSK \d+\.\d+/) ? [ tag.parent.parent, tag.parent ] : [ nil, nil ]
+    end
+  end
 
   def require_learn_session
     redirect_to learn_path unless session[:learn_queue].present?

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe "Learn", type: :request do
         end
       end
 
+      context "queue ordering by HSK level" do
+        let(:hsk_version) { create(:tag, name: "HSK 2.0") }
+        let(:hsk1_tag)    { create(:tag, name: "HSK 1", parent: hsk_version) }
+        let(:hsk4_tag)    { create(:tag, name: "HSK 4", parent: hsk_version) }
+
+        let!(:hsk4_entry) { create(:dictionary_entry).tap { |e| e.tags << hsk4_tag } }
+        let!(:hsk1_entry) { create(:dictionary_entry).tap { |e| e.tags << hsk1_tag } }
+
+        let!(:hsk4_card) { create(:user_learning, user: user, state: "new", dictionary_entry: hsk4_entry) }
+        let!(:hsk1_card) { create(:user_learning, user: user, state: "new", dictionary_entry: hsk1_entry) }
+
+        before { new_card.update!(state: "learning", next_due: 1.day.from_now, last_interval: 1) }
+
+        it "puts the lower HSK level card first in the queue" do
+          get learn_path
+          queue = request.session[:learn_queue]
+          expect(queue.index(hsk1_card.id)).to be < queue.index(hsk4_card.id)
+        end
+      end
+
       context "when no new cards are available" do
         before { new_card.update!(state: "learning", next_due: 1.day.from_now, last_interval: 1) }
 


### PR DESCRIPTION
## Summary

New cards in `/learn` were ordered by `created_at` (Anki import order), which doesn't reliably reflect HSK level. This fixes the ordering so lower HSK levels are always introduced first.

- Walks each entry's tag parent chain to find the HSK version tag (e.g. "HSK 2.0") and level tag (e.g. "HSK 1")
- Handles both 2-level (`entry → level → version`) and 3-level (`entry → lesson → level → version`) tag structures
- Cards with no recognisable HSK tags sort to the end
- Tags preloaded two levels deep (`{ tags: { parent: :parent } }`) to avoid N+1 queries

## Test plan

- [ ] HSK 1 card appears before HSK 4 card in the queue
- [ ] Cards with no HSK tags don't break sorting (sorted to end)
- [ ] Full suite green (314 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)