### PR TITLE
feat: stabilize flashcard reveal layout

### DIFF
--- a/app/javascript/controllers/adaptive_card_text_controller.js
+++ b/app/javascript/controllers/adaptive_card_text_controller.js
@@ -1,5 +1,26 @@
 import { Controller } from "@hotwired/stimulus"
 
+const HANZI_LENGTH_THRESHOLDS = {
+  largeMax: 3,
+  medium: 4
+}
+
+const HANZI_SIZE_CLASSES = {
+  large: "text-9xl",
+  medium: "text-8xl",
+  small: "text-7xl"
+}
+
+const COMPACT_MEANING_THRESHOLDS = {
+  hanziCountMin: 5,
+  meaningLengthMax: 36
+}
+
+const MEANING_SIZE_CLASSES = {
+  normal: "text-xl",
+  compact: "text-lg"
+}
+
 export default class extends Controller {
   static targets = ["hanzi", "meaning"]
 
@@ -12,9 +33,19 @@ export default class extends Controller {
     if (!this.hasHanziTarget) return
 
     const count = this.characterCount(this.hanziTarget.textContent)
-    const sizeClass = count <= 3 ? "text-9xl" : (count === 4 ? "text-8xl" : "text-7xl")
 
-    this.hanziTarget.classList.remove("text-9xl", "text-8xl", "text-7xl")
+    let sizeClass = HANZI_SIZE_CLASSES.small
+    if (count <= HANZI_LENGTH_THRESHOLDS.largeMax) {
+      sizeClass = HANZI_SIZE_CLASSES.large
+    } else if (count === HANZI_LENGTH_THRESHOLDS.medium) {
+      sizeClass = HANZI_SIZE_CLASSES.medium
+    }
+
+    this.hanziTarget.classList.remove(
+      HANZI_SIZE_CLASSES.large,
+      HANZI_SIZE_CLASSES.medium,
+      HANZI_SIZE_CLASSES.small
+    )
     this.hanziTarget.classList.add(sizeClass)
   }
 
@@ -23,10 +54,15 @@ export default class extends Controller {
 
     const hanziCount = this.hasHanziTarget ? this.characterCount(this.hanziTarget.textContent) : 0
     const meaningLength = this.characterCount(this.meaningTarget.textContent)
-    const useCompactMeaning = hanziCount >= 5 || meaningLength > 36
+    const useCompactMeaning = (
+      hanziCount >= COMPACT_MEANING_THRESHOLDS.hanziCountMin ||
+      meaningLength > COMPACT_MEANING_THRESHOLDS.meaningLengthMax
+    )
 
-    this.meaningTarget.classList.remove("text-xl", "text-lg")
-    this.meaningTarget.classList.add(useCompactMeaning ? "text-lg" : "text-xl")
+    this.meaningTarget.classList.remove(MEANING_SIZE_CLASSES.normal, MEANING_SIZE_CLASSES.compact)
+    this.meaningTarget.classList.add(
+      useCompactMeaning ? MEANING_SIZE_CLASSES.compact : MEANING_SIZE_CLASSES.normal
+    )
   }
 
   characterCount(text) {

--- a/app/javascript/controllers/adaptive_card_text_controller.js
+++ b/app/javascript/controllers/adaptive_card_text_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["hanzi", "meaning"]
+
+  connect() {
+    this.applyHanziScale()
+    this.applyMeaningScale()
+  }
+
+  applyHanziScale() {
+    if (!this.hasHanziTarget) return
+
+    const count = this.characterCount(this.hanziTarget.textContent)
+    const sizeClass = count <= 3 ? "text-9xl" : (count === 4 ? "text-8xl" : "text-7xl")
+
+    this.hanziTarget.classList.remove("text-9xl", "text-8xl", "text-7xl")
+    this.hanziTarget.classList.add(sizeClass)
+  }
+
+  applyMeaningScale() {
+    if (!this.hasMeaningTarget) return
+
+    const hanziCount = this.hasHanziTarget ? this.characterCount(this.hanziTarget.textContent) : 0
+    const meaningLength = this.characterCount(this.meaningTarget.textContent)
+    const useCompactMeaning = hanziCount >= 5 || meaningLength > 36
+
+    this.meaningTarget.classList.remove("text-xl", "text-lg")
+    this.meaningTarget.classList.add(useCompactMeaning ? "text-lg" : "text-xl")
+  }
+
+  characterCount(text) {
+    return Array.from((text || "").trim()).length
+  }
+}

--- a/app/javascript/controllers/collapsible_controller.js
+++ b/app/javascript/controllers/collapsible_controller.js
@@ -1,8 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["content", "chevron"]
+  static targets = ["content", "chevron", "button"]
   static values  = { open: { type: Boolean, default: true } }
+
+  connect() {
+    this.ensureContentId()
+    this.openValueChanged()
+  }
 
   toggle() {
     this.openValue = !this.openValue
@@ -11,5 +16,17 @@ export default class extends Controller {
   openValueChanged() {
     this.contentTarget.classList.toggle("hidden", !this.openValue)
     this.chevronTarget.classList.toggle("rotate-90", this.openValue)
+
+    if (this.hasButtonTarget) {
+      this.buttonTarget.setAttribute("aria-expanded", this.openValue.toString())
+      this.buttonTarget.setAttribute("aria-controls", this.contentTarget.id)
+    }
+  }
+
+  ensureContentId() {
+    if (this.contentTarget.id) return
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`
+    this.contentTarget.id = `collapsible-content-${suffix}`
   }
 }

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -12,7 +12,7 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
   <p class="text-sm text-gray-400 mb-2"><%= @position %> / <%= @total %></p>
   <p class="text-xs text-gray-300 mb-6">Quick review of today's new characters</p>
@@ -33,7 +33,7 @@
 
           <% if supplemental_meanings.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
-              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+              <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -8,26 +8,42 @@
   entry    = @user_learning.dictionary_entry
   pinyin   = entry.meanings.first&.pinyin
   meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  shown    = meanings.first(3)
-  overflow = meanings.size - shown.size
+  primary_meaning       = meanings.first
+  supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text">
 
   <p class="text-sm text-gray-400 mb-2"><%= @position %> / <%= @total %></p>
   <p class="text-xs text-gray-300 mb-6">Quick review of today's new characters</p>
 
   <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
 
-    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-10 pt-12 pb-10 text-center">
-      <span class="<%= hanzi_size_class(entry.text) %> font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
+    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
+      <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 
-      <div data-card-flip-target="back" class="hidden">
-        <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6">
+      <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6 flex-1 min-h-0">
+        <div data-card-flip-target="front" class="h-full flex items-center justify-center">
+          <p class="text-gray-300">Reveal to see pinyin and meaning</p>
+        </div>
+
+        <div data-card-flip-target="back" class="hidden h-full overflow-y-auto pr-1">
           <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
-          <p class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= shown.map(&:text).join(", ") %></p>
-          <% if overflow > 0 %>
-            <p class="mt-2 text-sm text-gray-400">and <%= overflow %> more</p>
+          <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
+
+          <% if supplemental_meanings.any? %>
+            <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
+              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+                <span>Show more meanings</span>
+                <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
+              </button>
+
+              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meanings.each do |meaning| %>
+                  <li><%= meaning.text %></li>
+                <% end %>
+              </ul>
+            </div>
           <% end %>
         </div>
       </div>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -12,7 +12,7 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="learn-card adaptive-card-text">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="learn-card adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
   <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
 
@@ -32,7 +32,7 @@
 
           <% if supplemental_meanings.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
-              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+              <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -8,25 +8,43 @@
   entry    = @user_learning.dictionary_entry
   pinyin   = entry.meanings.first&.pinyin
   meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  shown    = meanings.first(3)
+  primary_meaning       = meanings.first
+  supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="learn-card">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="learn-card adaptive-card-text">
 
   <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
 
   <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
 
     <%# Card %>
-    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-10 pt-12 pb-10 text-center">
-      <span class="<%= hanzi_size_class(entry.text) %> font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
+    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
+      <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 
-      <div data-learn-card-target="pinyin" class="hidden mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6">
-        <p class="text-3xl text-gray-400"><%= pinyin %></p>
-      </div>
+      <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6 flex-1 min-h-0 overflow-y-auto pr-1">
+        <div data-learn-card-target="pinyin" class="hidden">
+          <p class="text-3xl text-gray-400"><%= pinyin %></p>
+        </div>
 
-      <div data-learn-card-target="meaning" class="hidden mt-4">
-        <p class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= shown.map(&:text).join(", ") %></p>
+        <div data-learn-card-target="meaning" class="hidden mt-4">
+          <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
+
+          <% if supplemental_meanings.any? %>
+            <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
+              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+                <span>Show more meanings</span>
+                <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
+              </button>
+
+              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meanings.each do |meaning| %>
+                  <li><%= meaning.text %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -8,29 +8,44 @@
   entry    = @user_learning.dictionary_entry
   pinyin   = entry.meanings.first&.pinyin
   meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  shown    = meanings.first(3)
-  overflow = meanings.size - shown.size
+  primary_meaning      = meanings.first
+  supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text">
 
   <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
 
   <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
 
-    <%# ---- CARD — character pinned to top, expands downward on reveal ---- %>
-    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-10 pt-12 pb-10 text-center">
+    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
 
-      <span class="<%= hanzi_size_class(entry.text) %> font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
+      <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 
-      <%# ---- BACK: answer content (hidden until revealed) ---- %>
-      <div data-card-flip-target="back" class="hidden">
-        <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6">
+      <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6 flex-1 min-h-0">
+        <div data-card-flip-target="front" class="h-full flex items-center justify-center">
+          <p class="text-gray-300">Reveal to see pinyin and meaning</p>
+        </div>
+
+        <div data-card-flip-target="back" class="hidden h-full overflow-y-auto pr-1">
           <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
-          <p class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= shown.map(&:text).join(", ") %></p>
-          <% if overflow > 0 %>
-            <p class="mt-2 text-sm text-gray-400">and <%= overflow %> more</p>
+          <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
+
+          <% if supplemental_meanings.any? %>
+            <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4">
+              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+                <span>Show more meanings</span>
+                <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
+              </button>
+
+              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-left text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meanings.each do |meaning| %>
+                  <li><%= meaning.text %></li>
+                <% end %>
+              </ul>
+            </div>
           <% end %>
+
           <% if entry.tags.any? %>
             <div class="mt-4 flex flex-wrap gap-1 justify-center">
               <% entry.tags.each do |tag| %>

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -12,7 +12,7 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text">
+<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
   <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
 
@@ -33,7 +33,7 @@
 
           <% if supplemental_meanings.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4">
-              <button type="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+              <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -192,8 +192,10 @@ RSpec.describe "Learn", type: :request do
 
       it "renders a fixed-height adaptive card container" do
         get learn_card_path
-        expect(response.body).to include("h-[28rem]")
-        expect(response.body).to include('data-controller="learn-card adaptive-card-text"')
+        expect(response.body).to include('data-card-layout="fixed"')
+        expect(response.body).to include('data-card-text-scaling="adaptive"')
+        expect(response.body).to include("learn-card")
+        expect(response.body).to include("adaptive-card-text")
       end
 
       it "shows a supplemental meanings toggle when available" do
@@ -281,7 +283,9 @@ RSpec.describe "Learn", type: :request do
 
       it "renders adaptive text sizing on review cards" do
         get learn_review_path
-        expect(response.body).to include('data-controller="card-flip adaptive-card-text"')
+        expect(response.body).to include('data-card-text-scaling="adaptive"')
+        expect(response.body).to include("card-flip")
+        expect(response.body).to include("adaptive-card-text")
       end
 
       it "renders ease buttons with data-ease attributes for keyboard shortcuts" do

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -189,6 +189,20 @@ RSpec.describe "Learn", type: :request do
         get learn_card_path
         expect(response.body).to include(new_card.dictionary_entry.text)
       end
+
+      it "renders a fixed-height adaptive card container" do
+        get learn_card_path
+        expect(response.body).to include("h-[28rem]")
+        expect(response.body).to include('data-controller="learn-card adaptive-card-text"')
+      end
+
+      it "shows a supplemental meanings toggle when available" do
+        create(:meaning, dictionary_entry: new_card.dictionary_entry, text: "secondary meaning")
+
+        get learn_card_path
+
+        expect(response.body).to include("Show more meanings")
+      end
     end
 
     context "when authenticated without an active learn session" do
@@ -263,6 +277,11 @@ RSpec.describe "Learn", type: :request do
       it "includes the character in the response" do
         get learn_review_path
         expect(response.body).to include(new_card.dictionary_entry.text)
+      end
+
+      it "renders adaptive text sizing on review cards" do
+        get learn_review_path
+        expect(response.body).to include('data-controller="card-flip adaptive-card-text"')
       end
 
       it "renders ease buttons with data-ease attributes for keyboard shortcuts" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -198,8 +198,10 @@ RSpec.describe "Review", type: :request do
 
       it "renders a fixed-height adaptive card" do
         get review_card_path
-        expect(response.body).to include("h-[28rem]")
-        expect(response.body).to include('data-controller="card-flip adaptive-card-text"')
+        expect(response.body).to include('data-card-layout="fixed"')
+        expect(response.body).to include('data-card-text-scaling="adaptive"')
+        expect(response.body).to include("card-flip")
+        expect(response.body).to include("adaptive-card-text")
       end
 
       it "shows a supplemental meanings toggle when multiple meanings exist" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -195,6 +195,20 @@ RSpec.describe "Review", type: :request do
         get review_card_path
         expect(response.body).to include("1 / 1")
       end
+
+      it "renders a fixed-height adaptive card" do
+        get review_card_path
+        expect(response.body).to include("h-[28rem]")
+        expect(response.body).to include('data-controller="card-flip adaptive-card-text"')
+      end
+
+      it "shows a supplemental meanings toggle when multiple meanings exist" do
+        create(:meaning, dictionary_entry: user_learning.dictionary_entry, text: "secondary meaning")
+
+        get review_card_path
+
+        expect(response.body).to include("Show more meanings")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- fix layout shift in learn/review cards by rendering reveal content inside a fixed-height card shell
- add an adaptive Stimulus controller that scales hanzi and primary meaning text for longer entries
- collapse supplemental meanings behind a `Show more meanings` disclosure within the card content area
- add request specs asserting the adaptive card container and supplemental-meaning toggle in learn/review flows

## Testing
- `bundle exec rspec spec/requests/learn_spec.rb spec/requests/review_spec.rb` *(not run in this environment: missing project gems/Bundler)*
- `bin/rubocop app/views/learn/show.html.erb app/views/review/show.html.erb app/views/learn/review_show.html.erb app/javascript/controllers/adaptive_card_text_controller.js spec/requests/learn_spec.rb spec/requests/review_spec.rb` *(not run in this environment: missing project gems/Bundler)*