### PR TITLE
feat: redesign dictionary entry show page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,20 @@ Before merging, assess the fix commits produced during review:
 Use judgement — the goal is a history that tells a coherent story, not one
 that hides real corrections.
 
+## Rails Conventions
+
+**Time zones** — always use `Time.zone.today` or `Time.current` instead of `Date.today` or `Time.now`. `Date.today` and `Time.now` use the system clock and ignore the app's configured time zone, causing off-by-one errors around midnight and in non-UTC environments.
+
+```ruby
+# Bad
+Date.today
+Time.now
+
+# Good
+Time.zone.today
+Time.current
+```
+
 ## Architecture
 
 This is a Rails 8 app for learning Chinese Hanzi (characters). The core purpose is to display a user's HSK vocabulary progress by combining a Chinese dictionary with their Anki flashcard review history.

--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -4,5 +4,6 @@ class DictionaryEntriesController < ApplicationController
     @dictionary_entry = @entry[:entry]
     @meanings = @entry[:meanings].where(language: "en")
     @user_learning = @entry[:user_learning]
+    @review_logs = @user_learning&.review_logs&.order(created_at: :desc) || []
   end
 end

--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -4,6 +4,11 @@ class DictionaryEntriesController < ApplicationController
     @dictionary_entry = @entry[:entry]
     @meanings = @entry[:meanings].where(language: "en")
     @user_learning = @entry[:user_learning]
-    @review_logs = @user_learning&.review_logs&.order(created_at: :desc) || []
+    @review_logs =
+      if @user_learning
+        @user_learning.review_logs.order(created_at: :desc).limit(30)
+      else
+        ReviewLog.none
+      end
   end
 end

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -19,7 +19,7 @@ class DictionaryEntry < ApplicationRecord
 
   def self.find_with_associations(id, user)
     entry = includes(tags: :parent).find(id)
-    meanings = entry.meanings
+    meanings = entry.meanings.includes(:source)
     user_learning = entry.user_learning_for(user)
     { entry: entry, meanings: meanings, user_learning: user_learning }
   end

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -19,7 +19,7 @@ class DictionaryEntry < ApplicationRecord
 
   def self.find_with_associations(id, user)
     entry = includes(tags: :parent).find(id)
-    meanings = entry.meanings.includes(:source)
+    meanings = entry.meanings
     user_learning = entry.user_learning_for(user)
     { entry: entry, meanings: meanings, user_learning: user_learning }
   end

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -37,7 +37,21 @@
 
   <%# ── Back nav ──────────────────────────────────────────── %>
   <div class="mb-6">
-    <%= link_to "← back", :back,
+    <% back_url = begin
+       referer = request.referer
+       if referer.present?
+         referer_uri = URI.parse(referer)
+         request_scheme = request.protocol.delete_suffix("://")
+         if referer_uri.scheme == request_scheme &&
+            referer_uri.host == request.host &&
+            referer_uri.port == request.port
+           referer
+         end
+       end
+     rescue URI::InvalidURIError
+       nil
+     end || root_path %>
+  <%= link_to "← back", back_url,
           class: "de-mono text-[11px] text-gray-600 hover:text-red-400 transition-colors tracking-[0.18em] uppercase" %>
   </div>
 
@@ -76,10 +90,13 @@
 
     </div>
 
+    <% source_names = @meanings.map { |m| m.source&.name }.compact.uniq %>
     <div class="mt-5 pt-4 border-t border-gray-700/40">
       <p class="de-mono text-[10px] text-gray-700 tracking-[0.15em] uppercase">
-        Source: CC-CEDICT
-        &ensp;·&ensp;
+        <% if source_names.any? %>
+          Source: <%= source_names.join(", ") %>
+          &ensp;·&ensp;
+        <% end %>
         Entry #<%= @dictionary_entry.id %>
       </p>
     </div>
@@ -170,20 +187,21 @@
             <div>
               <p class="de-mono text-[10px] text-gray-600 uppercase tracking-wider mb-2">
                 Review history
