### PR TITLE
fix: move Playwright MCP config to .mcp.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,3 @@
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@0.0.70"]
-    }
-  }
+  "enabledMcpjsonServers": ["playwright"]
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@0.0.70"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Frontend debugging with Playwright MCP
 
-`.claude/settings.json` wires up `@playwright/mcp` so Claude can navigate the running app, take screenshots, read the DOM, and check JS console output.
+`.mcp.json` wires up `@playwright/mcp` so Claude can navigate the running app, take screenshots, read the DOM, and check JS console output.
 
 ### One-time setup
 


### PR DESCRIPTION
## Summary

Project-level MCP servers must be declared in `.mcp.json` at the repo root — the `mcpServers` key in `.claude/settings.json` is silently ignored and the server never starts.

- Moves the `playwright` server config from `.claude/settings.json` to `.mcp.json`
- Updates `.claude/settings.json` to use `enabledMcpjsonServers: ["playwright"]` to pre-approve the server (avoids a confirmation prompt each session)
- Updates CLAUDE.md to reference `.mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)