### PR TITLE
ci: add workflow_dispatch trigger to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Adds `workflow_dispatch` so the Docker build-and-push can be triggered manually from the Actions tab, without needing a push to main.

Merging this also fires a fresh Docker run against the current nginx + Cloudflare `service_auth` setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)