### PR TITLE
ci: use nginx CF-Access proxy for private registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install nginx
+        run: sudo apt-get install -y nginx
+
       - name: Start CF-Access registry proxy
         env:
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
@@ -23,18 +26,24 @@ jobs:
           # injecting CF-Access service token headers so Cloudflare Access accepts
           # the request. cloudflared access tcp cannot do this because it forwards
           # raw TCP bytes — Docker's plain HTTP reaches the HTTPS origin and is reset.
+          REGISTRY="${{ vars.REGISTRY }}"
+          if [ -z "$REGISTRY" ]; then
+            echo "::error::REGISTRY repository variable is not set" >&2
+            exit 1
+          fi
+
           cat > /tmp/registry-proxy.conf <<NGINX
           server {
               listen 127.0.0.1:5000;
               client_max_body_size 0;
 
               location / {
-                  proxy_pass              https://${{ vars.REGISTRY }};
+                  proxy_pass              https://${REGISTRY};
                   proxy_ssl_server_name   on;
-                  proxy_ssl_name          ${{ vars.REGISTRY }};
+                  proxy_ssl_name          ${REGISTRY};
                   proxy_http_version      1.1;
                   proxy_set_header        Connection              "";
-                  proxy_set_header        Host                    ${{ vars.REGISTRY }};
+                  proxy_set_header        Host                    ${REGISTRY};
                   proxy_set_header        CF-Access-Client-Id     "${CF_ACCESS_CLIENT_ID}";
                   proxy_set_header        CF-Access-Client-Secret "${CF_ACCESS_CLIENT_SECRET}";
                   proxy_request_buffering off;
@@ -49,6 +58,15 @@ jobs:
           sudo rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
           sudo nginx -t
           sudo systemctl reload-or-restart nginx
+
+          for i in $(seq 1 30); do
+            if bash -c '</dev/tcp/127.0.0.1/5000' 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Timed out waiting for nginx to bind localhost:5000" >&2
+          exit 1
 
       - name: Log in to private registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
 
-env:
-  REGISTRY: registry.huwdiprose.co.uk
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -32,10 +29,10 @@ jobs:
               client_max_body_size 0;
 
               location / {
-                  proxy_pass              https://${{ env.REGISTRY }};
+                  proxy_pass              https://${{ vars.REGISTRY }};
                   proxy_ssl_server_name   on;
-                  proxy_ssl_name          ${{ env.REGISTRY }};
-                  proxy_set_header        Host                    ${{ env.REGISTRY }};
+                  proxy_ssl_name          ${{ vars.REGISTRY }};
+                  proxy_set_header        Host                    ${{ vars.REGISTRY }};
                   proxy_set_header        CF-Access-Client-Id     "${CF_ACCESS_CLIENT_ID}";
                   proxy_set_header        CF-Access-Client-Secret "${CF_ACCESS_CLIENT_SECRET}";
                   proxy_request_buffering off;

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,36 +14,39 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install cloudflared
-        run: |
-          curl --fail --silent --show-error --location \
-            https://github.com/cloudflare/cloudflared/releases/download/2024.12.2/cloudflared-linux-amd64 \
-            --output /tmp/cloudflared
-          sudo install -m 0755 /tmp/cloudflared /usr/local/bin/cloudflared
-
-      - name: Start cloudflared TCP proxy
+      - name: Start CF-Access registry proxy
         env:
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          cloudflared access tcp \
-            --hostname registry.huwdiprose.co.uk \
-            --url localhost:5000 &
-          CLOUDFLARED_PID=$!
+          # nginx reverse-proxies HTTP from localhost:5000 to the HTTPS registry,
+          # injecting CF-Access service token headers so Cloudflare Access accepts
+          # the request. cloudflared access tcp cannot do this because it forwards
+          # raw TCP bytes — Docker's plain HTTP reaches the HTTPS origin and is reset.
+          cat > /tmp/registry-proxy.conf <<NGINX
+          server {
+              listen 5000;
+              client_max_body_size 0;
 
-          for _ in $(seq 1 30); do
-            if ! kill -0 "$CLOUDFLARED_PID" 2>/dev/null; then
-              echo "cloudflared exited before the TCP proxy became ready" >&2
-              exit 1
-            fi
-            if bash -c '</dev/tcp/127.0.0.1/5000' 2>/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
+              location / {
+                  proxy_pass              https://registry.huwdiprose.co.uk;
+                  proxy_ssl_server_name   on;
+                  proxy_ssl_name          registry.huwdiprose.co.uk;
+                  proxy_set_header        Host                    registry.huwdiprose.co.uk;
+                  proxy_set_header        CF-Access-Client-Id     "${CF_ACCESS_CLIENT_ID}";
+                  proxy_set_header        CF-Access-Client-Secret "${CF_ACCESS_CLIENT_SECRET}";
+                  proxy_request_buffering off;
+                  proxy_buffering         off;
+                  proxy_read_timeout      300s;
+                  proxy_send_timeout      300s;
+              }
+          }
+          NGINX
 
-          echo "Timed out waiting for cloudflared TCP proxy on localhost:5000" >&2
-          exit 1
+          sudo cp /tmp/registry-proxy.conf /etc/nginx/conf.d/registry-proxy.conf
+          sudo rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
+          sudo nginx -t
+          sudo systemctl reload-or-restart nginx
 
       - name: Log in to private registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,13 +25,15 @@ jobs:
           # raw TCP bytes — Docker's plain HTTP reaches the HTTPS origin and is reset.
           cat > /tmp/registry-proxy.conf <<NGINX
           server {
-              listen 5000;
+              listen 127.0.0.1:5000;
               client_max_body_size 0;
 
               location / {
                   proxy_pass              https://${{ vars.REGISTRY }};
                   proxy_ssl_server_name   on;
                   proxy_ssl_name          ${{ vars.REGISTRY }};
+                  proxy_http_version      1.1;
+                  proxy_set_header        Connection              "";
                   proxy_set_header        Host                    ${{ vars.REGISTRY }};
                   proxy_set_header        CF-Access-Client-Id     "${CF_ACCESS_CLIENT_ID}";
                   proxy_set_header        CF-Access-Client-Secret "${CF_ACCESS_CLIENT_SECRET}";

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  REGISTRY: registry.huwdiprose.co.uk
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -29,10 +32,10 @@ jobs:
               client_max_body_size 0;
 
               location / {
-                  proxy_pass              https://registry.huwdiprose.co.uk;
+                  proxy_pass              https://${{ env.REGISTRY }};
                   proxy_ssl_server_name   on;
-                  proxy_ssl_name          registry.huwdiprose.co.uk;
-                  proxy_set_header        Host                    registry.huwdiprose.co.uk;
+                  proxy_ssl_name          ${{ env.REGISTRY }};
+                  proxy_set_header        Host                    ${{ env.REGISTRY }};
                   proxy_set_header        CF-Access-Client-Id     "${CF_ACCESS_CLIENT_ID}";
                   proxy_set_header        CF-Access-Client-Secret "${CF_ACCESS_CLIENT_SECRET}";
                   proxy_request_buffering off;


### PR DESCRIPTION
## Summary

- Replaces the `cloudflared access tcp` approach with an nginx reverse proxy to push Docker images to the private registry at `registry.huwdiprose.co.uk` behind Cloudflare Access

## Why cloudflared access tcp didn't work

`cloudflared access tcp` is a layer-4 tunnel: it forwards raw TCP bytes from the local port to the origin. Docker sends plain HTTP to `localhost:5000`, those bytes reach the HTTPS registry origin unchanged, which immediately resets the connection.

## How nginx fixes it

nginx listens on `localhost:5000` over HTTP (Docker treats localhost as insecure by default — no daemon config needed), proxies upstream to `https://registry.huwdiprose.co.uk` over HTTPS, and injects the `CF-Access-Client-Id` / `CF-Access-Client-Secret` service token headers on every request. Cloudflare Access sees a valid authenticated HTTPS request.

Three nginx settings are required for Docker image pushes:
- `client_max_body_size 0` — no cap on layer upload size
- `proxy_request_buffering off` — stream chunked layer uploads directly, no disk buffering
- `proxy_read_timeout 300s` — allow time for large image pushes

## Secrets required

- `CF_ACCESS_CLIENT_ID`
- `CF_ACCESS_CLIENT_SECRET`
- `REGISTRY_USERNAME`
- `REGISTRY_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)