### PR TITLE
docs: SRS learning profiles research (feeds #167)

### DIFF
--- a/docs/research/learning-profiles-srs.md
+++ b/docs/research/learning-profiles-srs.md
@@ -100,8 +100,9 @@ Sources: Wozniak (supermemo.guru), Control-Alt-Backspace, MemoForge, Anki forums
 | New cards/day | 10–20 cards | The widely-cited sustainable rate |
 | New card multiplier | ~7–10× | Each new card generates ~7–10 reviews in the following month |
 
-At 20 new cards/day → 140–200 reviews/month minimum from those cards alone,
-before accounting for maturing older material.
+At a steady 20 new cards/day, that implies roughly 140–200 reviews/day from
+those cards alone once they are in circulation, before accounting for
+maturing older material.
 
 ### The Abandonment Spiral (Review Debt)
 


### PR DESCRIPTION
Research document for huwd/learn_hanzi#167 — the learning advisor / dashboard narrative feature.

## What's here

`docs/research/learning-profiles-srs.md` — comprehensive findings covering:

- SM-2 / Wozniak two-component memory model (retrievability, stability, difficulty)
- Ebbinghaus forgetting curve and Wozniak's stability-increase insight for overdue cards
- Review debt, the abandonment spiral, and the two-week lag effect
- Sustainable new card pacing (Cepeda 2006/2008, Bahrick 1993, community norms)
- Leech cards: cost, causes, handling (Hacking Chinese / Olle Linge data)
- Cramming vs spacing: the fluency illusion (Kornell 2009), desirable difficulties (Bjork)
- Observable thresholds for learner phase classification (retention %, backlog ratio, session frequency)
- Dashboard feedback design (SDT / Deci & Ryan, Duolingo streak research)

## How it feeds the issue

The research is synthesised into five learner profiles in #167, each with:
- Observable classification signals computable from existing data
- Recommended `new_cap` and `size` for `LearningSession::Composer`
- Plain-English narrative framing
- Specific dos/don'ts grounded in the literature

https://claude.ai/code/session_01R4q6QxjGCE6nrC2H3UXVpc