-                <span class="text-gray-700 normal-case tracking-normal">(<%= @review_logs.count %> total)</span>
+                <span class="text-gray-700 normal-case tracking-normal">(last <%= @review_logs.size %>)</span>
               </p>
-              <%# Ease legend %>
+              <%# Ease legend — coloured dots are decorative, text labels carry the meaning %>
               <div class="de-mono text-[9px] text-gray-700 flex gap-3 mb-2">
-                <span><span class="inline-block w-2 h-2 rounded-full de-ease-1 mr-0.5"></span>again</span>
-                <span><span class="inline-block w-2 h-2 rounded-full de-ease-2 mr-0.5"></span>hard</span>
-                <span><span class="inline-block w-2 h-2 rounded-full de-ease-3 mr-0.5"></span>good</span>
-                <span><span class="inline-block w-2 h-2 rounded-full de-ease-4 mr-0.5"></span>easy</span>
+                <span><span aria-hidden="true" class="inline-block w-2 h-2 rounded-full de-ease-1 mr-0.5"></span>again</span>
+                <span><span aria-hidden="true" class="inline-block w-2 h-2 rounded-full de-ease-2 mr-0.5"></span>hard</span>
+                <span><span aria-hidden="true" class="inline-block w-2 h-2 rounded-full de-ease-3 mr-0.5"></span>good</span>
+                <span><span aria-hidden="true" class="inline-block w-2 h-2 rounded-full de-ease-4 mr-0.5"></span>easy</span>
               </div>
               <%# Dot timeline — newest first, left to right %>
               <div class="flex flex-wrap gap-1.5">
-                <% @review_logs.first(30).each do |log| %>
-                  <span class="w-2.5 h-2.5 rounded-full de-ease-<%= log.ease %>"
-                        title="<%= %w[_ Again Hard Good Easy][log.ease] %> — <%= log.created_at.strftime('%-d %b %Y') %>">
+                <% @review_logs.each do |log| %>
+                  <span role="img"
+                        aria-label="<%= %w[_ Again Hard Good Easy][log.ease] %>, <%= log.created_at.strftime('%-d %b %Y') %>"
+                        class="w-2.5 h-2.5 rounded-full de-ease-<%= log.ease %>">
                   </span>
                 <% end %>
               </div>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -165,7 +165,7 @@
 
           <% if @user_learning.next_due %>
             <%
-              days = (@user_learning.next_due.to_date - Date.today).to_i
+              days = (@user_learning.next_due.to_date - Time.zone.today).to_i
               urgency_class = days < 0 ? "text-red-400" : days == 0 ? "text-amber-400" : "text-gray-500"
               urgency_label = days < 0 ? "#{days.abs}d overdue" : days == 0 ? "due today" : "in #{days}d"
             %>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -138,6 +138,8 @@
             </span>
           </div>
 
+          <%# Load once so first(5), any?, size, each all reuse cached records %>
+          <% @review_logs.load %>
           <%# Struggling indicator — derived from last 5 reviews %>
           <% recent_ease = @review_logs.first(5).map(&:ease) %>
           <% if recent_ease.any? %>
@@ -201,7 +203,7 @@
                 <% @review_logs.each do |log| %>
                   <span role="img"
                         aria-label="<%= %w[_ Again Hard Good Easy][log.ease] %>, <%= log.created_at.strftime('%-d %b %Y') %>"
-                        class="w-2.5 h-2.5 rounded-full de-ease-<%= log.ease %>">
+                        class="inline-block w-2.5 h-2.5 rounded-full de-ease-<%= log.ease %>">
                   </span>
                 <% end %>
               </div>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -67,16 +67,6 @@
           <span class="de-mono inline-block px-3 py-1 rounded-full border text-xs tracking-widest de-state-<%= @user_learning.state %>">
             <%= @user_learning.state.upcase %>
           </span>
