### PR TITLE
fix: data migration to correct epoch next_due dates

### DIFF
--- a/db/migrate/20260404215231_correct_anki_next_due_dates.rb
+++ b/db/migrate/20260404215231_correct_anki_next_due_dates.rb
@@ -15,7 +15,7 @@ class CorrectAnkiNextDueDates < ActiveRecord::Migration[8.1]
 
     fix_mastered_cards(deck_id, col_crt)
     fix_mastered_cards_from_review_logs
-    fix_new_cards(deck_id)
+    fix_new_cards
   end
 
   def down
@@ -74,14 +74,13 @@ class CorrectAnkiNextDueDates < ActiveRecord::Migration[8.1]
     remaining = UserLearning
                   .where(state: "mastered")
                   .where("next_due < ?", EPOCH_CUTOFF)
-                  .includes(:review_logs)
 
     updated = 0
-    remaining.each do |ul|
-      last_log = ul.review_logs.max_by(&:time)
-      next unless last_log
+    remaining.find_each do |ul|
+      last_review_time = ul.review_logs.maximum(:time)
+      next unless last_review_time
 
-      correct_due = Time.at(last_log.time / 1000.0) + ul.last_interval.days
+      correct_due = Time.at(last_review_time / 1000.0) + ul.last_interval.to_i.days
       ul.update_columns(next_due: correct_due)
       updated += 1
     end
@@ -89,17 +88,13 @@ class CorrectAnkiNextDueDates < ActiveRecord::Migration[8.1]
     say "Reconstructed next_due from review logs for #{updated} mastered UserLearning records"
   end
 
-  def fix_new_cards(deck_id)
-    char_map = char_to_next_due(deck_id, queues: 0)
-
-    updated = 0
-    DictionaryEntry.where(text: char_map.keys).find_each do |entry|
-      n = UserLearning
-            .where(dictionary_entry: entry, state: "new")
-            .where("next_due < ?", EPOCH_CUTOFF)
-            .update_all(next_due: nil)
-      updated += n
-    end
+  def fix_new_cards
+    # queue=0 due values are always ordinals regardless of deck, so no Anki
+    # lookup needed — clear every state=new row with an epoch-era next_due.
+    updated = UserLearning
+                .where(state: "new")
+                .where("next_due < ?", EPOCH_CUTOFF)
+                .update_all(next_due: nil)
 
     say "Cleared next_due for #{updated} new UserLearning records"
   end

--- a/spec/migrations/correct_anki_next_due_dates_spec.rb
+++ b/spec/migrations/correct_anki_next_due_dates_spec.rb
@@ -3,17 +3,15 @@ require Rails.root.join('db/migrate/20260404215231_correct_anki_next_due_dates')
 
 # Tests for the CorrectAnkiNextDueDates data migration.
 #
-# The Anki test DB seeds card 1 (好, queue=2, due=300) and card 3 (学, queue=0,
-# due=3), which provide the Anki-side data the migration reads.
-# We create matching UserLearning rows with wrong epoch dates and assert the
-# migration corrects them.
+# The Anki test DB seeds card 1 (好, queue=2, due=300) which provides the
+# Anki-side data the mastered-card pass reads. New-card clearing no longer
+# requires an Anki lookup so any entry works for that case.
 RSpec.describe "CorrectAnkiNextDueDates migration" do
   let(:migration) { CorrectAnkiNextDueDates.new }
   let(:user)      { create(:user) }
   let(:crt)       { AnkiSeedData::COL_CRT }
 
   let!(:entry_hao) { create(:dictionary_entry, text: "好") }  # card 1, queue=2, due=300
-  let!(:entry_xue) { create(:dictionary_entry, text: "学") }  # card 3, queue=0,  due=3
 
   describe "#up" do
     context "mastered card with an epoch next_due (bad import)" do
@@ -74,7 +72,7 @@ RSpec.describe "CorrectAnkiNextDueDates migration" do
       let!(:ul) do
         create(:user_learning,
           user:             user,
-          dictionary_entry: entry_xue,
+          dictionary_entry: entry_hao,
           state:            "new",
           next_due:         Time.at(3))  # wrong: treated ordinal 3 as 3 seconds
       end


### PR DESCRIPTION
## Summary

Fixes 986 `UserLearning` records whose `next_due` was stored as an epoch-relative date (1960s–70s) because the Anki migration called `Time.at(card.due)` uniformly — but for queue=2 (mastered) cards, `due` is **days since `col.crt`**, not Unix seconds.

Depends on huwd/learn_hanzi#153 (which fixes the rake task so new imports are correct going forward).

### Two-pass strategy

1. **Target-deck lookup** — for mastered cards whose Anki card is still in the target deck, recompute `next_due = Time.at(col.crt + due_days * 86_400)`
2. **Review-log fallback** — for cards that have since moved to a different Anki deck (unreachable via the target deck query), reconstruct `next_due = Time.at(last_log.time / 1000) + last_interval.days`

Also sets `next_due = nil` for `new`-state cards whose `due` was a sort ordinal.

Records with a future `next_due` (the 57 recently reviewed cards) are preserved untouched via an `EPOCH_CUTOFF = 2000-01-01` guard.

## Test plan

- [x] Four migration specs: epoch mastered fixed, future mastered preserved, orphaned mastered reconstructed from review logs, new card cleared to nil
- [x] Full suite green (335 examples, 0 failures)
- [x] Verified in dev: 0 records with next_due < 2000-01-01 after running

🤖 Generated with [Claude Code](https://claude.com/claude-code)