### PR TITLE
feat: surface frequency rank in dictionary UX

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,7 +4,7 @@ class TagsController < ApplicationController
   end
 
   def show
-    @order = params[:order].presence_in(TagEntriesGrouper::ORDER_OPTIONS.keys) || "hsk"
+    @order = params[:order].presence_in(TagEntriesGrouper::ORDER_OPTIONS.keys) || "text"
     @entry_tag = Tag.includes(children: :children).find(params[:id])
     @child_tags = @entry_tag.children
     @dictionary_entries_grouped = TagEntriesGrouper.new(@entry_tag, Current.user).grouped_by_learning_state(order: @order)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,9 +4,11 @@ class TagsController < ApplicationController
   end
 
   def show
+    @order = params[:order].presence_in(TagEntriesGrouper::ORDER_OPTIONS.keys) || "hsk"
     @entry_tag = Tag.includes(children: :children).find(params[:id])
     @child_tags = @entry_tag.children
-    @dictionary_entries_grouped = TagEntriesGrouper.new(@entry_tag, Current.user).grouped_by_learning_state
+    @dictionary_entries_grouped = TagEntriesGrouper.new(@entry_tag, Current.user).grouped_by_learning_state(order: @order)
+    @order_options = TagEntriesGrouper::ORDER_OPTIONS
     @states = {
       new_entries: "New",
       learning:    "Learning",

--- a/app/helpers/tag_entries_grouper.rb
+++ b/app/helpers/tag_entries_grouper.rb
@@ -1,6 +1,6 @@
 class TagEntriesGrouper
   ORDER_OPTIONS = {
-    "hsk" => "HSK order",
+    "text" => "Text (A-Z)",
     "frequency_common" => "Most common first",
     "frequency_rare" => "Rarest first"
   }.freeze
@@ -10,24 +10,24 @@ class TagEntriesGrouper
     @user = user
   end
 
-  def grouped_by_learning_state(order: "hsk")
+  def grouped_by_learning_state(order: "text")
     entries = @tag.dictionary_entries
                     .joins(:user_learnings)
                     .where(user_learnings: { user_id: @user.id })
                     .select("dictionary_entries.*, user_learnings.state as learning_state, user_learnings.factor as learning_factor")
 
-    grouped = entries.group_by(&:learning_state).transform_values { |group| apply_order(group, order) }
-    learning = grouped["learning"] || []
+    grouped = entries.group_by(&:learning_state)
+    learning = apply_order(grouped["learning"] || [], order)
 
     unstarted = @tag.dictionary_entries.where.not(id: UserLearning.where(user: @user).select(:dictionary_entry_id)).to_a
-    ordered_unstarted = apply_order(unstarted, order)
+    new_entries = apply_order((grouped["new"] || []) + unstarted, order)
 
     {
-      new_entries:  apply_order((grouped["new"] || []) + ordered_unstarted, order),
+      new_entries:  new_entries,
       learning:     learning.reject { |e| e.learning_factor < 2000 },
       struggling:   learning.select { |e| e.learning_factor < 2000 },
-      mastered:     grouped["mastered"] || [],
-      suspended:    grouped["suspended"] || []
+      mastered:     apply_order(grouped["mastered"] || [], order),
+      suspended:    apply_order(grouped["suspended"] || [], order)
     }
   end
 

--- a/app/helpers/tag_entries_grouper.rb
+++ b/app/helpers/tag_entries_grouper.rb
@@ -1,27 +1,46 @@
 class TagEntriesGrouper
+  ORDER_OPTIONS = {
+    "hsk" => "HSK order",
+    "frequency_common" => "Most common first",
+    "frequency_rare" => "Rarest first"
+  }.freeze
+
   def initialize(tag, user)
     @tag = tag
     @user = user
   end
 
-  def grouped_by_learning_state
+  def grouped_by_learning_state(order: "hsk")
     entries = @tag.dictionary_entries
                     .joins(:user_learnings)
                     .where(user_learnings: { user_id: @user.id })
                     .select("dictionary_entries.*, user_learnings.state as learning_state, user_learnings.factor as learning_factor")
 
-    grouped = entries.group_by(&:learning_state)
+    grouped = entries.group_by(&:learning_state).transform_values { |group| apply_order(group, order) }
     learning = grouped["learning"] || []
 
-    unstarted = @tag.dictionary_entries
-                    .where.not(id: UserLearning.where(user: @user).select(:dictionary_entry_id))
+    unstarted = @tag.dictionary_entries.where.not(id: UserLearning.where(user: @user).select(:dictionary_entry_id)).to_a
+    ordered_unstarted = apply_order(unstarted, order)
 
     {
-      new_entries:  (grouped["new"] || []) + unstarted.to_a,
+      new_entries:  apply_order((grouped["new"] || []) + ordered_unstarted, order),
       learning:     learning.reject { |e| e.learning_factor < 2000 },
       struggling:   learning.select { |e| e.learning_factor < 2000 },
       mastered:     grouped["mastered"] || [],
       suspended:    grouped["suspended"] || []
     }
+  end
+
+  private
+
+  def apply_order(entries, order)
+    case order
+    when "frequency_common"
+      entries.sort_by { |entry| [ entry.frequency_rank || Float::INFINITY, entry.text ] }
+    when "frequency_rare"
+      entries.sort_by { |entry| [ entry.frequency_rank ? 0 : 1, -(entry.frequency_rank || 0), entry.text ] }
+    else
+      entries.sort_by(&:text)
+    end
   end
 end

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -86,6 +86,11 @@
             NOT STARTED
           </span>
         <% end %>
+        <% if @dictionary_entry.frequency_rank.present? %>
+          <p class="de-mono text-[11px] text-gray-400 mt-3">FREQUENCY #<%= @dictionary_entry.frequency_rank %></p>
+        <% else %>
+          <p class="de-mono text-[11px] text-gray-600 mt-3">FREQUENCY N/A</p>
+        <% end %>
       </div>
 
     </div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -52,12 +52,27 @@
           <% end %>
         <% end %>
       </div>
+      <% if key == :new_entries %>
+        <div class="mb-4">
+          <%= form_with url: tag_path(@entry_tag), method: :get, local: true, class: "inline-flex items-center gap-2" do |f| %>
+            <label for="order" class="text-sm text-gray-600 dark:text-gray-300">Order</label>
+            <%= f.select :order,
+                  options_for_select(@order_options.map { |value, label_text| [ label_text, value ] }, @order),
+                  {},
+                  class: "rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-sm text-gray-800 dark:text-gray-100",
+                  onchange: "this.form.requestSubmit()" %>
+          <% end %>
+        </div>
+      <% end %>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-7 mb-6">
         <% entries_in_state.each.with_index(1) do |entry, index| %>
           <%= link_to dictionary_entry_path(entry.id), class: "relative bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 text-center" do %>
             <span class="absolute top-0 left-0 text-xs text-gray-500 dark:text-gray-400 p-1"><%= index %></span>
             <% if @due_entry_ids.include?(entry.id) %>
               <span class="due-indicator absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full"></span>
+            <% end %>
+            <% if entry.frequency_rank.present? %>
+              <span class="absolute bottom-1 right-1 text-[10px] text-gray-500 dark:text-gray-400">#<%= entry.frequency_rank %></span>
             <% end %>
             <p class="text-2xl font-bold text-gray-800 dark:text-gray-200"><%= entry.text %></p>
           <% end %>

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe "DictionaryEntries", type: :request do
         expect(response.body).to include(dictionary_entry.text)
       end
 
+      it "shows frequency rank when present" do
+        dictionary_entry.update!(frequency_rank: 42)
+
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body).to include("FREQUENCY #42")
+      end
+
+      it "shows frequency as unavailable when absent" do
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body).to include("FREQUENCY N/A")
+      end
+
       context "when the user has no learning record" do
         it "shows the not-started state" do
           get dictionary_entry_path(dictionary_entry)

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -48,6 +48,47 @@ RSpec.describe "Tags", type: :request do
         get tag_path(root_tag)
         expect(response.body).not_to include("breadcrumb")
       end