-          <% if @user_learning.next_due %>
-            <%
-              days = (@user_learning.next_due.to_date - Date.today).to_i
-              urgency_class = days < 0 ? "text-red-400" : days == 0 ? "text-amber-400" : "text-gray-500"
-              urgency_label = days < 0 ? "#{days.abs}d overdue" : days == 0 ? "due today" : "in #{days}d"
-            %>
-            <p class="de-mono text-[11px] text-gray-500 mt-2">next review</p>
-            <p class="de-mono text-xs text-gray-400 mt-0.5"><%= @user_learning.next_due.strftime("%-d %b %Y") %></p>
-            <p class="de-mono text-[11px] mt-0.5 <%= urgency_class %>"><%= urgency_label %></p>
-          <% end %>
         <% else %>
           <span class="de-mono inline-block px-3 py-1 rounded-full border text-xs tracking-widest de-state-unstarted">
             NOT STARTED
@@ -130,6 +120,42 @@
               <%= @user_learning.state %>
             </span>
           </div>
+
+          <%# Struggling indicator — derived from last 5 reviews %>
+          <% recent_ease = @review_logs.first(5).map(&:ease) %>
+          <% if recent_ease.any? %>
+            <% avg_ease = recent_ease.sum.to_f / recent_ease.size %>
+            <% if avg_ease < 2.0 %>
+              <div class="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-red-500/10 border border-red-500/25">
+                <span class="text-red-400 mt-0.5 text-xs leading-none select-none">▲</span>
+                <div>
+                  <p class="de-mono text-[11px] text-red-400 tracking-wide">Struggling</p>
+                  <p class="de-mono text-[10px] text-red-400/60 mt-0.5">Mostly Again / Hard in recent reviews</p>
+                </div>
+              </div>
+            <% elsif avg_ease < 2.5 %>
+              <div class="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/25">
+                <span class="text-amber-400 mt-0.5 text-xs leading-none select-none">▲</span>
+                <div>
+                  <p class="de-mono text-[11px] text-amber-400 tracking-wide">Needs practice</p>
+                  <p class="de-mono text-[10px] text-amber-400/60 mt-0.5">More Hard ratings than Good recently</p>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+
+          <% if @user_learning.next_due %>
+            <%
+              days = (@user_learning.next_due.to_date - Date.today).to_i
+              urgency_class = days < 0 ? "text-red-400" : days == 0 ? "text-amber-400" : "text-gray-500"
+              urgency_label = days < 0 ? "#{days.abs}d overdue" : days == 0 ? "due today" : "in #{days}d"
+            %>
+            <div>
+              <p class="de-mono text-[10px] text-gray-600 uppercase tracking-wider mb-1">Next Review</p>
+              <p class="de-mono text-sm text-gray-300"><%= @user_learning.next_due.strftime("%-d %b %Y") %></p>
+              <p class="de-mono text-[11px] mt-0.5 <%= urgency_class %>"><%= urgency_label %></p>
+            </div>
+          <% end %>
 
           <% if @user_learning.last_interval %>
             <div>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -3,9 +3,9 @@
 <% content_for :head do %>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&family=Ma+Shan+Zheng&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
   <style>
-    .de-char    { font-family: 'Noto Serif SC', 'Source Han Serif CN', 'STSong', 'SimSun', serif; line-height: 1; text-rendering: optimizeLegibility; }
+    .de-char    { line-height: 1; text-rendering: optimizeLegibility; }
     .de-lora    { font-family: 'Lora', Georgia, 'Times New Roman', serif; }
     .de-mono    { font-family: 'Space Mono', 'Courier New', monospace; }
 
@@ -45,7 +45,7 @@
   <div class="de-hero rounded-2xl p-8 mb-4 border border-gray-700/40 relative overflow-hidden">
 
     <%# Ghost character in background %>
-    <div class="de-char absolute -right-6 -top-4 text-[11rem] leading-none text-white/[0.04] select-none pointer-events-none" aria-hidden="true">
+    <div class="de-char font-hanzi absolute -right-6 -top-4 text-[11rem] leading-none text-white/[0.04] select-none pointer-events-none" aria-hidden="true">
       <%= @dictionary_entry.text %>
     </div>
 
