### PR TITLE
ci: switch Docker publish to private registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,24 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to private registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: registry.huwdiprose.co.uk
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/learn_hanzi
+          images: registry.huwdiprose.co.uk/learn_hanzi
           tags: |
             type=sha,prefix=,format=short
             type=raw,value=latest


### PR DESCRIPTION
## Summary

- Switches the Docker publish target from GitHub Container Registry (`ghcr.io`) to the private Synology registry at `registry.huwdiprose.co.uk`
- Replaces `GITHUB_TOKEN` auth with `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` secrets (same names as the growatt repo)
- Drops the `packages: write` permission which is no longer needed

## Before merging

Add two repository secrets:
- `REGISTRY_USERNAME`
- `REGISTRY_PASSWORD`

## Test plan

- [x] Secrets added to repo
- [ ] PR merged to main
- [ ] Docker workflow runs and image appears at `registry.huwdiprose.co.uk/learn_hanzi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)