+
+      it "renders ordering options for entries" do
+        get tag_path(root_tag)
+
+        expect(response.body).to include("Most common first")
+        expect(response.body).to include("Rarest first")
+      end
+    end
+
+    describe "GET /tags/:id ordering" do
+      let(:entry_common) { create(:dictionary_entry, text: "常", frequency_rank: 1) }
+      let(:entry_mid) { create(:dictionary_entry, text: "中", frequency_rank: 100) }
+      let(:entry_nil) { create(:dictionary_entry, text: "稀") }
+
+      before do
+        root_tag.dictionary_entries << entry_common
+        root_tag.dictionary_entries << entry_mid
+        root_tag.dictionary_entries << entry_nil
+      end
+
+      it "orders new entries by ascending frequency for common-first" do
+        get tag_path(root_tag, order: "frequency_common")
+
+        common_idx = response.body.index(entry_common.text)
+        mid_idx = response.body.index(entry_mid.text)
+        nil_idx = response.body.index(entry_nil.text)
+
+        expect(common_idx).to be < mid_idx
+        expect(mid_idx).to be < nil_idx
+      end
+
+      it "orders new entries by descending frequency for rare-first" do
+        get tag_path(root_tag, order: "frequency_rare")
+
+        mid_idx = response.body.index(entry_mid.text)
+        common_idx = response.body.index(entry_common.text)
+        nil_idx = response.body.index(entry_nil.text)
+
+        expect(mid_idx).to be < common_idx
+        expect(common_idx).to be < nil_idx
+      end
     end
 
     describe "GET /tags/:id — due indicator" do


### PR DESCRIPTION
Closes #271

## Summary
- show `frequency_rank` on dictionary entry pages with an explicit fallback when rank is unavailable
- add frequency-based ordering options to tag browsing (`Most common first`, `Rarest first`) with nil-rank entries placed last
- display per-tile frequency rank badges in tag grids and wire request specs for display and ordering behaviour

## Testing
- `BUNDLE_PATH=vendor/bundle bundle exec rspec spec/requests/dictionary_entries_spec.rb spec/requests/tags_spec.rb spec/helpers/tag_entries_grouper_spec.rb` *(examples pass; SimpleCov repo-wide threshold still fails on partial runs)*