@@ -53,7 +53,7 @@
 
       <%# Left: character + pinyin %>
       <div>
-        <h1 class="de-char text-[6.5rem] text-gray-50 mb-3" lang="zh">
+        <h1 class="de-char font-hanzi text-[6.5rem] text-gray-50 mb-3" lang="zh">
           <%= @dictionary_entry.text %>
         </h1>
         <% @meanings.map(&:pinyin).uniq.each do |pinyin| %>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -1,56 +1,273 @@
-<div>
-  <%= link_to '< Back', :back, class: 'text-blue-500 hover:underline mb-4 inline-block' %>
+<% content_for :title, "#{@dictionary_entry.text} — Learn Hanzi" %>
 
-  <h1 class="font-bold text-4xl">
-    <%= @dictionary_entry.text %>
-  </h1>
+<% content_for :head do %>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,600;1,400&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    .de-char    { font-family: 'Noto Serif SC', 'Source Han Serif CN', 'STSong', 'SimSun', serif; line-height: 1; text-rendering: optimizeLegibility; }
+    .de-lora    { font-family: 'Lora', Georgia, 'Times New Roman', serif; }
+    .de-mono    { font-family: 'Space Mono', 'Courier New', monospace; }
 
-  <% @meanings.group_by(&:source).each do |source, meanings| %>
-    <% meanings.map(&:pinyin).uniq.map do |pinyin| %>
-      <p class="text-gray-800 dark:text-gray-200"><%= pinyin %></p>
-    <% end %>
-    <br>
-    <h2 class="text-4xl font-extrabold text-gray-800 dark:text-gray-200 mb-6">
-      <%= source.name %>
-    </h2>
-    <% meanings.each do |meaning| %>
-      <p class="text-gray-800 dark:text-gray-200">
-        <%= meaning.text %>
+    .de-hero {
+      background:
+        radial-gradient(ellipse at 20% 60%, rgba(220,38,38,0.07) 0%, transparent 55%),
+        linear-gradient(150deg, #131c2e 0%, #0d1117 100%);
+    }
+
+    .de-state-new        { background: rgba(59,130,246,0.12);  border-color: rgba(59,130,246,0.35);  color: #93c5fd; }
+    .de-state-learning   { background: rgba(245,158,11,0.12);  border-color: rgba(245,158,11,0.35);  color: #fcd34d; }
+    .de-state-mastered   { background: rgba(34,197,94,0.12);   border-color: rgba(34,197,94,0.35);   color: #86efac; }
+    .de-state-suspended  { background: rgba(107,114,128,0.12); border-color: rgba(107,114,128,0.35); color: #9ca3af; }
+    .de-state-unstarted  { background: rgba(107,114,128,0.08); border-color: rgba(107,114,128,0.25); color: #6b7280; }
+
+    .de-ease-1 { background: #ef4444; }
+    .de-ease-2 { background: #f97316; }
+    .de-ease-3 { background: #22c55e; }
+    .de-ease-4 { background: #3b82f6; }
+
+    .de-future {
+      border: 1px dashed rgba(75,85,99,0.45);
+      background: rgba(17,24,39,0.4);
+    }
+  </style>
+<% end %>
+
+<div class="w-full max-w-4xl mx-auto pb-20">
+
+  <%# ── Back nav ──────────────────────────────────────────── %>
+  <div class="mb-6">
+    <%= link_to "← back", :back,
+          class: "de-mono text-[11px] text-gray-600 hover:text-red-400 transition-colors tracking-[0.18em] uppercase" %>
+  </div>
+
+  <%# ── Character hero ────────────────────────────────────── %>
+  <div class="de-hero rounded-2xl p-8 mb-4 border border-gray-700/40 relative overflow-hidden">
+
+    <%# Ghost character in background %>
+    <div class="de-char absolute -right-6 -top-4 text-[11rem] leading-none text-white/[0.04] select-none pointer-events-none" aria-hidden="true">
+      <%= @dictionary_entry.text %>
+    </div>
+
+    <div class="relative flex items-start justify-between gap-6">
+
+      <%# Left: character + pinyin %>
+      <div>
+        <h1 class="de-char text-[6.5rem] text-gray-50 mb-3" lang="zh">
+          <%= @dictionary_entry.text %>
+        </h1>
+        <% @meanings.map(&:pinyin).uniq.each do |pinyin| %>
+          <p class="de-mono text-amber-400 text-lg tracking-[0.25em]"><%= pinyin %></p>
+        <% end %>
+      </div>
+
+      <%# Right: learning state badge %>
+      <div class="text-right shrink-0 mt-1">
+        <% if @user_learning %>
+          <span class="de-mono inline-block px-3 py-1 rounded-full border text-xs tracking-widest de-state-<%= @user_learning.state %>">
+            <%= @user_learning.state.upcase %>
+          </span>
+          <% if @user_learning.next_due %>
+            <%
+              days = (@user_learning.next_due.to_date - Date.today).to_i
+              urgency_class = days < 0 ? "text-red-400" : days == 0 ? "text-amber-400" : "text-gray-500"
+              urgency_label = days < 0 ? "#{days.abs}d overdue" : days == 0 ? "due today" : "in #{days}d"
+            %>
+            <p class="de-mono text-[11px] text-gray-500 mt-2">next review</p>
+            <p class="de-mono text-xs text-gray-400 mt-0.5"><%= @user_learning.next_due.strftime("%-d %b %Y") %></p>
+            <p class="de-mono text-[11px] mt-0.5 <%= urgency_class %>"><%= urgency_label %></p>
+          <% end %>
+        <% else %>
+          <span class="de-mono inline-block px-3 py-1 rounded-full border text-xs tracking-widest de-state-unstarted">
+            NOT STARTED
+          </span>
+        <% end %>
+      </div>
+
+    </div>
+
+    <div class="mt-5 pt-4 border-t border-gray-700/40">
+      <p class="de-mono text-[10px] text-gray-700 tracking-[0.15em] uppercase">
+        Source: CC-CEDICT
+        &ensp;·&ensp;
+        Entry #<%= @dictionary_entry.id %>
       </p>
+    </div>
+  </div>
+
+  <%# ── Definitions + Progress (side by side on wide screens) %>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
+
+    <%# Definitions — 2 cols %>
+    <div class="lg:col-span-2 bg-gray-800/40 border border-gray-700/40 rounded-xl p-6">
+      <h2 class="de-lora text-[10px] text-red-500 uppercase tracking-[0.2em] font-semibold mb-4">
+        Definitions
+      </h2>
+      <ol class="space-y-3">
+        <% @meanings.each_with_index do |meaning, i| %>
+          <li class="flex gap-3">
+            <span class="de-mono text-[11px] text-gray-600 pt-[3px] w-5 shrink-0 text-right select-none">
+              <%= i + 1 %>.
+            </span>
+            <p class="de-lora text-gray-200 text-[1.1rem] leading-snug"><%= meaning.text %></p>
+          </li>
+        <% end %>
+      </ol>
+    </div>
+
+    <%# Learning progress — 1 col %>
+    <div class="bg-gray-800/40 border border-gray-700/40 rounded-xl p-6">
+      <h2 class="de-lora text-[10px] text-red-500 uppercase tracking-[0.2em] font-semibold mb-4">
+        Progress
+      </h2>
+
+      <% if @user_learning %>
+        <div class="space-y-5">
+
+          <div>
+            <p class="de-mono text-[10px] text-gray-600 uppercase tracking-wider mb-1.5">Status</p>
+            <span class="de-mono inline-block px-2.5 py-1 rounded-full border text-[11px] tracking-wide de-state-<%= @user_learning.state %>">
+              <%= @user_learning.state %>
+            </span>
+          </div>
+
+          <% if @user_learning.last_interval %>
+            <div>
+              <p class="de-mono text-[10px] text-gray-600 uppercase tracking-wider mb-1">Interval</p>
+              <p class="de-mono text-sm text-gray-300">
+                <%= @user_learning.last_interval %> day<%= @user_learning.last_interval == 1 ? "" : "s" %>
+              </p>
+            </div>
+          <% end %>
+
+          <% if @review_logs.any? %>
+            <div>
+              <p class="de-mono text-[10px] text-gray-600 uppercase tracking-wider mb-2">
+                Review history
+                <span class="text-gray-700 normal-case tracking-normal">(<%= @review_logs.count %> total)</span>
+              </p>
+              <%# Ease legend %>
+              <div class="de-mono text-[9px] text-gray-700 flex gap-3 mb-2">
+                <span><span class="inline-block w-2 h-2 rounded-full de-ease-1 mr-0.5"></span>again</span>
+                <span><span class="inline-block w-2 h-2 rounded-full de-ease-2 mr-0.5"></span>hard</span>
+                <span><span class="inline-block w-2 h-2 rounded-full de-ease-3 mr-0.5"></span>good</span>
+                <span><span class="inline-block w-2 h-2 rounded-full de-ease-4 mr-0.5"></span>easy</span>
+              </div>
+              <%# Dot timeline — newest first, left to right %>
+              <div class="flex flex-wrap gap-1.5">
+                <% @review_logs.first(30).each do |log| %>
+                  <span class="w-2.5 h-2.5 rounded-full de-ease-<%= log.ease %>"
+                        title="<%= %w[_ Again Hard Good Easy][log.ease] %> — <%= log.created_at.strftime('%-d %b %Y') %>">
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+        </div>
+      <% else %>
+        <div class="py-4 text-center">
+          <p class="de-lora text-gray-500 italic text-sm">No learning record yet</p>
+          <p class="de-mono text-[11px] text-gray-600 mt-1 leading-snug">
+            Start a learn session<br>to begin tracking progress
+          </p>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+
+  <%# ── Vocabulary Sets / Tags ─────────────────────────────── %>
+  <div class="bg-gray-800/40 border border-gray-700/40 rounded-xl p-6 mb-4">
+    <h2 class="de-lora text-[10px] text-red-500 uppercase tracking-[0.2em] font-semibold mb-4">
+      Vocabulary Sets
+    </h2>
+    <% if @dictionary_entry.tags.any? %>
+      <div class="flex flex-wrap gap-2">
+        <% @dictionary_entry.tags.each do |tag| %>
+          <%= link_to tag_path(tag), class: "group" do %>
+            <div class="flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-600/40 bg-gray-700/25 hover:border-red-500/40 hover:bg-gray-700/50 transition-all">
+              <% if tag.parent %>
+                <span class="de-mono text-[11px] text-gray-500 group-hover:text-gray-400 transition-colors">
+                  <%= tag.parent.name %>
+                </span>
+                <span class="text-gray-600 text-xs mx-0.5">›</span>
+              <% end %>
+              <span class="de-mono text-[11px] text-gray-300 group-hover:text-red-300 transition-colors">
+                <%= tag.name %>
+              </span>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="de-lora text-gray-600 italic text-sm">No vocabulary sets assigned</p>
     <% end %>
-  <% end %>
+  </div>
 
-  <h2 class="text-4xl font-extrabold text-gray-800 dark:text-gray-200 mb-6">
-    Tags
-  </h2>
+  <%# ── Future sections ──────────────────────────────────── %>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
 
-  <ul>
-    <% @dictionary_entry.tags.each do |tag| %>
-      <li>
-        <%= link_to "#{tag.parent.name} |  #{tag.name}", tag_path(tag), data: { turbo_frame: "tag_#{tag.id}" }, class: "text-blue-500 hover:underline" %>
-      </li>
-    <% end %>
-  </ul>
+    <div class="de-future rounded-xl p-6">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
+          Radical Breakdown
+        </h2>
+        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
+          SOON
+        </span>
+      </div>
+      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
+        Component radicals and stroke order will appear here.
+      </p>
+    </div>
 
-  <h2 class="text-4xl font-extrabold text-gray-800 dark:text-gray-200 mb-6">
-    Learning Progress
-  </h2>
+    <div class="de-future rounded-xl p-6">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
+          Similar Characters
+        </h2>
+        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
+          SOON
+        </span>
+      </div>
+      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
+        Characters sharing components or pronunciation.
+      </p>
+    </div>
 
-  <% if @user_learning %>
-    <p>
-      State: <%= @user_learning[:state] %>
-    </p>
+  </div>
 
-    <p>
-      Next Review: <%= @user_learning[:next_due] %>
-    </p>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-    <p>
-      Last Interval: <%= @user_learning[:last_interval] %>
-    </p>
-  <% else %>
-    <p>
-    No record of current learning
-    </p>
-  <% end %>
+    <div class="de-future rounded-xl p-6">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
+          Example Sentences
+        </h2>
+        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
+          SOON
+        </span>
+      </div>
+      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
+        Contextual examples from literature and everyday usage.
+      </p>
+    </div>
+
+    <div class="de-future rounded-xl p-6">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
+          Pronunciation
+        </h2>
+        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
+          SOON
+        </span>
+      </div>
+      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
+        Audio recording of native speaker pronunciation.
+      </p>
+    </div>
+
+  </div>
+
 </div>

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "DictionaryEntries", type: :request do
 
         it "shows the learning state badge" do
           get dictionary_entry_path(dictionary_entry)
-          expect(response.body).to include("learning")
+          expect(response.body).to include("LEARNING")
         end
 
         it "does not render the review history section when there are no logs" do

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -17,6 +17,43 @@ RSpec.describe "DictionaryEntries", type: :request do
         get dictionary_entry_path(dictionary_entry)
         expect(response.body).to include(dictionary_entry.text)
       end
+
+      context "when the user has no learning record" do
+        it "shows the not-started state" do
+          get dictionary_entry_path(dictionary_entry)
+          expect(response.body).to include("NOT STARTED")
+        end
+
+        it "does not render the review history section" do
+          get dictionary_entry_path(dictionary_entry)
+          expect(response.body).not_to include("Review history")
+        end
+      end
+
+      context "when the user has a learning record" do
+        let!(:user_learning) do
+          create(:user_learning, user: user, dictionary_entry: dictionary_entry, state: "learning")
+        end
+
+        it "shows the learning state badge" do
+          get dictionary_entry_path(dictionary_entry)
+          expect(response.body).to include("learning")
+        end
+
+        it "does not render the review history section when there are no logs" do
+          get dictionary_entry_path(dictionary_entry)
+          expect(response.body).not_to include("Review history")
+        end
+
+        context "with review logs" do
+          before { create_list(:review_log, 3, user_learning: user_learning, ease: 3) }
+
+          it "renders the review history section" do
+            get dictionary_entry_path(dictionary_entry)
+            expect(response.body).to include("Review history")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Replaces the plain, unstyled show view with an "Ink & Reference" editorial design: dark background, vermillion accent, Lora serif for English, Space Mono for metadata/pinyin, and Ma Shan Zheng (matching the flashcard views) for the character display
- Organises the page into a character hero → definitions + progress panel → vocabulary sets → four placeholder sections (radical breakdown, similar characters, example sentences, pronunciation)
- `DictionaryEntry.find_with_associations` uses `includes(:source)` so the view can derive the source label(s) from `@meanings` rather than hard-coding 'CC-CEDICT'
- Adds `@review_logs` to the controller (last 30, `ReviewLog.none` for no-record case) so the progress panel can show a dot-timeline of recent reviews coloured by ease, without N+1 queries
- Derives a difficulty indicator (Struggling / Needs practice) from average ease of the last 5 reviews

## Test plan

- [ ] Visit `/dictionary_entries/:id` for an entry with meanings, tags, and a user learning record — verify all sections render correctly
- [ ] Visit an entry with no user learning record — verify the progress panel shows the "Not started" state gracefully
- [ ] Full test suite passes (`bundle exec rspec`)

## Deliberate decisions

None — all reviewer comments accepted and addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)