### PR TITLE
feat: show due indicator on tag tile when review needed

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -14,5 +14,12 @@ class TagsController < ApplicationController
       mastered:    "Mastered",
       suspended:   "Suspended"
     }
+    @due_entry_ids = Set.new(
+      Current.user.user_learnings
+             .where(dictionary_entry: @entry_tag.dictionary_entries)
+             .where(state: %w[learning mastered])
+             .due
+             .pluck(:dictionary_entry_id)
+    )
   end
 end

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -42,6 +42,9 @@
         <% entries_in_state.each.with_index(1) do |entry, index| %>
           <%= link_to dictionary_entry_path(entry.id), class: "relative bg-white shadow-md rounded-lg p-4 text-center" do %>
             <span class="absolute top-0 left-0 text-xs text-gray-500 p-1"><%= index %></span>
+            <% if @due_entry_ids.include?(entry.id) %>
+              <span class="due-indicator absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full"></span>
+            <% end %>
             <p class="text-2xl font-bold text-gray-800"><%= entry.text %></p>
           <% end %>
         <% end %>

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -50,6 +50,41 @@ RSpec.describe "Tags", type: :request do
       end
     end
 
+    describe "GET /tags/:id — due indicator" do
+      let(:due_entry) { create(:dictionary_entry).tap { |e| e.tags << root_tag } }
+
+      context "when an entry is due for review" do
+        before do
+          create(:user_learning, user: user, dictionary_entry: due_entry,
+                 state: "learning", next_due: 1.day.ago, last_interval: 1)
+        end
+
+        it "renders a due indicator for that tile" do
+          get tag_path(root_tag)
+          expect(response.body).to include("due-indicator")
+        end
+      end
+
+      context "when an entry is not yet due" do
+        before do
+          create(:user_learning, user: user, dictionary_entry: due_entry,
+                 state: "learning", next_due: 1.day.from_now, last_interval: 1)
+        end
+
+        it "does not render a due indicator" do
+          get tag_path(root_tag)
+          expect(response.body).not_to include("due-indicator")
+        end
+      end
+
+      context "when an entry has no UserLearning" do
+        it "does not render a due indicator" do
+          get tag_path(root_tag)
+          expect(response.body).not_to include("due-indicator")
+        end
+      end
+    end
+
     describe "GET /tags/:id (nested tag)" do
       before { leaf_tag }
 


### PR DESCRIPTION
## Summary

Adds a small red dot to the top-right corner of any character tile on a tag page when that entry's `UserLearning` is currently due for review.

- One extra `pluck` query in `TagsController#show` builds a `Set` of due `dictionary_entry_id`s scoped to the tag
- `Set#include?` check per tile is O(1)
- Only `learning` and `mastered` entries can be due — `new`, `not_learned`, and `suspended` tiles never show the dot

## Test plan

- [ ] Tile with overdue `learning` entry shows `due-indicator`
- [ ] Tile with not-yet-due `learning` entry shows no indicator
- [ ] Tile with no `UserLearning` shows no indicator
- [ ] Full suite green (329 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)