### PR TITLE
fix: correct next_due date conversion for Anki queue=2 cards

### DIFF
--- a/spec/support/anki_seed_data.rb
+++ b/spec/support/anki_seed_data.rb
@@ -105,9 +105,15 @@ module AnkiSeedData
   ].freeze
   # rubocop:enable Layout/ExtraSpacing
 
+  # Structured collection seed data. Keep values that are persisted to `col`
+  # here so constants can derive from the same source and cannot drift.
+  COL = {
+    crt: 1_234_567_890
+  }.freeze
+
   # Collection creation timestamp stored in col.crt (Unix seconds).
   # Used as the epoch for converting queue=2 "due day" values to real dates.
-  COL_CRT = 1_234_567_890
+  COL_CRT = COL.fetch(:crt)
 
   # One card per note, each exercising a different queue state.
   # Cards default to did=DECK_ID and odid=0. Pass :did and :odid to override


### PR DESCRIPTION
## Summary

- Fixes a bug where mastered card `next_due` dates were stored as
  `1970-01-01` after the Anki migration
- Anki stores `due` for queue=2 cards as **days since `col.crt`**, not
  Unix seconds — the migration was calling `Time.at(card.due)` for all
  queues, producing epoch-relative garbage dates
- Also fixes queue=0 (new) cards, which store `due` as a sort ordinal
  — these now get `nil` instead of a meaningless timestamp
- Reads `crt` alongside `decks` in a single `col` query; routes each
  card through a new `anki_next_due` helper that applies the correct
  conversion per queue type

Note: a corrective data migration for already-imported records is
tracked separately — see discussion on this PR.

## Test plan

- [x] Updated seed data so queue=2 fixtures carry `due: 300` (days
  since crt) rather than a Unix timestamp — the bug was previously
  invisible to the test suite
- [x] Three new assertions: queue=2 → `Time.at(crt + due * 86_400)`,
  queue=1 → `Time.at(due)` unchanged, queue=0 → `nil`
- [x] Full suite green (331 examples, 0 failures)
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)