### PR TITLE
fix: add data-ease attrs to learn/review ease buttons

### DIFF
--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -42,13 +42,13 @@
 
     <div data-card-flip-target="back" class="hidden">
       <div class="mt-6 flex justify-between">
-        <%= button_to "Again", learn_review_path, params: { ease: 1 },
+        <%= button_to "Again", learn_review_path, params: { ease: 1 }, data: { ease: "1" },
               class: "p-5 bg-red-50 dark:bg-red-900/40 text-red-600 dark:text-red-400 font-medium rounded-xl hover:bg-red-100 dark:hover:bg-red-900/60 transition-colors" %>
-        <%= button_to "Hard",  learn_review_path, params: { ease: 2 },
+        <%= button_to "Hard",  learn_review_path, params: { ease: 2 }, data: { ease: "2" },
               class: "p-5 bg-orange-50 dark:bg-orange-900/40 text-orange-600 dark:text-orange-400 font-medium rounded-xl hover:bg-orange-100 dark:hover:bg-orange-900/60 transition-colors" %>
-        <%= button_to "Good",  learn_review_path, params: { ease: 3 },
+        <%= button_to "Good",  learn_review_path, params: { ease: 3 }, data: { ease: "3" },
               class: "p-5 bg-green-50 dark:bg-green-900/40 text-green-600 dark:text-green-400 font-medium rounded-xl hover:bg-green-100 dark:hover:bg-green-900/60 transition-colors" %>
-        <%= button_to "Easy",  learn_review_path, params: { ease: 4 },
+        <%= button_to "Easy",  learn_review_path, params: { ease: 4 }, data: { ease: "4" },
               class: "p-5 bg-blue-50 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 font-medium rounded-xl hover:bg-blue-100 dark:hover:bg-blue-900/60 transition-colors" %>
       </div>
     </div>

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -256,6 +256,14 @@ RSpec.describe "Learn", type: :request do
         get learn_review_path
         expect(response.body).to include(new_card.dictionary_entry.text)
       end
+
+      it "renders ease buttons with data-ease attributes for keyboard shortcuts" do
+        get learn_review_path
+        expect(response.body).to include('data-ease="1"')
+        expect(response.body).to include('data-ease="2"')
+        expect(response.body).to include('data-ease="3"')
+        expect(response.body).to include('data-ease="4"')
+      end
     end
 
     context "when authenticated without an active review phase" do


### PR DESCRIPTION
## Summary

Fixes keyboard shortcuts (1–4 ease keys) being silently ignored in the `/learn/review` confirmation loop.

`card_flip_controller.js` resolves keypresses by querying `button[data-ease="N"]`. The standard `/review/card` view correctly includes these attributes; `learn/review_show.html.erb` did not — so the query always returned `null` and the submit never fired.

**Fix:** add `data: { ease: "N" }` to all four ease buttons in `learn/review_show.html.erb`, matching the existing pattern in `review/show.html.erb`.

**Regression spec:** added an assertion that all four `data-ease` attributes are present in the rendered response, so this class of bug is caught at the request level.

## Test plan

- [x] `bundle exec rspec spec/requests/learn_spec.rb` — 33 examples, 0 failures
- [ ] Visual verification via Playwright MCP (available after session restart with new `settings.json`)

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)