### PR TITLE
refactor: advisor advises, settings drive sessions

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,6 +4,10 @@ class DashboardController < ApplicationController
 
     @no_data = user_learnings.none?
     @advice  = @no_data ? nil : LearningAdvisor.classify(user: Current.user)
+    @settings_nudge = @advice && (
+      @advice.recommended_size != Current.user.session_size ||
+      @advice.recommended_new_cap != Current.user.new_cards_per_session
+    )
 
     @learning_due = user_learnings.overdue_learning.count
     @review_due   = user_learnings.due_mastered.count

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -1,13 +1,10 @@
 class LearnController < ApplicationController
-  QUEUE_SIZE = 5
-
   before_action :require_learn_session, only: [ :show, :submit ]
   before_action :require_review_phase,  only: [ :review_show, :review_submit ]
   before_action :require_started_session, only: [ :summary ]
 
   def start
-    advice     = LearningAdvisor.classify(user: Current.user)
-    queue_size = advice.recommended_new_cap
+    queue_size = Current.user.new_cards_per_session
 
     queue = if params[:tag_id].present?
       tag = Tag.find_by(id: params[:tag_id])
@@ -117,7 +114,7 @@ class LearnController < ApplicationController
   # Priority 1: entries with no UserLearning yet ("Not Learned Yet") — create records on demand.
   # Priority 2: existing UserLearnings with state "new" for this tag.
   # Both groups are sorted by HSK level within their priority band.
-  def build_tagged_queue(tag, size = QUEUE_SIZE)
+  def build_tagged_queue(tag, size)
     learned_entry_ids = Current.user.user_learnings
                                .joins(:dictionary_entry)
                                .where(dictionary_entries: { id: tag.dictionary_entries.select(:id) })
@@ -143,7 +140,7 @@ class LearnController < ApplicationController
     (newly_created + existing_new.first(remaining))
   end
 
-  def build_global_queue(size = QUEUE_SIZE)
+  def build_global_queue(size)
     Current.user.user_learnings
            .new_learnings
            .includes(dictionary_entry: { tags: { parent: :parent } })

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -5,12 +5,11 @@ class ReviewController < ApplicationController
   def start
     Current.user.learning_sessions.in_progress.update_all(state: "abandoned")
 
