### PR TITLE
chore: remove required_signatures from protect_main ruleset

### DIFF
--- a/.github/rulesets/protect_main.json
+++ b/.github/rulesets/protect_main.json
@@ -16,22 +16,17 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_linear_history"
+    },
+    {
       "type": "pull_request",
       "parameters": {
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "dismiss_stale_reviews_on_push": false,
         "required_approving_review_count": 0,
-        "required_review_thread_resolution": false
-      }
-    },
-    {
-      "type": "commit_message_pattern",
-      "parameters": {
-        "name": "Conventional commits",
-        "negate": false,
-        "operator": "regex",
-        "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\(([\\w\\-\\.]+)\\))?(!)?: ([\\w ])+([\\s\\S]*)"
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["rebase"]
       }
     },
     {
@@ -44,6 +39,31 @@
           { "context": "lint" },
           { "context": "test" }
         ]
+      }
+    },
+    {
+      "type": "code_scanning",
+      "parameters": {
+        "code_scanning_tools": [
+          {
+            "tool": "CodeQL",
+            "alerts_threshold": "errors",
+            "security_alerts_threshold": "high_or_higher"
+          }
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": false
+      }
+    },
+    {
+      "type": "code_quality",
+      "parameters": {
+        "severity": "errors"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Removes `required_signatures` from the branch protection ruleset and syncs the JSON file with the current live configuration.

**Why:** `required_signatures` is incompatible with GitHub's "Rebase and merge" button — GitHub rewrites commit SHAs during a rebase merge and cannot sign the resulting commits with the author's key. This was blocking all three open PRs.

Feature branch commits are still signed locally; the protection just can't be enforced at the GitHub merge step without switching away from rebase merges entirely.

**Also:** syncs `protect_main.json` with several rules that had been added to the live ruleset but not committed back here (`required_linear_history`, `allowed_merge_methods`, `code_scanning`, `copilot_code_review`, `code_quality`). Note that `commit_message_pattern` is UI-only and cannot be expressed via the rulesets REST API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)