### PR TITLE
chore: error tracking, structured logging, health check, Mission Control

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem "mission_control-jobs"
 gem "rubyzip", "~> 3.0"
 
 # Observability
-gem "sentry-ruby"
 gem "sentry-rails"
 gem "lograge"
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,13 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Use the database-backed adapters for Rails.cache and Active Job
 gem "solid_cache"
 gem "solid_queue"
+gem "mission_control-jobs"
 gem "rubyzip", "~> 3.0"
+
+# Observability
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "lograge"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,11 @@ GEM
       launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -214,6 +219,16 @@ GEM
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
+      irb (~> 1.13)
+      railties (>= 7.1)
+      stimulus-rails
+      turbo-rails
     msgpack (1.8.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -365,6 +380,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.4.4)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
@@ -421,6 +438,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (6.5.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.5.0)
+    sentry-ruby (6.5.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
     simplecov (0.22.0)
@@ -546,6 +570,8 @@ DEPENDENCIES
   importmap-rails
   kamal
   letter_opener
+  lograge
+  mission_control-jobs
   omniauth-rails_csrf_protection (~> 2.0)
   omniauth_openid_connect
   propshaft
@@ -559,6 +585,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubyzip (~> 3.0)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 7.0)
   simplecov
   solid_cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,7 +586,6 @@ DEPENDENCIES
   rubyzip (~> 3.0)
   selenium-webdriver
   sentry-rails
-  sentry-ruby
   shoulda-matchers (~> 7.0)
   simplecov
   solid_cache

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,5 +1,15 @@
 module Admin
   class BaseController < ApplicationController
     include AdminAuthentication
+
+    private
+
+    # Mission Control mounts as a Rails engine, so engine-scoped route helpers
+    # cannot resolve main-app named routes (sign_in_path picks up server_id
+    # defaults and raises UrlGenerationError). Use a literal path instead.
+    def request_authentication
+      session[:return_to_after_authenticating] = request.url if request.get? || request.head?
+      redirect_to "/sign_in"
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,14 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :set_sentry_user
+
+  private
+
+  def set_sentry_user
+    return unless Current.user&.telemetry_enabled?
+
+    Sentry.set_user(id: Current.user.id, email: Current.user.email_address)
+  end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -2,7 +2,7 @@ class HealthController < ActionController::Base
   def show
     ActiveRecord::Base.connection.execute("SELECT 1")
     render plain: "OK"
-  rescue StandardError
+  rescue ActiveRecord::ActiveRecordError
     render plain: "Service Unavailable", status: :service_unavailable
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,8 @@
+class HealthController < ActionController::Base
+  def show
+    ActiveRecord::Base.connection.execute("SELECT 1")
+    render plain: "OK"
+  rescue StandardError
+    render plain: "Service Unavailable", status: :service_unavailable
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -17,6 +17,6 @@ class SettingsController < ApplicationController
   private
 
   def settings_params
-    params.require(:user).permit(:session_size, :new_cards_per_session)
+    params.require(:user).permit(:session_size, :new_cards_per_session, :telemetry_enabled)
   end
 end

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -68,6 +68,32 @@
   </div>
 
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-6">Privacy</h2>
+
+    <%= form_with model: @user, url: settings_path, method: :patch do |f| %>
+      <div class="flex items-start gap-3">
+        <%= f.check_box :telemetry_enabled,
+              class: "mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600
+                      text-indigo-600 focus:ring-indigo-500 cursor-pointer" %>
+        <div>
+          <%= f.label :telemetry_enabled, "Share diagnostic data",
+                class: "block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer" %>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            Attach your user ID and email to error reports sent to our error tracker.
+            Helps diagnose issues affecting your account. Off by default.
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-6">
+        <%= f.submit "Save privacy settings",
+              class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-6 py-3
+                      transition-colors cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
     <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Your data</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
       Export all your learning progress as a JSON file, or restore from a previous export.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
+  # Single-line structured request logs (replaces Rails' multi-line default).
+  config.lograge.enabled = true
+
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
 

--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,0 +1,3 @@
+# Use the existing session-based admin authentication rather than HTTP Basic.
+MissionControl::Jobs.base_controller_class = "Admin::BaseController"
+MissionControl::Jobs.http_basic_auth_enabled = false

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+Sentry.init do |config|
+  config.dsn = ENV["GLITCHTIP_DSN"]
+  config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
+  config.traces_sample_rate = 0.2
+  config.send_default_pii = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  get "up" => "health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
@@ -44,5 +44,6 @@ Rails.application.routes.draw do
     resources :tasks, only: [ :create ] do
       member { post :retry }
     end
+    mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  # Returns 200 when the primary DB is reachable, 503 when the connection fails.
   get "up" => "health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)

--- a/db/migrate/20260505130100_add_telemetry_enabled_to_users.rb
+++ b/db/migrate/20260505130100_add_telemetry_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddTelemetryEnabledToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :telemetry_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_182048) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_130100) do
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -159,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_07_182048) do
     t.integer "new_cards_per_session", default: 5, null: false
     t.string "provider", default: "", null: false
     t.integer "session_size", default: 20, null: false
