### PR TITLE
feat: split review due count and show on tag page

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,8 +5,8 @@ class DashboardController < ApplicationController
     @no_data = user_learnings.none?
     @advice  = @no_data ? nil : LearningAdvisor.classify(user: Current.user)
 
-    @cards_due = user_learnings.overdue_learning.count +
-                 user_learnings.due_mastered.count
+    @learning_due = user_learnings.overdue_learning.count
+    @review_due   = user_learnings.due_mastered.count
 
     @state_counts = {
       new:      user_learnings.new_learnings.count,
@@ -14,7 +14,7 @@ class DashboardController < ApplicationController
       mastered: user_learnings.mastered.count
     }
 
-    @new_cards_count = user_learnings.new_learnings.count
+    @new_cards_count = @state_counts[:new]
 
     @vocabulary_sections = build_vocabulary_sections
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -25,7 +25,7 @@ class TagsController < ApplicationController
     subtree_learnings = Current.user.user_learnings
                                     .joins(dictionary_entry: :dictionary_entry_tags)
                                     .where(dictionary_entry_tags: { tag_id: @entry_tag.subtree_ids })
-    @overdue_in_subtree = subtree_learnings.overdue_learning.exists? ||
-                          subtree_learnings.due_mastered.exists?
+    @learning_due_count = subtree_learnings.overdue_learning.count
+    @review_due_count   = subtree_learnings.due_mastered.count
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,6 +23,7 @@ class TagsController < ApplicationController
     )
 
     subtree_learnings = Current.user.user_learnings
+                                    .distinct
                                     .joins(dictionary_entry: :dictionary_entry_tags)
                                     .where(dictionary_entry_tags: { tag_id: @entry_tag.subtree_ids })
     @learning_due_count = subtree_learnings.overdue_learning.count

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -54,10 +54,20 @@
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col">
       <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-1">Review</h2>
       <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">Cards due for review today</p>
-      <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6"><%= @cards_due %></div>
+      <dl class="space-y-3 flex-grow mb-6">
+        <div class="flex justify-between items-center">
+          <dt class="text-gray-600 dark:text-gray-400">In progress</dt>
+          <dd class="font-bold text-amber-500 text-lg"><%= @learning_due %></dd>
+        </div>
+        <div class="flex justify-between items-center">
+          <dt class="text-gray-600 dark:text-gray-400">To review</dt>
+          <dd class="font-bold text-blue-600 dark:text-blue-400 text-lg"><%= @review_due %></dd>
+        </div>
+      </dl>
+      <% total_due = @learning_due + @review_due %>
       <%= link_to review_path,
             class: "mt-auto inline-block text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg px-5 py-3 transition-colors" do %>
-        <%= @cards_due > 0 ? "Start review" : "No cards due" %>
+        <%= total_due > 0 ? "Start review" : "No cards due" %>
       <% end %>
     </div>
 

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -14,11 +14,17 @@
 
   <div class="flex items-center gap-4 mb-6">
     <h1 class="text-4xl font-extrabold text-gray-800 dark:text-gray-200"><%= @entry_tag.name %></h1>
-    <% if @overdue_in_subtree %>
-      <%= link_to review_path(tag_id: @entry_tag.id),
-            class: "text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors" do %>
-        Review overdue &rarr;
-      <% end %>
+    <% if @learning_due_count > 0 || @review_due_count > 0 %>
+      <div class="flex items-center gap-3 text-sm">
+        <% if @learning_due_count > 0 %>
+          <span class="font-medium text-amber-600 dark:text-amber-400"><%= @learning_due_count %> in progress</span>
+        <% end %>
+        <% if @review_due_count > 0 %>
+          <span class="font-medium text-blue-600 dark:text-blue-400"><%= @review_due_count %> to review</span>
+        <% end %>
+        <%= link_to "Start \u2192", review_path(tag_id: @entry_tag.id),
+              class: "font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors" %>
+      </div>
     <% end %>
   </div>
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -83,9 +83,14 @@ RSpec.describe "Dashboard", type: :request do
                  next_due: 1.day.ago, last_interval: 3)
         end
 
-        it "shows 1 in the in-progress due count" do
+        it "shows 1 in the in-progress due row" do
           get root_path
-          expect(response.body).to include("1")
+          expect(response.body).to match(%r{In progress</dt>\s*<dd[^>]*>1</dd>})
+        end
+
+        it "shows 0 in the to-review due row" do
+          get root_path
+          expect(response.body).to match(%r{To review</dt>\s*<dd[^>]*>0</dd>})
         end
       end
 
@@ -95,16 +100,27 @@ RSpec.describe "Dashboard", type: :request do
                  next_due: 1.day.ago, last_interval: 30)
         end
 
-        it "shows 1 in the to-review count" do
+        it "shows 0 in the in-progress due row" do
           get root_path
