### PR TITLE
fix: correct docker/metadata-action SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbea8a7bf8b3f14f7fc65fe0c6ea # v5.7.0
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/learn_hanzi
           tags: |


### PR DESCRIPTION
## Summary

The `docker/metadata-action` SHA in the Docker publish workflow was fabricated
and caused the CI run on #171 to fail. Replaced with the verified SHA for
v5.7.0 fetched directly from the GitHub API.

## Test plan

- [ ] Docker workflow runs successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)