### PR TITLE
fix: add Buildx setup step to enable GHA caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
## Summary

The Docker publish workflow was failing with:

```
Cache export is not supported for the docker driver.
```

The default Docker driver does not support GHA cache export. Adding
`docker/setup-buildx-action` switches to the `docker-container` driver,
which unblocks the `cache-from`/`cache-to` GHA configuration.

## Test plan

- [ ] Docker workflow builds and pushes successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)