### PR TITLE
fix: add libyaml-dev to Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git pkg-config libyaml-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
## Summary

The `psych` gem requires `yaml.h` to build its native extension. The
`ruby:4.0.1-slim` base image does not include `libyaml-dev`, causing
`bundle install` to fail with `yaml.h not found`.

## Test plan

- [ ] Docker build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)