### PR TITLE
fix: make container UID/GID configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,17 @@ PORT=80
 WEB_CONCURRENCY=1
 
 # -----------------------------------------------------------------------------
+# Container user
+# -----------------------------------------------------------------------------
+
+# OPTIONAL — UID and GID the container process runs as. Defaults to 1000:1000
+# (the Rails user created in the Dockerfile). Set these to match the owner of
+# STORAGE_PATH on your host so the container can read and write the directory
+# without requiring a chown. Find your UID/GID with: id
+CONTAINER_UID=1000
+CONTAINER_GID=1000
+
+# -----------------------------------------------------------------------------
 # Storage
 # -----------------------------------------------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   app:
     image: ghcr.io/${GHCR_OWNER:?GHCR_OWNER is required}/learn_hanzi:${IMAGE_TAG:-latest}
+    user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
     restart: unless-stopped
     ports:
       - "${PORT:-80}:80"


### PR DESCRIPTION
## Summary

The container runs as UID 1000 by default (the `rails` user in the Dockerfile),
which may not match the host filesystem owner on self-hosted deployments. This
causes SQLite to fail opening database files on a bind-mounted storage directory.

Adds `CONTAINER_UID` and `CONTAINER_GID` env vars (defaulting to `1000:1000`)
so the container can be run as the correct host user without requiring a `chown`.
Set these to match the output of `id` on your host.

## Test plan

- [ ] Container starts and `db:prepare` succeeds with `CONTAINER_UID`/`CONTAINER_GID` set to host user

🤖 Generated with [Claude Code](https://claude.com/claude-code)