### PR TITLE
chore: wire up Playwright MCP for browser debugging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--headless"]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@0.0.70", "--headless"]
+      "args": ["-y", "@playwright/mcp@0.0.70"]
     }
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--headless"]
+      "args": ["-y", "@playwright/mcp@0.0.70", "--headless"]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@
 /coverage/*
 
 /.claude.env
-.claude/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,7 @@ When upgrading the version in `.claude/settings.json`, re-run this command to ke
 ### Workflow
 
 1. Start the dev server: `bin/rails server`
-2. **Authenticate first (headless-safe)** — `@playwright/mcp` runs headless, so do not rely on manually completing OIDC in a visible browser window. Use one of these approaches instead:
-   - Reuse a pre-authenticated browser/storage state if one has already been prepared for local debugging.
-   - Or navigate to `http://localhost:3000/sign_in` with MCP and drive the OIDC flow via MCP actions, validating progress with `browser_take_screenshot`, `browser_snapshot`, and `browser_console_messages`.
-   The authenticated session cookie persists for subsequent Playwright navigations in the same browser context.
+2. **Authenticate first** — `@playwright/mcp` runs in headed mode so a browser window is visible. Navigate to `http://localhost:3000/sign_in` and complete the OIDC login in that window. The session cookie then persists for subsequent Playwright navigations in the same browser context.
 3. Navigate to the relevant route and use `browser_take_screenshot`, `browser_snapshot` (accessibility tree), or `browser_console_messages` to inspect state.
 
 ### Key routes for UI verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### One-time setup
 
+Install the Chromium build that matches the pinned `@playwright/mcp` version:
+
 ```bash
-npx playwright install chromium
+npx -p @playwright/mcp@0.0.70 playwright install chromium
 ```
+
+When upgrading the version in `.claude/settings.json`, re-run this command to keep the browser in sync.
 
 ### Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,38 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Browser automation (Playwright MCP)
+## Frontend debugging with Playwright MCP
 
-`.claude/settings.json` wires up `@playwright/mcp` so Claude can navigate the running app, take screenshots, read the DOM, and check JS console output. Before using it in a session, ensure Chromium is installed:
+`.claude/settings.json` wires up `@playwright/mcp` so Claude can navigate the running app, take screenshots, read the DOM, and check JS console output.
+
+### One-time setup
 
 ```bash
 npx playwright install chromium
 ```
 
-The Rails dev server must be running (`bin/rails server`) for any browser navigation to work.
+### Workflow
+
+1. Start the dev server: `bin/rails server`
+2. **Authenticate first** — navigate to `http://localhost:3000/sign_in` and complete the OIDC login (Pocket ID on the NAS). The session cookie persists for subsequent Playwright navigations in the same browser context.
+3. Navigate to the relevant route and use `browser_take_screenshot`, `browser_snapshot` (accessibility tree), or `browser_console_messages` to inspect state.
+
+### Key routes for UI verification
+
+| Flow | Routes |
+|---|---|
+| Learn | `/learn` → `/learn/card` → `/learn/review` → `/learn/summary` |
+| Review | `/review` → `/review/card` → `/review/summary` |
+| History | `/review/history` |
+
+### Stimulus controllers
+
+- `card_flip_controller.js` — handles card reveal and keyboard shortcuts (1–4 ease keys) on both review flows
+- `learn_card_controller.js` — controls the learn card presentation
+- `collapsible_controller.js` — show/hide toggles (e.g. supplemental meanings)
+- `dropdown_controller.js` — dropdown menus
+
+After any frontend change: navigate to the affected route, take a screenshot, and check `browser_console_messages` for JS errors before marking the task complete.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,10 @@ When upgrading the version in `.claude/settings.json`, re-run this command to ke
 ### Workflow
 
 1. Start the dev server: `bin/rails server`
-2. **Authenticate first** — navigate to `http://localhost:3000/sign_in` and complete the OIDC login (Pocket ID on the NAS). The session cookie persists for subsequent Playwright navigations in the same browser context.
+2. **Authenticate first (headless-safe)** — `@playwright/mcp` runs headless, so do not rely on manually completing OIDC in a visible browser window. Use one of these approaches instead:
+   - Reuse a pre-authenticated browser/storage state if one has already been prepared for local debugging.
+   - Or navigate to `http://localhost:3000/sign_in` with MCP and drive the OIDC flow via MCP actions, validating progress with `browser_take_screenshot`, `browser_snapshot`, and `browser_console_messages`.
+   The authenticated session cookie persists for subsequent Playwright navigations in the same browser context.
 3. Navigate to the relevant route and use `browser_take_screenshot`, `browser_snapshot` (accessibility tree), or `browser_console_messages` to inspect state.
 
 ### Key routes for UI verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Browser automation (Playwright MCP)
+
+`.claude/settings.json` wires up `@playwright/mcp` so Claude can navigate the running app, take screenshots, read the DOM, and check JS console output. Before using it in a session, ensure Chromium is installed:
+
+```bash
+npx playwright install chromium
+```
+
+The Rails dev server must be running (`bin/rails server`) for any browser navigation to work.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `@playwright/mcp` to `.claude/settings.json` so Claude Code can navigate the running app, take screenshots, read the DOM, and inspect JS console output during frontend work
- Tightens `.gitignore` from ignoring `.claude/` entirely to ignoring only `settings.local.json`, so the shared `settings.json` can be tracked
- Documents the one-time `npx playwright install chromium` setup step in `CLAUDE.md`

## Tool choice rationale

Evaluated `@playwright/mcp`, Puppeteer MCP, and `browser-tools-mcp`:

| | @playwright/mcp | Puppeteer MCP | browser-tools-mcp |
|---|---|---|---|
| Screenshot | ✅ | ✅ | ✅ |
| DOM / accessibility tree | ✅ | ✅ | limited |
| Console output | ✅ | ✅ | ✅ |
| Click / fill | ✅ | ✅ | limited |
| Maintenance | Active (v0.0.70) | Moderate | Light |
| Multi-browser | ✅ | Chromium only | Chromium only |

`@playwright/mcp` wins on maintenance, official backing, and multi-browser support.

## Capabilities validated

- [x] Navigate to a URL
- [x] Take and read a screenshot
- [x] Read the DOM / accessibility tree
- [x] Read browser console output
- [x] Click elements and fill form inputs

## Dependencies

`npx playwright install chromium` must be run once per machine. The Rails dev server must be running for navigation to work.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)