### PR TITLE
fix: replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -8,7 +8,7 @@ class SettingsController < ApplicationController
     if @user.update(settings_params)
       redirect_to settings_path, notice: "Settings saved."
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "Learn", type: :request do
     context "with an invalid ease rating" do
       it "returns unprocessable content" do
         post learn_review_path, params: { ease: 5 }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe "Review", type: :request do
       context "with an invalid ease rating" do
         it "returns unprocessable content" do
           post review_card_path, params: { ease: 99 }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe "Settings", type: :request do
       context "with invalid params" do
         it "re-renders the form when session_size is out of range" do
           patch settings_path, params: { user: { session_size: 0, new_cards_per_session: 5 } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "re-renders the form when new_cards_per_session exceeds session_size" do
           patch settings_path, params: { user: { session_size: 5, new_cards_per_session: 10 } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end


### PR DESCRIPTION
## Summary

- Replaces `:unprocessable_entity` with `:unprocessable_content` in three request spec files and `SettingsController`
- Silences the Rack deprecation warning that appeared on every test run touching these files

## Why

Rack deprecated the `:unprocessable_entity` symbol alias; the canonical name is now `:unprocessable_content` (matching the RFC). Both map to HTTP 422 for now, but the old symbol will be removed in a future Rack version.

## Test plan

- [x] `bundle exec rspec spec/requests/learn_spec.rb spec/requests/settings_spec.rb spec/requests/review_spec.rb` — 82 examples, 0 failures, no deprecation warnings
- [x] `bin/rubocop` on all changed files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)