### PR TITLE
feat: tag-filtered learn session with on-demand UserLearning creation

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -6,11 +6,12 @@ class LearnController < ApplicationController
   before_action :require_started_session, only: [ :summary ]
 
   def start
-    queue = Current.user.user_learnings
-                   .new_learnings
-                   .includes(dictionary_entry: { tags: { parent: :parent } })
-                   .sort_by { |ul| hsk_sort_key(ul) }
-                   .first(QUEUE_SIZE)
+    queue = if params[:tag_id].present?
+      tag = Tag.find_by(id: params[:tag_id])
+      tag ? build_tagged_queue(tag) : build_global_queue
+    else
+      build_global_queue
+    end
 
     if queue.empty?
       render :start
@@ -99,33 +100,67 @@ class LearnController < ApplicationController
   end
 
   def summary
-    started_at    = Time.parse(session[:learn_started_at])
-    @introduced   = session[:learn_introduced]&.size || 0
-    @review_logs  = ReviewLog.joins(:user_learning)
-                             .where(user_learnings: { user: Current.user })
-                             .where(created_at: started_at..)
-                             .order(:created_at)
+    started_at   = Time.parse(session[:learn_started_at])
+    @introduced  = session[:learn_introduced]&.size || 0
+    @review_logs = ReviewLog.joins(:user_learning)
+                            .where(user_learnings: { user: Current.user })
+                            .where(created_at: started_at..)
+                            .order(:created_at)
   end
 
   private
 
-  # Sort key for ordering new cards by HSK version then level number.
-  # Walks up the tag parent chain to find the version tag (e.g. "HSK 2.0")
-  # and the level tag (e.g. "HSK 1"). Handles both 2-level structures
-  # (entry → level → version) and 3-level (entry → lesson → level → version).
-  # Cards with no recognisable HSK tags sort to the end.
-  def hsk_sort_key(user_learning)
-    best = nil
+  # Build a queue filtered to a specific tag.
+  # Priority 1: entries with no UserLearning yet ("Not Learned Yet") — create records on demand.
+  # Priority 2: existing UserLearnings with state "new" for this tag.
+  # Both groups are sorted by HSK level within their priority band.
+  def build_tagged_queue(tag)
+    learned_entry_ids = Current.user.user_learnings
+                               .joins(:dictionary_entry)
+                               .where(dictionary_entries: { id: tag.dictionary_entries.select(:id) })
+                               .pluck(:dictionary_entry_id)
 
-    user_learning.dictionary_entry.tags.each do |tag|
+    unlearned_entries = tag.dictionary_entries
+                           .where.not(id: learned_entry_ids)
+                           .includes(tags: { parent: :parent })
+                           .sort_by { |e| hsk_entry_sort_key(e) }
+
+    existing_new = Current.user.user_learnings
+                          .new_learnings
+                          .joins(:dictionary_entry)
+                          .where(dictionary_entries: { id: tag.dictionary_entries.select(:id) })
+                          .includes(dictionary_entry: { tags: { parent: :parent } })
+                          .sort_by { |ul| hsk_sort_key(ul) }
+
+    newly_created = unlearned_entries.first(QUEUE_SIZE).map do |entry|
+      Current.user.user_learnings.create!(dictionary_entry: entry, state: "new")
+    end
+
+    remaining = QUEUE_SIZE - newly_created.size
+    (newly_created + existing_new.first(remaining))
+  end
+
+  def build_global_queue
+    Current.user.user_learnings
+           .new_learnings
+           .includes(dictionary_entry: { tags: { parent: :parent } })
+           .sort_by { |ul| hsk_sort_key(ul) }
+           .first(QUEUE_SIZE)
+  end
+
+  def hsk_sort_key(user_learning)
+    hsk_entry_sort_key(user_learning.dictionary_entry)
+  end
+
+  def hsk_entry_sort_key(entry)
+    best = nil
+    entry.tags.each do |tag|
       version_tag, level_tag = hsk_version_and_level(tag)
       next unless version_tag && level_tag
-
       level_num = level_tag.name.scan(/\d+/).first.to_i
       key = [ version_tag.name, level_num ]
       best = key if best.nil? || key < best
     end
-
     best || [ "\xff", Float::INFINITY ]
   end
 
@@ -133,10 +168,8 @@ class LearnController < ApplicationController
     if tag.parent.nil?
       [ nil, nil ]
     elsif tag.parent.parent.nil?
-      # 2-level: tag is the level tag, tag.parent is the version tag
       tag.parent.name.match?(/HSK \d+\.\d+/) ? [ tag.parent, tag ] : [ nil, nil ]
     else
-      # 3-level: tag is a lesson tag, tag.parent is the level tag, tag.parent.parent is the version tag
       tag.parent.parent.name.match?(/HSK \d+\.\d+/) ? [ tag.parent.parent, tag.parent ] : [ nil, nil ]
     end
   end

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -29,8 +29,16 @@
   <% @states.each do |key, label| %>
     <% entries_in_state = @dictionary_entries_grouped[key] || [] %>
     <% unless entries_in_state.empty? %>