+    t.boolean "telemetry_enabled", default: false, null: false
     t.string "uid", default: "", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:?OIDC_CLIENT_ID must be set}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?OIDC_CLIENT_SECRET must be set}
       OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:?OIDC_REDIRECT_URI must be set}
+      GLITCHTIP_DSN: ${GLITCHTIP_DSN}
     volumes:
       - ${STORAGE_PATH:?STORAGE_PATH is required}:/rails/storage
     healthcheck:

--- a/spec/requests/admin/jobs_spec.rb
+++ b/spec/requests/admin/jobs_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Jobs", type: :request do
+  describe "GET /admin/jobs" do
+    context "when unauthenticated" do
+      it "redirects to sign in" do
+        get "/admin/jobs"
+        expect(response).to redirect_to("/sign_in")
+      end
+    end
+
+    context "when authenticated as a non-admin" do
+      let(:user) { create(:user) }
+      before { sign_in user }
+
+      it "redirects to root with an alert" do
+        get "/admin/jobs"
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when authenticated as an admin" do
+      let(:admin) { create(:user, admin: true) }
+      before { sign_in admin }
+
+      it "returns 200" do
+        get "/admin/jobs"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Health check", type: :request do
+  describe "GET /up" do
+    it "returns 200 when the database is reachable" do
+      get rails_health_check_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 503 when the database is unreachable" do
+      allow(ActiveRecord::Base).to receive(:connection).and_raise(ActiveRecord::StatementInvalid)
+      get rails_health_check_path
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+end

--- a/spec/requests/sentry_user_context_spec.rb
+++ b/spec/requests/sentry_user_context_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Sentry user context", type: :request do
+  let(:user) { create(:user) }
+
+  describe "authenticated requests" do
+    context "when telemetry_enabled is true" do
+      before { user.update!(telemetry_enabled: true) }
+
+      it "sets Sentry user context on each request" do
+        sign_in user
+        expect(Sentry).to receive(:set_user).with(id: user.id, email: user.email_address)
+        get settings_path
+      end
+    end
+
+    context "when telemetry_enabled is false" do
+      it "does not set Sentry user context" do
+        sign_in user
+        expect(Sentry).not_to receive(:set_user)
+        get settings_path
+      end
+    end
+  end
+end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe "Settings", type: :request do
           expect(user.reload.new_cards_per_session).to eq(8)
           expect(response).to redirect_to(settings_path)
         end
+
+        it "enables telemetry_enabled and redirects back to settings" do
+          patch settings_path, params: { user: { telemetry_enabled: true } }
+          expect(user.reload.telemetry_enabled).to be(true)
+          expect(response).to redirect_to(settings_path)
+        end
+
+        it "disables telemetry_enabled" do
+          user.update!(telemetry_enabled: true)
+          patch settings_path, params: { user: { telemetry_enabled: false } }
+          expect(user.reload.telemetry_enabled).to be(false)
+        end
       end
 
       context "with invalid params" do


### PR DESCRIPTION
Closes #128.

## What's in this PR

### `/up` health check — DB connectivity
Replaces the default boot-only check (`rails/health#show`) with a custom `HealthController` that executes `SELECT 1` against the primary DB. Returns `200` when the connection is healthy, `503` when it isn't.

### Mission Control at `/admin/jobs`
Adds `mission_control-jobs` and mounts the engine at `/admin/jobs` inside the existing admin namespace. Built-in HTTP Basic auth is disabled; access is enforced by `Admin::BaseController` (`require_authentication` + `require_admin`). `Admin::BaseController` also gets a local override of `request_authentication` to use a literal `/sign_in` path — necessary because Mission Control injects engine-scoped route defaults (`server_id`) that cause `UrlGenerationError` when standard named route helpers are called from within the engine.

### GlitchTip error tracking
Adds `sentry-ruby` + `sentry-rails`. The initialiser reads DSN from `GLITCHTIP_DSN` env var and is a no-op when the var is absent (development and test run without any configuration). Set `GLITCHTIP_DSN` in the production environment to enable.

### Lograge structured logging
Enables `lograge` in production — replaces Rails' multi-line request log with a single structured line per request.

## Test plan

- [x] `bundle exec rspec spec/requests/health_spec.rb` — 200 when DB up, 503 when unreachable
- [x] `bundle exec rspec spec/requests/admin/jobs_spec.rb` — 200 for admin, redirect for non-admin, redirect to `/sign_in` for unauthenticated
- [x] `bundle exec rspec` — 641 examples, 0 failures
- [x] `bin/rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deliberate decisions

**Literal `/sign_in` path in `Admin::BaseController#request_authentication`**
`main_app` is only available when a controller is mounted inside a Rails engine (Mission Control's context). `Admin::BaseController` is also the base for regular admin routes (`/admin`, `/admin/tasks`) which are served by the main app's router directly — calling `main_app` there raises `NoMethodError`. The literal path is the only approach that works in both contexts safely. The comment in the code captures this constraint.