### PR TITLE
feat: import SUBTLEX frequency ranks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle/
 
 # Ignore environment files, but track the example template.
 /.env*

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ bin/rails tag_import:audit_hsk_3_gaps
 
 See `docs/DATA_GAPS.md` for current known counts and context.
 
+### Import SUBTLEX-CH frequency ranks
+
+Download and import frequency data used to populate `DictionaryEntry#frequency_rank`:
+
+```bash
+bin/rails frequency:download
+bin/rails frequency:import
+```
+
 ### Connect your Anki collection
 
 Export a backup from Anki (`File → Export → Anki Collection Package`) and unzip it:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ A small number of HSK vocabulary items are not present in CC-CEDICT (multi-chara
 bin/rails dictionary_import:custom_entries
 ```
 
+### Audit unresolved HSK 3.0 gaps
+
+To report words still absent from both the dictionary and TSV fallback stubs:
+
+```bash
+bin/rails tag_import:audit_hsk_3_gaps
+```
+
+See `docs/DATA_GAPS.md` for current known counts and context.
+
 ### Connect your Anki collection
 
 Export a backup from Anki (`File → Export → Anki Collection Package`) and unzip it:

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary hsk_tags].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary hsk_tags frequency_data].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|
@@ -35,7 +35,8 @@ module Admin
       {
         dictionary_entries: DictionaryEntry.count,
         hsk_tags:           Tag.where(category: "HSK").count,
-        custom_entries:     Meaning.joins(:source).where(sources: { name: "learn_hanzi" }).select(:dictionary_entry_id).distinct.count
+        custom_entries:     Meaning.joins(:source).where(sources: { name: "learn_hanzi" }).select(:dictionary_entry_id).distinct.count,
+        frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count
       }
     end
   end

--- a/app/jobs/admin/provisioning_job.rb
+++ b/app/jobs/admin/provisioning_job.rb
@@ -5,7 +5,8 @@ module Admin
     SERVICE_MAP = {
       "cc_cedict"          => Admin::CcCedictProvisioningService,
       "hsk_tags"           => Admin::HskTagsProvisioningService,
-      "custom_dictionary"  => Admin::CustomDictionaryProvisioningService
+      "custom_dictionary"  => Admin::CustomDictionaryProvisioningService,
+      "frequency_data"     => Admin::FrequencyProvisioningService
     }.freeze
 
     def perform(task_id)

--- a/app/models/admin_task.rb
+++ b/app/models/admin_task.rb
@@ -1,5 +1,5 @@
 class AdminTask < ApplicationRecord
-  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary].freeze
+  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data].freeze
   VALID_STATES     = %w[pending running complete failed].freeze
 
   validates :task_type, presence: true, inclusion: { in: VALID_TASK_TYPES }

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -5,6 +5,7 @@ class DictionaryEntry < ApplicationRecord
   has_many :user_learnings, dependent: :destroy
 
   validates :text, presence: true
+  validates :frequency_rank, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
   validate :must_have_at_least_one_meaning
 
   accepts_nested_attributes_for :meanings, allow_destroy: true

--- a/app/services/admin/frequency_provisioning_service.rb
+++ b/app/services/admin/frequency_provisioning_service.rb
@@ -11,18 +11,18 @@ module Admin
       download_subtlex
 
       word_to_freq = parse_subtlex_frequencies(SUBTLEX_PATH)
+      raise "No valid SUBTLEX rows found. Aborting to avoid clearing existing ranks." if word_to_freq.empty?
+
       ranked_words = word_to_freq.sort_by { |word, freq| [ -freq, word ] }
       texts = ranked_words.map(&:first)
       entry_id_by_text = DictionaryEntry.where(text: texts).pluck(:text, :id).to_h
 
       rows = []
-      rank = 0
-      ranked_words.each do |word, _freq|
+      ranked_words.each_with_index do |(word, _freq), idx|
         entry_id = entry_id_by_text[word]
         next unless entry_id
 
-        rank += 1
-        rows << { id: entry_id, frequency_rank: rank }
+        rows << { id: entry_id, frequency_rank: idx + 1 }
       end
 
       DictionaryEntry.transaction do
@@ -51,23 +51,35 @@ module Admin
     end
 
     def parse_subtlex_frequencies(file_path)
-      lines = File.readlines(file_path, chomp: true, encoding: "bom|utf-8")
-      header = lines.shift.to_s.split("\t")
-      word_index = header.index("Word")
-      freq_index = header.index("W.million")
+      word_index = nil
+      freq_index = nil
+      word_to_freq = {}
 
-      return {} if word_index.nil? || freq_index.nil?
-
-      lines.each_with_object({}) do |line, acc|
+      File.foreach(file_path, chomp: true, encoding: "bom|utf-8").with_index do |line, idx|
         fields = line.split("\t")
+
+        if idx.zero?
+          word_index = fields.index("Word")
+          freq_index = fields.index("W.million")
+          next
+        end
+
+        next if word_index.nil? || freq_index.nil?
+
         word = fields[word_index]&.strip
         next if word.blank?
 
         freq = fields[freq_index].to_s.strip.tr(",", "").to_f
         next if freq <= 0
 
-        acc[word] = [ acc[word].to_f, freq ].max
+        word_to_freq[word] = [ word_to_freq[word].to_f, freq ].max
       end
+
+      if word_index.nil? || freq_index.nil?
+        raise "Invalid SUBTLEX header in #{file_path}: expected Word and W.million columns"
+      end
+
+      word_to_freq
     end
   end
 end

--- a/app/services/admin/frequency_provisioning_service.rb
+++ b/app/services/admin/frequency_provisioning_service.rb
@@ -1,5 +1,7 @@
 module Admin
   class FrequencyProvisioningService
+    include ImportFilesHelper
+
     SUBTLEX_URL = "https://raw.githubusercontent.com/krmanik/HSK-3.0/main/Scripts%20and%20data/SUBTLEX_CH_131210_CE.utf8"
     SUBTLEX_PATH = Rails.root.join("tmp", "frequency", "SUBTLEX_CH_131210_CE.utf8")
 
@@ -42,12 +44,8 @@ module Admin
     private
 
     def download_subtlex
-      path = SUBTLEX_PATH.to_s
-      FileUtils.mkdir_p(File.dirname(path))
-
-      File.open(path, "wb") do |file|
-        file.write(URI(SUBTLEX_URL).open.read)
-      end
+      download_file_to_tmp(SUBTLEX_URL, SUBTLEX_PATH)
+      confirm_file_presence(SUBTLEX_PATH.basename.to_s, SUBTLEX_PATH.dirname)
     end
 
     def parse_subtlex_frequencies(file_path)

--- a/app/services/admin/frequency_provisioning_service.rb
+++ b/app/services/admin/frequency_provisioning_service.rb
@@ -1,0 +1,73 @@
+module Admin
+  class FrequencyProvisioningService
+    SUBTLEX_URL = "https://raw.githubusercontent.com/krmanik/HSK-3.0/main/Scripts%20and%20data/SUBTLEX_CH_131210_CE.utf8"
+    SUBTLEX_PATH = Rails.root.join("tmp", "frequency", "SUBTLEX_CH_131210_CE.utf8")
+
+    def self.call
+      new.call
+    end
+
+    def call
+      download_subtlex
+
+      word_to_freq = parse_subtlex_frequencies(SUBTLEX_PATH)
+      ranked_words = word_to_freq.sort_by { |word, freq| [ -freq, word ] }
+      texts = ranked_words.map(&:first)
+      entry_id_by_text = DictionaryEntry.where(text: texts).pluck(:text, :id).to_h
+
+      rows = []
+      rank = 0
+      ranked_words.each do |word, _freq|
+        entry_id = entry_id_by_text[word]
+        next unless entry_id
+
+        rank += 1
+        rows << { id: entry_id, frequency_rank: rank }
+      end
+
+      DictionaryEntry.transaction do
+        DictionaryEntry.update_all(frequency_rank: nil)
+        rows.each_slice(1000) do |slice|
+          DictionaryEntry.upsert_all(slice, unique_by: :id, update_only: [ :frequency_rank ])
+        end
+      end
+
+      {
+        words_parsed: word_to_freq.size,
+        entries_updated: rows.size,
+        missing_from_dictionary: word_to_freq.size - rows.size
+      }
+    end
+
+    private
+
+    def download_subtlex
+      path = SUBTLEX_PATH.to_s
+      FileUtils.mkdir_p(File.dirname(path))
+
+      File.open(path, "wb") do |file|
+        file.write(URI(SUBTLEX_URL).open.read)
+      end
+    end
+
+    def parse_subtlex_frequencies(file_path)
+      lines = File.readlines(file_path, chomp: true, encoding: "bom|utf-8")
+      header = lines.shift.to_s.split("\t")
+      word_index = header.index("Word")
+      freq_index = header.index("W.million")
+
+      return {} if word_index.nil? || freq_index.nil?
+
+      lines.each_with_object({}) do |line, acc|
+        fields = line.split("\t")
+        word = fields[word_index]&.strip
+        next if word.blank?
+
+        freq = fields[freq_index].to_s.strip.tr(",", "").to_f
+        next if freq <= 0
+
+        acc[word] = [ acc[word].to_f, freq ].max
+      end
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <%# Task cards %>
-  <div class="grid gap-4 sm:grid-cols-3">
+  <div class="grid gap-4 sm:grid-cols-4">
 
     <%= render "task_card",
           label:     "CC-CEDICT dictionary",
@@ -38,6 +38,14 @@
           task:      @tasks_by_type["hsk_tags"],
           db_count:  @db_stats[:hsk_tags],
           unit:      "tags",
+          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+
+    <%= render "task_card",
+          label:     "Frequency data",
+          task_type: "frequency_data",
+          task:      @tasks_by_type["frequency_data"],
+          db_count:  @db_stats[:frequency_entries],
+          unit:      "ranked entries",
           requires_dictionary: @db_stats[:dictionary_entries].zero? %>
 
   </div>

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -51,6 +51,12 @@ FileUtils.chdir APP_ROOT do
   step "Importing HSK 3.0 tags"
   system! "bin/rails tag_import:hsk_3"
 
+  step "Downloading SUBTLEX-CH frequency data"
+  system! "bin/rails frequency:download"
+
+  step "Importing SUBTLEX-CH frequency ranks"
+  system! "bin/rails frequency:import"
+
   puts "\n== Bootstrap complete =="
   puts ""
   puts "To import your Anki learning history:"

--- a/db/migrate/20260507120000_add_frequency_rank_to_dictionary_entries.rb
+++ b/db/migrate/20260507120000_add_frequency_rank_to_dictionary_entries.rb
@@ -1,0 +1,6 @@
+class AddFrequencyRankToDictionaryEntries < ActiveRecord::Migration[8.1]
+  def change
+    add_column :dictionary_entries, :frequency_rank, :integer
+    add_index :dictionary_entries, :frequency_rank
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_130100) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -40,8 +40,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_130100) do
 
   create_table "dictionary_entries", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "frequency_rank"
     t.string "text"
     t.datetime "updated_at", null: false
+    t.index ["frequency_rank"], name: "index_dictionary_entries_on_frequency_rank"
     t.index ["text"], name: "index_dictionary_entries_on_text", unique: true
   end
 

--- a/docs/DATA_GAPS.md
+++ b/docs/DATA_GAPS.md
@@ -1,0 +1,49 @@
+# Data Gaps
+
+## HSK 3.0 unresolved dictionary gaps
+
+After importing:
+
+- CC-CEDICT
+- HSK 3.0 word lists from `krmanik/HSK-3.0`
+- TSV-based HSK stub entries
+- curated `db/custom_dictionary_entries.yml`
+
+there are still 49 HSK words that cannot be tagged because they are absent
+from both CC-CEDICT and the krmanik TSV fallback data.
+
+### Counts
+
+| Level | Expected | Covered | Missing |
+|---|---:|---:|---:|
+| HSK 1 | 500 | 497 | 3 |
+| HSK 2 | 771 | 764 | 7 |
+| HSK 3 | 973 | 966 | 7 |
+| HSK 4 | 1,000 | 995 | 5 |
+| HSK 5 | 1,071 | 1,067 | 4 |
+| HSK 6 | 1,140 | 1,134 | 6 |
+| HSK 7-9 | 5,636 | 5,619 | 17 |
+| **Total** | **10,091** | **10,042** | **49** |
+
+### Why this remains
+
+These words exist in the TXT lesson lists, but have no matching row in the TSV
+files used for fallback stub creation. Without at least pinyin and a gloss,
+the importer has no source data to safely create entries.
+
+### How to audit current gaps
+
+Run:
+
+```bash
+bin/rails tag_import:audit_hsk_3_gaps
+```
+
+This reports per-level coverage and lists words still missing from both the
+dictionary and TSV fallback files.
+
+### Resolution options
+
+1. Accept this documented gap.
+2. Add a third dictionary source that covers the missing words.
+3. Manually curate entries in `db/custom_dictionary_entries.yml`.

--- a/lib/tasks/frequency.rake
+++ b/lib/tasks/frequency.rake
@@ -23,18 +23,20 @@ namespace :frequency do
 
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     word_to_freq = parse_subtlex_frequencies(file_path)
+    if word_to_freq.empty?
+      raise "No valid SUBTLEX rows found in #{file_path}. Aborting to avoid clearing existing ranks."
+    end
+
     ranked_words = word_to_freq.sort_by { |word, freq| [ -freq, word ] }
     texts = ranked_words.map(&:first)
 
     entry_id_by_text = DictionaryEntry.where(text: texts).pluck(:text, :id).to_h
 
     rows = []
-    rank = 0
-    ranked_words.each do |word, _freq|
+    ranked_words.each_with_index do |(word, _freq), idx|
       entry_id = entry_id_by_text[word]
       next unless entry_id
-      rank += 1
-      rows << { id: entry_id, frequency_rank: rank }
+      rows << { id: entry_id, frequency_rank: idx + 1 }
     end
 
     DictionaryEntry.transaction do
@@ -48,7 +50,9 @@ namespace :frequency do
     puts "Imported frequency ranks from #{file_path} in #{elapsed.round(2)}s"
     puts "#{word_to_freq.size} unique words parsed"
     puts "#{rows.size} dictionary entries updated"
-    puts "#{word_to_freq.size - rows.size} words missing from dictionary"
+    missing_count = word_to_freq.size - rows.size
+    label = missing_count == 1 ? "word" : "words"
+    puts "#{missing_count} #{label} missing from dictionary"
   end
 end
 
@@ -57,21 +61,33 @@ def subtlex_default_path
 end
 
 def parse_subtlex_frequencies(file_path)
-  lines = File.readlines(file_path, chomp: true, encoding: "bom|utf-8")
-  header = lines.shift.to_s.split("\t")
-  word_index = header.index("Word")
-  freq_index = header.index("W.million")
+  word_index = nil
+  freq_index = nil
+  word_to_freq = {}
 
-  return {} if word_index.nil? || freq_index.nil?
-
-  lines.each_with_object({}) do |line, acc|
+  File.foreach(file_path, chomp: true, encoding: "bom|utf-8").with_index do |line, idx|
     fields = line.split("\t")
+
+    if idx.zero?
+      word_index = fields.index("Word")
+      freq_index = fields.index("W.million")
+      next
+    end
+
+    next if word_index.nil? || freq_index.nil?
+
     word = fields[word_index]&.strip
     next if word.blank?
 
     freq = fields[freq_index].to_s.strip.tr(",", "").to_f
     next if freq <= 0
 
-    acc[word] = [ acc[word].to_f, freq ].max
+    word_to_freq[word] = [ word_to_freq[word].to_f, freq ].max
   end
+
+  if word_index.nil? || freq_index.nil?
+    raise "Invalid SUBTLEX header in #{file_path}: expected Word and W.million columns"
+  end
+
+  word_to_freq
 end

--- a/lib/tasks/frequency.rake
+++ b/lib/tasks/frequency.rake
@@ -1,0 +1,77 @@
+require_relative "../../app/helpers/import_files_helper"
+
+include ImportFilesHelper
+
+namespace :frequency do
+  SUBTLEX_URL = "https://raw.githubusercontent.com/krmanik/HSK-3.0/main/Scripts%20and%20data/SUBTLEX_CH_131210_CE.utf8"
+
+  desc "Download SUBTLEX-CH frequency data"
+  task download: :environment do
+    file_dir = Rails.root.join("tmp", "frequency")
+    file_path = file_dir.join("SUBTLEX_CH_131210_CE.utf8")
+    ImportFilesHelper.download_file_to_tmp(SUBTLEX_URL, file_path)
+    ImportFilesHelper.confirm_file_presence(File.basename(file_path), file_dir)
+  end
+
+  desc "Import SUBTLEX-CH frequency ranks into DictionaryEntry"
+  task :import, [ :file_path ] => :environment do |_task, args|
+    file_path = args[:file_path] || subtlex_default_path
+
+    unless File.exist?(file_path)
+      raise "File not found at #{file_path}. Run `bin/rails frequency:download` first."
+    end
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    word_to_freq = parse_subtlex_frequencies(file_path)
+    ranked_words = word_to_freq.sort_by { |word, freq| [ -freq, word ] }
+    texts = ranked_words.map(&:first)
+
+    entry_id_by_text = DictionaryEntry.where(text: texts).pluck(:text, :id).to_h
+
+    rows = []
+    rank = 0
+    ranked_words.each do |word, _freq|
+      entry_id = entry_id_by_text[word]
+      next unless entry_id
+      rank += 1
+      rows << { id: entry_id, frequency_rank: rank }
+    end
+
+    DictionaryEntry.transaction do
+      DictionaryEntry.update_all(frequency_rank: nil)
+      rows.each_slice(1000) do |slice|
+        DictionaryEntry.upsert_all(slice, unique_by: :id, update_only: [ :frequency_rank ])
+      end
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+    puts "Imported frequency ranks from #{file_path} in #{elapsed.round(2)}s"
+    puts "#{word_to_freq.size} unique words parsed"
+    puts "#{rows.size} dictionary entries updated"
+    puts "#{word_to_freq.size - rows.size} words missing from dictionary"
+  end
+end
+
+def subtlex_default_path
+  Rails.root.join("tmp", "frequency", "SUBTLEX_CH_131210_CE.utf8").to_s
+end
+
+def parse_subtlex_frequencies(file_path)
+  lines = File.readlines(file_path, chomp: true, encoding: "bom|utf-8")
+  header = lines.shift.to_s.split("\t")
+  word_index = header.index("Word")
+  freq_index = header.index("W.million")
+
+  return {} if word_index.nil? || freq_index.nil?
+
+  lines.each_with_object({}) do |line, acc|
+    fields = line.split("\t")
+    word = fields[word_index]&.strip
+    next if word.blank?
+
+    freq = fields[freq_index].to_s.strip.tr(",", "").to_f
+    next if freq <= 0
+
+    acc[word] = [ acc[word].to_f, freq ].max
+  end
+end

--- a/lib/tasks/frequency.rake
+++ b/lib/tasks/frequency.rake
@@ -9,8 +9,8 @@ namespace :frequency do
   task download: :environment do
     file_dir = Rails.root.join("tmp", "frequency")
     file_path = file_dir.join("SUBTLEX_CH_131210_CE.utf8")
-    ImportFilesHelper.download_file_to_tmp(SUBTLEX_URL, file_path)
-    ImportFilesHelper.confirm_file_presence(File.basename(file_path), file_dir)
+    download_file_to_tmp(SUBTLEX_URL, file_path)
+    confirm_file_presence(File.basename(file_path), file_dir)
   end
 
   desc "Import SUBTLEX-CH frequency ranks into DictionaryEntry"

--- a/lib/tasks/tag_import.rake
+++ b/lib/tasks/tag_import.rake
@@ -1,4 +1,5 @@
 require_relative "../../app/helpers/tag_import_helper"
+require "set"
 
 include TagImportHelper
 
@@ -15,6 +16,29 @@ namespace :tag_import do
     hsk_level_files = hsk_file_paths_for_level(args, "hsk_3", "*.txt")
     parent_tag = find_or_create_top_level_tags("HSK 3.0")
     import_hsk_file(hsk_level_files, parent_tag)
+  end
+
+  desc "Audit HSK 3.0 words absent from dictionary and TSV fallbacks"
+  task :audit_hsk_3_gaps, [ :file_path ] => :environment do |_task, args|
+    hsk_level_files = hsk_file_paths_for_level(args, "hsk_3", "*.txt")
+    rows, missing_by_level = hsk_3_gap_report(hsk_level_files)
+
+    puts "Level | Expected | Covered | Missing"
+    rows.each do |row|
+      puts "#{row[:level]} | #{row[:expected]} | #{row[:covered]} | #{row[:missing]}"
+    end
+
+    total_expected = rows.sum { |row| row[:expected] }
+    total_covered = rows.sum { |row| row[:covered] }
+    total_missing = rows.sum { |row| row[:missing] }
+    puts "Total | #{total_expected} | #{total_covered} | #{total_missing}"
+
+    missing_by_level.each do |level, words|
+      next if words.empty?
+
+      puts "\n#{level} missing from dictionary and TSV:"
+      puts words.join("\n")
+    end
   end
 end
 
@@ -119,6 +143,33 @@ def parse_tsv_lookup(tsv_file)
     _traditional, simplified, pinyin, definition = parts
     lookup[simplified] = { pinyin: pinyin, definition: definition }
   end
+end
+
+def hsk_3_gap_report(hsk_level_files)
+  rows = []
+  missing_by_level = {}
+
+  hsk_level_files.each do |file|
+    texts = texts_from_file(file)
+    existing = DictionaryEntry.where(text: texts).pluck(:text).to_set
+    tsv_file = file.sub(/\.txt$/, ".tsv")
+    tsv_lookup = File.exist?(tsv_file) ? parse_tsv_lookup(tsv_file) : {}
+
+    missing = texts.reject do |text|
+      existing.include?(text) || tsv_lookup.key?(text)
+    end
+
+    level = tag_name_from_file(file)
+    rows << {
+      level: level,
+      expected: texts.count,
+      covered: texts.count - missing.count,
+      missing: missing.count
+    }
+    missing_by_level[level] = missing
+  end
+
+  [ rows, missing_by_level ]
 end
 
 def find_or_create_krmanik_source

--- a/spec/fixtures/subtlex_sample.tsv
+++ b/spec/fixtures/subtlex_sample.tsv
@@ -1,0 +1,4 @@
+Word	WCount	W.million	Dominant.PoS
+你好	200	60.0	n
+爱	180	45.5	v
+缺词	160	40.0	n

--- a/spec/jobs/admin/provisioning_job_spec.rb
+++ b/spec/jobs/admin/provisioning_job_spec.rb
@@ -78,4 +78,11 @@ RSpec.describe Admin::ProvisioningJob, type: :job do
 
     include_examples "a provisioning job", Admin::CustomDictionaryProvisioningService
   end
+
+  describe "#perform for frequency_data" do
+    let(:task_type)      { "frequency_data" }
+    let(:summary_result) { { words_parsed: 120_000, entries_updated: 95_000, missing_from_dictionary: 25_000 } }
+
+    include_examples "a provisioning job", Admin::FrequencyProvisioningService
+  end
 end

--- a/spec/models/admin_task_spec.rb
+++ b/spec/models/admin_task_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe AdminTask, type: :model do
     end
   end
 
+  describe "VALID_TASK_TYPES" do
+    it "includes frequency_data for admin provisioning" do
+      expect(AdminTask::VALID_TASK_TYPES).to include("frequency_data")
+    end
+  end
+
   describe ".in_progress" do
     it "returns pending and running tasks" do
       pending_task = create(:admin_task, task_type: "cc_cedict",         state: "pending")

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DictionaryEntry, type: :model do
 
   describe "validations" do
     it { should validate_presence_of(:text) }
+    it { should validate_numericality_of(:frequency_rank).only_integer.is_greater_than(0).allow_nil }
 
     it "requires at least one associated meaning" do
       dictionary_entry = build(:dictionary_entry)

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Admin::Dashboard", type: :request do
         get admin_root_path
         expect(response.body).to include("CC-CEDICT")
         expect(response.body).to include("HSK")
+        expect(response.body).to include("Frequency data")
       end
 
       it "shows task history" do
@@ -80,13 +81,13 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
 
       it "enqueues a job for each unlocked task type" do
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(3).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(4).times
         post admin_provision_all_path
       end
 
       it "does not enqueue a job for a locked task type" do
         create(:admin_task, task_type: "cc_cedict", state: "running")
-        expect(Admin::ProvisioningJob).to receive(:perform_later).twice
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(3).times
         post admin_provision_all_path
       end
 

--- a/spec/requests/admin/tasks_spec.rb
+++ b/spec/requests/admin/tasks_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe "Admin::Tasks", type: :request do
         end
       end
 
+      context "when task_type is frequency_data" do
+        it "creates a frequency_data task" do
+          post admin_tasks_path, params: { task_type: "frequency_data" }
+
+          expect(AdminTask.last.task_type).to eq("frequency_data")
+        end
+      end
+
       context "when the task type is already locked" do
         before { create(:admin_task, task_type: "cc_cedict", state: "running") }
 

--- a/spec/services/admin/frequency_provisioning_service_spec.rb
+++ b/spec/services/admin/frequency_provisioning_service_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Admin::FrequencyProvisioningService do
+  describe ".call" do
+    subject(:result) { described_class.call }
+
+    let(:subtlex_path) { Admin::FrequencyProvisioningService::SUBTLEX_PATH }
+
+    let(:subtlex_content) do
+      <<~TSV
+        Word\tWCount\tW.million\tDominant.PoS
+        你好\t200\t60.0\tn
+        爱\t180\t45.5\tv
+        缺词\t160\t40.0\tn
+      TSV
+    end
+
+    let!(:entry_nihao) { create(:dictionary_entry, text: "你好") }
+    let!(:entry_ai) { create(:dictionary_entry, text: "爱") }
+
+    before do
+      stub_request(:get, Admin::FrequencyProvisioningService::SUBTLEX_URL)
+        .to_return(body: subtlex_content)
+      FileUtils.rm_f(subtlex_path)
+    end
+
+    after { FileUtils.rm_f(subtlex_path) }
+
+    it "returns parsed, updated, and missing counts" do
+      expect(result).to eq(
+        words_parsed: 3,
+        entries_updated: 2,
+        missing_from_dictionary: 1
+      )
+    end
+
+    it "updates contiguous ranks for matched dictionary entries" do
+      result
+
+      expect(entry_nihao.reload.frequency_rank).to eq(1)
+      expect(entry_ai.reload.frequency_rank).to eq(2)
+    end
+
+    it "clears ranks for entries absent from the latest import" do
+      stale_entry = create(:dictionary_entry, text: "旧词", frequency_rank: 9)
+
+      result
+
+      expect(stale_entry.reload.frequency_rank).to be_nil
+    end
+  end
+end

--- a/spec/services/admin/frequency_provisioning_service_spec.rb
+++ b/spec/services/admin/frequency_provisioning_service_spec.rb
@@ -34,11 +34,26 @@ RSpec.describe Admin::FrequencyProvisioningService do
       )
     end
 
-    it "updates contiguous ranks for matched dictionary entries" do
+    it "uses source corpus positions for matched dictionary entries" do
       result
 
       expect(entry_nihao.reload.frequency_rank).to eq(1)
       expect(entry_ai.reload.frequency_rank).to eq(2)
+    end
+
+    it "preserves source rank positions when top words are missing" do
+      stub_request(:get, Admin::FrequencyProvisioningService::SUBTLEX_URL)
+        .to_return(body: <<~TSV)
+          Word\tWCount\tW.million\tDominant.PoS
+          缺词\t300\t90.0\tn
+          你好\t200\t60.0\tn
+          爱\t180\t45.5\tv
+        TSV
+
+      result
+
+      expect(entry_nihao.reload.frequency_rank).to eq(2)
+      expect(entry_ai.reload.frequency_rank).to eq(3)
     end
 
     it "clears ranks for entries absent from the latest import" do
@@ -47,6 +62,13 @@ RSpec.describe Admin::FrequencyProvisioningService do
       result
 
       expect(stale_entry.reload.frequency_rank).to be_nil
+    end
+
+    it "raises on invalid SUBTLEX headers" do
+      stub_request(:get, Admin::FrequencyProvisioningService::SUBTLEX_URL)
+        .to_return(body: "Token\tCount\n你好\t10\n")
+
+      expect { result }.to raise_error(/Invalid SUBTLEX header/)
     end
   end
 end

--- a/spec/tasks/frequency_spec.rb
+++ b/spec/tasks/frequency_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "frequency", type: :task do
+  before do
+    Rake.application.rake_require("tasks/frequency")
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "download" do
+    let(:file_path) { Rails.root.join("tmp", "frequency", "SUBTLEX_CH_131210_CE.utf8") }
+
+    before do
+      stub_request(:get, "https://raw.githubusercontent.com/krmanik/HSK-3.0/main/Scripts%20and%20data/SUBTLEX_CH_131210_CE.utf8")
+        .to_return(body: "Word\tWCount\tW.million\tDominant.PoS\n你好\t10\t1.0\tn\n")
+      FileUtils.rm_f(file_path)
+    end
+
+    after do
+      FileUtils.rm_f(file_path)
+      Rake::Task["frequency:download"].reenable
+    end
+
+    it "downloads the SUBTLEX file to tmp/frequency" do
+      silence_output { Rake::Task["frequency:download"].invoke }
+      expect(File.exist?(file_path)).to be(true)
+    end
+  end
+
+  describe "import" do
+    let(:fixture_file_path) { Rails.root.join("spec", "fixtures", "subtlex_sample.tsv") }
+
+    let!(:entry_nihao) { create(:dictionary_entry, text: "你好") }
+    let!(:entry_ai) { create(:dictionary_entry, text: "爱") }
+
+    after { Rake::Task["frequency:import"].reenable }
+
+    it "assigns lower ranks to higher W.million values" do
+      silence_output { Rake::Task["frequency:import"].invoke(fixture_file_path.to_s) }
+
+      expect(entry_nihao.reload.frequency_rank).to eq(1)
+      expect(entry_ai.reload.frequency_rank).to eq(2)
+    end
+
+    it "prints parsed and updated counts" do
+      output = capture_output { Rake::Task["frequency:import"].invoke(fixture_file_path.to_s) }
+
+      expect(output).to include("3 unique words parsed")
+      expect(output).to include("2 dictionary entries updated")
+      expect(output).to include("1 words missing from dictionary")
+    end
+  end
+end

--- a/spec/tasks/frequency_spec.rb
+++ b/spec/tasks/frequency_spec.rb
@@ -35,11 +35,42 @@ RSpec.describe "frequency", type: :task do
 
     after { Rake::Task["frequency:import"].reenable }
 
-    it "assigns lower ranks to higher W.million values" do
+    it "uses source corpus positions for ranks" do
       silence_output { Rake::Task["frequency:import"].invoke(fixture_file_path.to_s) }
 
       expect(entry_nihao.reload.frequency_rank).to eq(1)
       expect(entry_ai.reload.frequency_rank).to eq(2)
+    end
+
+    it "keeps source rank when top words are missing in dictionary" do
+      temp_file = Rails.root.join("tmp", "frequency_spec_rank.tsv")
+      File.write(temp_file, <<~TSV)
+        Word\tWCount\tW.million\tDominant.PoS
+        缺词\t300\t90.0\tn
+        你好\t200\t60.0\tn
+        爱\t180\t45.5\tv
+      TSV
+
+      silence_output { Rake::Task["frequency:import"].invoke(temp_file.to_s) }
+
+      expect(entry_nihao.reload.frequency_rank).to eq(2)
+      expect(entry_ai.reload.frequency_rank).to eq(3)
+    ensure
+      FileUtils.rm_f(temp_file)
+    end
+
+    it "raises when required SUBTLEX headers are missing" do
+      temp_file = Rails.root.join("tmp", "frequency_spec_invalid.tsv")
+      File.write(temp_file, <<~TSV)
+        Token\tCount
+        你好\t10
+      TSV
+
+      expect {
+        Rake::Task["frequency:import"].invoke(temp_file.to_s)
+      }.to raise_error(/Invalid SUBTLEX header/)
+    ensure
+      FileUtils.rm_f(temp_file)
     end
 
     it "prints parsed and updated counts" do
@@ -47,7 +78,7 @@ RSpec.describe "frequency", type: :task do
 
       expect(output).to include("3 unique words parsed")
       expect(output).to include("2 dictionary entries updated")
-      expect(output).to include("1 words missing from dictionary")
+      expect(output).to include("1 word missing from dictionary")
     end
   end
 end

--- a/spec/tasks/tag_import_spec.rb
+++ b/spec/tasks/tag_import_spec.rb
@@ -122,4 +122,30 @@ RSpec.describe "tag_import", type: :task do
       expect(output).to match(/Completed in [\d.]+s/)
     end
   end
+
+  describe "audit_hsk_3_gaps" do
+    include_context "hsk 3 fixture directory"
+
+    let!(:entry_ai)  { create(:dictionary_entry, text: "爱") }
+    let!(:entry_hao) { create(:dictionary_entry, text: "好") }
+
+    after { Rake::Task["tag_import:audit_hsk_3_gaps"].reenable }
+
+    it "reports rows with expected, covered, and missing counts" do
+      output = capture_output { Rake::Task["tag_import:audit_hsk_3_gaps"].invoke(fixture_dir) }
+
+      expect(output).to include("Level | Expected | Covered | Missing")
+      expect(output).to include("HSK 1 | 3 | 3 | 0")
+      expect(output).to include("Total | 3 | 3 | 0")
+    end
+
+    it "lists words that are absent from both dictionary and TSV" do
+      File.write(File.join(fixture_dir, "HSK 2.txt"), "缺词\n")
+
+      output = capture_output { Rake::Task["tag_import:audit_hsk_3_gaps"].invoke(fixture_dir) }
+
+      expect(output).to include("HSK 2 missing from dictionary and TSV:")
+      expect(output).to include("缺词")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- document the unresolved HSK 3.0 upstream data gap with a dedicated `tag_import:audit_hsk_3_gaps` task and `docs/DATA_GAPS.md`
- add SUBTLEX-CH import support (`frequency:download`, `frequency:import`) and persist `dictionary_entries.frequency_rank`
- wire frequency import into bootstrap and add task/model specs plus fixtures for both changes

## Testing
- `BUNDLE_PATH=vendor/bundle bundle exec rspec spec/tasks/tag_import_spec.rb spec/tasks/frequency_spec.rb spec/models/dictionary_entry_spec.rb` *(examples passed; SimpleCov threshold still fails on partial runs in this repo)*
- `BUNDLE_PATH=vendor/bundle bin/rails db:migrate`