### PR TITLE
fix: scope history spec assertions to table cells

### DIFF
--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe "Review", type: :request do
         create(:learning_session, user: user, state: "completed",
                started_at: 1.hour.ago, completed_at: 30.minutes.ago, card_count: 5)
         get review_history_path
-        expect(response.body).to include("5")
+        expect(response.body).to match(/<td[^>]*>\s*5\s*<\/td>/)
       end
 
       it "does not show in_progress sessions" do
@@ -369,8 +369,8 @@ RSpec.describe "Review", type: :request do
         create(:learning_session, user: user, state: "in_progress",
                started_at: 1.hour.ago, card_count: 263)
         get review_history_path
-        expect(response.body).to include("271")
-        expect(response.body).not_to include("263")
+        expect(response.body).to match(/<td[^>]*>\s*271\s*<\/td>/)
+        expect(response.body).not_to match(/<td[^>]*>\s*263\s*<\/td>/)
       end
     end
   end


### PR DESCRIPTION
## Summary

- The "does not show in_progress sessions" test in the review history spec was checking for the raw string `"263"` anywhere in the full HTML response body.
- In CI, asset pipeline fingerprints (e.g. `application-a8f3263d.css`) can coincidentally contain that substring, causing an intermittent false failure that never reproduces locally where assets are unfingerprinted.
- Fix: scope both the positive (`271`) and negative (`263`) assertions to `<td>` elements, matching only the card count column.

## Test plan

- [ ] `bundle exec rspec spec/requests/review_spec.rb` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)