-          expect(response.body).to include("1")
+          expect(response.body).to match(%r{In progress</dt>\s*<dd[^>]*>0</dd>})
+        end
+
+        it "shows 1 in the to-review due row" do
+          get root_path
+          expect(response.body).to match(%r{To review</dt>\s*<dd[^>]*>1</dd>})
         end
       end
 
       context "with no cards due" do
+        before do
+          create(:user_learning, user: user, state: "learning",
+                 next_due: 7.days.from_now, last_interval: 1)
+        end
+
         it "shows zero for both due counts" do
           get root_path
-          expect(response.body).to include("0")
+          expect(response.body).to match(%r{In progress</dt>\s*<dd[^>]*>0</dd>})
+          expect(response.body).to match(%r{To review</dt>\s*<dd[^>]*>0</dd>})
         end
       end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -77,20 +77,32 @@ RSpec.describe "Dashboard", type: :request do
         end
       end
 
-      context "with cards due" do
+      context "with an overdue learning card" do
         before do
           create(:user_learning, user: user, state: "learning",
                  next_due: 1.day.ago, last_interval: 3)
         end
 
-        it "shows the number of cards due" do
+        it "shows 1 in the in-progress due count" do
+          get root_path
+          expect(response.body).to include("1")
+        end
+      end
+
+      context "with a mastered card due for review" do
+        before do
+          create(:user_learning, user: user, state: "mastered",
+                 next_due: 1.day.ago, last_interval: 30)
+        end
+
+        it "shows 1 in the to-review count" do
           get root_path
           expect(response.body).to include("1")
         end
       end
 
       context "with no cards due" do
-        it "shows zero cards due" do
+        it "shows zero for both due counts" do
           get root_path
           expect(response.body).to include("0")
         end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -85,18 +85,23 @@ RSpec.describe "Tags", type: :request do
       end
     end
 
-    describe "GET /tags/:id — review overdue link" do
+    describe "GET /tags/:id — due summary" do
       let(:entry) { create(:dictionary_entry).tap { |e| e.tags << mid_tag } }
 
-      context "when overdue cards exist within the tag subtree" do
+      context "when overdue learning cards exist within the tag subtree" do
         before do
           create(:user_learning, user: user, dictionary_entry: entry,
                  state: "learning", next_due: 1.day.ago, last_interval: 1)
         end
 
-        it "shows a review overdue link scoped to that tag" do
+        it "shows the review link scoped to that tag" do
           get tag_path(mid_tag)
           expect(response.body).to include(review_path(tag_id: mid_tag.id))
+        end
+
+        it "shows the in-progress count" do
+          get tag_path(mid_tag)
+          expect(response.body).to include("1 in progress")
         end
       end
 
@@ -108,7 +113,7 @@ RSpec.describe "Tags", type: :request do
                  state: "learning", next_due: 1.day.ago, last_interval: 1)
         end
 
-        it "shows a review overdue link for the parent tag" do
+        it "shows the review link for the parent tag" do
           get tag_path(mid_tag)
           expect(response.body).to include(review_path(tag_id: mid_tag.id))
         end
@@ -120,9 +125,14 @@ RSpec.describe "Tags", type: :request do
                  state: "mastered", next_due: 1.day.ago, last_interval: 30)
         end
 
-        it "shows the review overdue link" do
+        it "shows the review link" do
           get tag_path(mid_tag)
           expect(response.body).to include(review_path(tag_id: mid_tag.id))
+        end
+
+        it "shows the to-review count" do
+          get tag_path(mid_tag)
+          expect(response.body).to include("1 to review")
         end
       end
 
@@ -132,7 +142,7 @@ RSpec.describe "Tags", type: :request do
                  state: "learning", next_due: 7.days.from_now, last_interval: 1)
         end
 
-        it "does not show the review overdue link" do
+        it "does not show the review link" do
           get tag_path(mid_tag)
           expect(response.body).not_to include(review_path(tag_id: mid_tag.id))
         end


### PR DESCRIPTION
## Summary

- Splits the dashboard Review panel's single combined count into two rows: **In progress** (overdue learning-state cards) and **To review** (mastered cards due for SRS spot-check)
- Adds a due summary inline on the tag show page — e.g. "12 in progress · 47 to review → Start →" — so you can see what's waiting in each HSK level before starting a session
- Removes a redundant `new_learnings.count` DB query in `DashboardController`; `@new_cards_count` now reads from `@state_counts[:new]`

## Motivation

When catching up from a backlog, the combined count obscured whether progress was being made on mastered vocabulary vs. cards still in the unstable learning phase. The tag-page summary lets you navigate HSK 1 → 2 → 3 etc. and review each level's mastered cards deliberately rather than being pulled into a mixed session dominated by struggling cards.

## Test plan

- [ ] Dashboard spec: verify in-progress and to-review counts render correctly for each state
- [ ] Tags spec: verify count labels ("1 in progress", "1 to review") appear for the correct card states
- [ ] Tags spec: verify review link is absent when no cards are due

🤖 Generated with [Claude Code](https://claude.com/claude-code)