### PR TITLE
fix: align Dockerfile Ruby version with .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.3.0
+ARG RUBY_VERSION=4.0.1
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here


### PR DESCRIPTION
## Summary

The Dockerfile had `RUBY_VERSION=3.3.0` hardcoded while the project runs Ruby
4.0.1 (per `.ruby-version`). ActionView 8.1.3 uses syntax only valid in Ruby
3.4+, causing a `SyntaxError` during `assets:precompile` in the Docker build.

## Test plan

- [ ] Docker workflow builds successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)