-      <h2 class="text-4xl font-extrabold text-gray-800 mb-6"><%= label %></h2>
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-7">
+      <div class="flex items-baseline gap-4 mb-6">
+        <h2 class="text-4xl font-extrabold text-gray-800"><%= label %></h2>
+        <% if key == :not_learned || key == :new_entries %>
+          <%= link_to learn_path(tag_id: @entry_tag.id),
+                class: "text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors" do %>
+            Learn these &rarr;
+          <% end %>
+        <% end %>
+      </div>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-7 mb-6">
         <% entries_in_state.each.with_index(1) do |entry, index| %>
           <%= link_to dictionary_entry_path(entry.id), class: "relative bg-white shadow-md rounded-lg p-4 text-center" do %>
             <span class="absolute top-0 left-0 text-xs text-gray-500 p-1"><%= index %></span>

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -68,6 +68,73 @@ RSpec.describe "Learn", type: :request do
           expect(response).to have_http_status(:success)
         end
       end
+
+      context "with a tag_id param (tag-filtered session)" do
+        let(:tag) { create(:tag) }
+        let!(:tagged_entry) { create(:dictionary_entry).tap { |e| e.tags << tag } }
+
+        before { new_card.update!(state: "learning", next_due: 1.day.from_now, last_interval: 1) }
+
+        context "when the tag has unlearned entries (no UserLearning)" do
+          it "creates UserLearning records for unlearned entries" do
+            expect {
+              get learn_path(tag_id: tag.id)
+            }.to change(UserLearning, :count).by(1)
+          end
+
+          it "sets the new records to state new" do
+            get learn_path(tag_id: tag.id)
+            expect(UserLearning.last.state).to eq("new")
+          end
+
+          it "queues the newly created card" do
+            get learn_path(tag_id: tag.id)
+            new_ul = UserLearning.find_by(user: user, dictionary_entry: tagged_entry)
+            expect(request.session[:learn_queue]).to include(new_ul.id)
+          end
+
+          it "redirects to the learn card path" do
+            get learn_path(tag_id: tag.id)
+            expect(response).to redirect_to(learn_card_path)
+          end
+        end
+
+        context "when the tag has existing new-state entries" do
+          let!(:existing_new) { create(:user_learning, user: user, state: "new", dictionary_entry: tagged_entry) }
+
+          it "does not create duplicate UserLearning records" do
+            expect {
+              get learn_path(tag_id: tag.id)
+            }.not_to change(UserLearning, :count)
+          end
+
+          it "queues the existing new card" do
+            get learn_path(tag_id: tag.id)
+            expect(request.session[:learn_queue]).to include(existing_new.id)
+          end
+        end
+
+        context "prioritisation: unlearned before existing new" do
+          let(:other_entry) { create(:dictionary_entry).tap { |e| e.tags << tag } }
+          let!(:existing_new) { create(:user_learning, user: user, state: "new", dictionary_entry: other_entry) }
+
+          it "puts the unlearned (newly created) card before the existing new card" do
+            get learn_path(tag_id: tag.id)
+            queue   = request.session[:learn_queue]
+            new_ul  = UserLearning.find_by(user: user, dictionary_entry: tagged_entry)
+            expect(queue.index(new_ul.id)).to be < queue.index(existing_new.id)
+          end
+        end
+
+        context "when the tag has no unlearned or new entries" do
+          before { tagged_entry.user_learnings.create!(user: user, state: "mastered", last_interval: 10, factor: 2500, next_due: 1.day.from_now) }
+
+          it "renders the empty state" do
+            get learn_path(tag_id: tag.id)
+            expect(response).to have_http_status(:success)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Users can now start a learn session scoped to a specific tag directly from the tag show page.

**"Learn these →"** appears next to both **Not Learned Yet** and **New** headings on any tag page.

### Queue behaviour (`GET /learn?tag_id=N`)

Priority 1 — **Not Learned Yet** entries (no `UserLearning` record): created on demand with `state: "new"`, sorted by HSK level  
Priority 2 — Existing **New** state entries for that tag, sorted by HSK level  
Combined cap: `QUEUE_SIZE` (5)

The global `/learn` flow (no `tag_id`) is unchanged.

### Refactor

`hsk_sort_key` now delegates to `hsk_entry_sort_key(entry)` so the same HSK ordering logic works for bare `DictionaryEntry` objects (unlearned entries with no `UserLearning`) and `UserLearning` objects alike.

## Test plan

- [ ] Tag with unlearned entries: `UserLearning` records created on `GET /learn?tag_id=N`
- [ ] Newly created records have `state: "new"`
- [ ] Newly created cards appear before existing new cards in the queue
- [ ] No duplicate records created when entry already has a `UserLearning`
- [ ] Tag with only mastered entries → empty state rendered
- [ ] "Learn these →" link visible next to Not Learned Yet and New sections on tag page
- [ ] Full suite green (322 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)