-    tag    = Tag.find_by(id: params[:tag_id]) if params[:tag_id].present?
-    advice = LearningAdvisor.classify(user: Current.user)
-    queue  = LearningSession::Composer.call(
+    tag   = Tag.find_by(id: params[:tag_id]) if params[:tag_id].present?
+    queue = LearningSession::Composer.call(
       user:    Current.user,
-      size:    [ Current.user.session_size, advice.recommended_size ].min,
-      new_cap: [ Current.user.new_cards_per_session, advice.recommended_new_cap ].min,
+      size:    Current.user.session_size,
+      new_cap: Current.user.new_cards_per_session,
       tag:     tag
     )
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,7 @@
 class SettingsController < ApplicationController
   def show
-    @user = Current.user
+    @user   = Current.user
+    @advice = LearningAdvisor.classify(user: Current.user)
   end
 
   def update
@@ -8,6 +9,7 @@ class SettingsController < ApplicationController
     if @user.update(settings_params)
       redirect_to settings_path, notice: "Settings saved."
     else
+      @advice = LearningAdvisor.classify(user: Current.user)
       render :show, status: :unprocessable_content
     end
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -34,6 +34,12 @@
         Some cards keep slipping back — they may benefit from a mnemonic or a fresh look rather than more repetition.
       </p>
     <% end %>
+    <% if @settings_nudge %>
+      <p class="mt-2 text-xs text-indigo-600 dark:text-indigo-400">
+        Your current session caps differ from our recommendation —
+        <%= link_to "adjust your settings", settings_path, class: "underline hover:no-underline" %>.
+      </p>
+    <% end %>
   </div>
 
   <%# Top panels: Learn / Review / Progress %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -44,6 +44,21 @@
         </div>
       </div>
 
+      <% if @advice.recommended_size != @user.session_size || @advice.recommended_new_cap != @user.new_cards_per_session %>
+        <div class="mt-6 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4">
+          <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">Advisor suggestion</p>
+          <p class="text-sm text-amber-700 dark:text-amber-400 mb-3">
+            Based on your recent learning patterns, we suggest session size
+            <strong><%= @advice.recommended_size %></strong> and
+            <strong><%= @advice.recommended_new_cap %></strong> new cards per session.
+          </p>
+          <%= button_to "Align to recommendation", settings_path,
+                method: :patch,
+                params: { user: { session_size: @advice.recommended_size, new_cards_per_session: @advice.recommended_new_cap } },
+                class: "text-sm font-semibold text-amber-800 dark:text-amber-200 underline hover:no-underline bg-transparent border-0 p-0 cursor-pointer" %>
+        </div>
+      <% end %>
+
       <div class="mt-8">
         <%= f.submit "Save settings",
               class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-6 py-3

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -4,6 +4,21 @@
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8">
     <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-6">Session preferences</h2>
 
+    <% if @advice.recommended_size != @user.session_size || @advice.recommended_new_cap != @user.new_cards_per_session %>
+      <div class="mb-6 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4">
+        <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">Advisor suggestion</p>
+        <p class="text-sm text-amber-700 dark:text-amber-400 mb-3">
+          Based on your recent learning patterns, we suggest session size
+          <strong><%= @advice.recommended_size %></strong> and
+          <strong><%= @advice.recommended_new_cap %></strong> new cards per session.
+        </p>
+        <%= button_to "Align to recommendation", settings_path,
+              method: :patch,
+              params: { user: { session_size: @advice.recommended_size, new_cards_per_session: @advice.recommended_new_cap } },
+              class: "text-sm font-semibold text-amber-800 dark:text-amber-200 underline hover:no-underline bg-transparent border-0 p-0 cursor-pointer" %>
+      </div>
+    <% end %>
+
     <%= form_with model: @user, url: settings_path, method: :patch do |f| %>
       <% if @user.errors.any? %>
         <div class="mb-6 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-4">
@@ -43,21 +58,6 @@
                         focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
         </div>
       </div>
-
-      <% if @advice.recommended_size != @user.session_size || @advice.recommended_new_cap != @user.new_cards_per_session %>
-        <div class="mt-6 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4">
-          <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">Advisor suggestion</p>
-          <p class="text-sm text-amber-700 dark:text-amber-400 mb-3">
-            Based on your recent learning patterns, we suggest session size
-            <strong><%= @advice.recommended_size %></strong> and
-            <strong><%= @advice.recommended_new_cap %></strong> new cards per session.
-          </p>
-          <%= button_to "Align to recommendation", settings_path,
-                method: :patch,
-                params: { user: { session_size: @advice.recommended_size, new_cards_per_session: @advice.recommended_new_cap } },
-                class: "text-sm font-semibold text-amber-800 dark:text-amber-200 underline hover:no-underline bg-transparent border-0 p-0 cursor-pointer" %>
-        </div>
-      <% end %>
 
       <div class="mt-8">
         <%= f.submit "Save settings",

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -75,6 +75,28 @@ RSpec.describe "Dashboard", type: :request do
           get root_path
           expect(response.body).to include(CGI.escapeHTML(LearningAdvisor::NARRATIVES[:lapsed]))
         end
+
+        context "when settings differ from the advisor's recommendation" do
+          # user defaults (20/5) differ from lapsed recommendation (15/0)
+          it "shows a nudge toward settings" do
+            get root_path
+            expect(response.body).to include("differ from")
+          end
+
+          it "links to the settings page in the nudge" do
+            get root_path
+            expect(response.body).to include("href=\"#{settings_path}\"")
+          end
+        end
+
+        context "when settings match the advisor's recommendation" do
+          before { user.update!(session_size: 15, new_cards_per_session: 0) }
+
+          it "does not show a settings nudge" do
+            get root_path
+            expect(response.body).not_to include("differ from")
+          end
+        end
       end
 
       context "with an overdue learning card" do

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -77,6 +77,31 @@ RSpec.describe "Learn", type: :request do
         end
       end
 
+      context "when new_cards_per_session is lower than the available new cards" do
+        before do
+          user.update!(new_cards_per_session: 2)
+          create_list(:user_learning, 4, user: user, state: "new")
+        end
+
+        it "caps the queue at new_cards_per_session" do
+          get learn_path
+          expect(request.session[:learn_queue].size).to eq(2)
+        end
+      end
+
+      context "when new_cards_per_session exceeds what the advisor would cap" do
+        before do
+          user.update!(new_cards_per_session: 8)
+          create_list(:user_learning, 8, user: user, state: "new")
+          new_card.update!(state: "learning", next_due: 1.day.from_now, last_interval: 1)
+        end
+
+        it "queues up to new_cards_per_session rather than the advisor's lower recommendation" do
+          get learn_path
+          expect(request.session[:learn_queue].size).to eq(8)
+        end
+      end
+
       context "when no new cards are available" do
         before { new_card.update!(state: "learning", next_due: 1.day.from_now, last_interval: 1) }
 

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -4,23 +4,6 @@ RSpec.describe "Learn", type: :request do
   let(:user) { create(:user) }
   let!(:new_card) { create(:user_learning, user: user, state: "new") }
 
-  # Stub the advisor so these tests remain focused on the learn flow rather
-  # than advisor classification. Without this, new users are classified as
-  # :lapsed (recommended_new_cap: 0) and every queue is empty.
-  before do
-    allow(LearningAdvisor).to receive(:classify).and_return(
-      LearningAdvisor::Result.new(
-        profile:             :healthy,
-        narrative:           "",
-        recommended_size:    20,
-        recommended_new_cap: 5,
-        leech_warning:       false,
-        first_90_days:       false,
-        signals:             {}
-      )
-    )
-  end
-
   # -------------------------------------------------------------------------
   # GET /learn — start session
   # -------------------------------------------------------------------------

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -46,16 +46,30 @@ RSpec.describe "Review", type: :request do
         end
       end
 
-      context "when there are more overdue cards than the advisor's recommended size" do
+      context "when there are more overdue cards than the user's session_size" do
         before do
-          # advisor classifies as :lapsed (no review_logs) → recommended_size: 15
+          user.update!(session_size: 10)
+          create_list(:user_learning, 15, user: user, state: "learning",
+                      next_due: 1.day.ago, last_interval: 1)
+        end
+
+        it "caps the queue at session_size" do
+          get review_path
+          expect(LearningSession.last.card_count).to eq(10)
+        end
+      end
+
+      context "when session_size exceeds what the advisor would cap" do
+        before do
+          user_learning.update!(next_due: 7.days.from_now)
+          user.update!(session_size: 25)
           create_list(:user_learning, 20, user: user, state: "learning",
                       next_due: 1.day.ago, last_interval: 1)
         end
 
-        it "limits the queue to the advisor's recommended size" do
+        it "queues up to session_size rather than the advisor's lower recommendation" do
           get review_path
-          expect(LearningSession.last.card_count).to eq(15)
+          expect(LearningSession.last.card_count).to eq(20)
         end
       end
 

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -21,6 +21,32 @@ RSpec.describe "Settings", type: :request do
         get settings_path
         expect(response).to have_http_status(:ok)
       end
+
+      context "when settings differ from the advisor's recommendation" do
+        before do
+          create(:user_learning, user: user)
+          # user defaults: session_size 20, new_cards_per_session 5
+          # lapsed advisor (no review_logs) recommends: size 15, new_cap 0 — both differ
+        end
+
+        it "shows the advisor suggestion callout" do
+          get settings_path
+          expect(response.body).to include("Advisor suggestion")
+        end
+
+        it "includes an align-to-recommendation button" do
+          get settings_path
+          expect(response.body).to include("Align to recommendation")
+        end
+      end
+
+      context "when settings match the advisor's recommendation" do
+        # no user_learnings → empty profile recommends size 20, new_cap 5 — matches DB defaults
+        it "does not show the advisor suggestion callout" do
+          get settings_path
+          expect(response.body).not_to include("Advisor suggestion")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- **Session size is now exclusively controlled by user settings.** Both `LearnController` and `ReviewController` read `new_cards_per_session` / `session_size` directly from the `User` record. The `LearningAdvisor` is no longer consulted when building queues.
- **`LearningAdvisor` is now purely advisory.** The settings page shows an "Advisor suggestion" callout when the user's configured caps diverge from the advisor's recommendation, with a one-click "Align to recommendation" button. The dashboard shows a brief nudge in the narrative block with a link to settings.
- **Dead code removed.** The `QUEUE_SIZE` constant and default-argument fallbacks in `LearnController`, plus the advisor stub in the learn request spec, are all gone.

## Motivation

The settings page gave users explicit control over session size, but the advisor was still silently overriding or capping those values. This made the settings page misleading — users could set a value that was never actually used. The fix separates concerns: settings are the authority, the advisor is a hint.

## Test plan

- [ ] `bundle exec rspec spec/requests/learn_spec.rb` — queue size reflects `new_cards_per_session`
- [ ] `bundle exec rspec spec/requests/review_spec.rb` — session size reflects `session_size`; advisor cap no longer constrains when user sets a higher value
- [ ] `bundle exec rspec spec/requests/settings_spec.rb` — advisory callout appears/disappears correctly
- [ ] `bundle exec rspec spec/requests/dashboard_spec.rb` — nudge appears when settings diverge, absent when they match
- [ ] `bundle exec rspec` — full suite green (636 examples, 0 failures)
- [ ] Manual: visit `/settings` with a lapsed profile user — confirm advisor suggestion and align button appear
- [ ] Manual: click "Align to recommendation" — confirm settings update and callout disappears
- [ ] Manual: visit dashboard — confirm nudge appears in narrative block with link to settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)