### PR TITLE
fix: remove GHA cache from Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,5 +38,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

The default Docker driver does not support GHA cache export, causing the build
to fail. Removing the cache lines keeps the workflow simple and dependency-free.
Build times can be optimised with a proper buildx setup later if needed.

Closes the approach taken in #174.

## Test plan

- [ ] Docker workflow builds and pushes successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)