### PR TITLE
refactor: merge not_learned into new_entries bucket

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,7 +8,6 @@ class TagsController < ApplicationController
     @child_tags = @entry_tag.children
     @dictionary_entries_grouped = TagEntriesGrouper.new(@entry_tag, Current.user).grouped_by_learning_state
     @states = {
-      not_learned: "Not Learned yet",
       new_entries: "New",
       learning:    "Learning",
       mastered:    "Mastered",

--- a/app/helpers/tag_entries_grouper.rb
+++ b/app/helpers/tag_entries_grouper.rb
@@ -13,10 +13,11 @@ class TagEntriesGrouper
     grouped = entries.group_by(&:learning_state)
     learning = grouped["learning"] || []
 
+    unstarted = @tag.dictionary_entries
+                    .where.not(id: UserLearning.where(user: @user).select(:dictionary_entry_id))
+
     {
-      not_learned:  @tag.dictionary_entries
-                          .where.not(id: UserLearning.where(user: @user).select(:dictionary_entry_id)),
-      new_entries:  grouped["new"]      || [],
+      new_entries:  (grouped["new"] || []) + unstarted.to_a,
       learning:     learning.reject { |e| e.learning_factor < 2000 },
       struggling:   learning.select { |e| e.learning_factor < 2000 },
       mastered:     grouped["mastered"] || [],

--- a/spec/helpers/tag_entries_grouper_spec.rb
+++ b/spec/helpers/tag_entries_grouper_spec.rb
@@ -21,16 +21,15 @@ RSpec.describe TagEntriesGrouper do
       expect(grouped_entries[:mastered]).to include(dictionary_entry2)
     end
 
-    it "returns empty buckets for a user who has no learnings for the tag" do
+    it "places all tag entries in new_entries for a user who has no learnings" do
       other_user = create(:user)
-      grouper = TagEntriesGrouper.new(tag, other_user)
-      grouped_entries = grouper.grouped_by_learning_state
+      grouped = TagEntriesGrouper.new(tag, other_user).grouped_by_learning_state
 
-      expect(grouped_entries[:learning]).to eq([])
-      expect(grouped_entries[:struggling]).to eq([])
-      expect(grouped_entries[:mastered]).to eq([])
-      expect(grouped_entries[:new_entries]).to eq([])
-      expect(grouped_entries[:suspended]).to eq([])
+      expect(grouped[:new_entries]).to include(dictionary_entry1, dictionary_entry2)
+      expect(grouped[:learning]).to eq([])
+      expect(grouped[:struggling]).to eq([])
+      expect(grouped[:mastered]).to eq([])
+      expect(grouped[:suspended]).to eq([])
     end
 
     context "struggling bucket" do


### PR DESCRIPTION
## Summary

- Entries with no `UserLearning` record and entries with `state=new` are both "not yet started" — showing them as separate sections added visual noise without value
- `TagEntriesGrouper` now returns a single `:new_entries` bucket combining both groups
- `TagsController` drops the `:not_learned` state key
- Pre-creating `UserLearning` records for all 106k entries was considered and rejected — the distinction is preserved in the data model, just collapsed visually

## Test plan

- [x] Updated grouper specs: `not_learned` tests replaced with `new_entries` context covering no-record entries, state=new entries, and non-new exclusions
- [x] Full suite green (333 examples, 0 failures)
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)