### PR TITLE
fix: tighten mobile card spacing and width stability

### DIFF
--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -12,12 +12,12 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
+<div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
-  <p class="text-sm text-gray-400 mb-2"><%= @position %> / <%= @total %></p>
-  <p class="text-xs text-gray-300 mb-6">Quick review of today's new characters</p>
+  <p class="text-sm text-gray-400 mb-1 sm:mb-2"><%= @position %> / <%= @total %></p>
+  <p class="text-xs text-gray-300 mb-4 sm:mb-6">Quick review of today's new characters</p>
 
-  <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
+  <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
     <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
       <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -12,11 +12,11 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="learn-card adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
+<div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="learn-card adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
-  <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
+  <p class="text-sm text-gray-400 mb-4 sm:mb-8"><%= @position %> / <%= @total %></p>
 
-  <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
+  <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
     <%# Card %>
     <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -12,11 +12,11 @@
   supplemental_meanings = meanings.drop(1)
 %>
 
-<div class="w-full flex flex-col items-center pt-16 pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
+<div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
 
-  <p class="text-sm text-gray-400 mb-8"><%= @position %> / <%= @total %></p>
+  <p class="text-sm text-gray-400 mb-4 sm:mb-8"><%= @position %> / <%= @total %></p>
 
-  <div class="w-fit min-w-72 max-w-xl flex flex-col items-stretch">
+  <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
     <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
 

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include('data-card-text-scaling="adaptive"')
         expect(response.body).to include("learn-card")
         expect(response.body).to include("adaptive-card-text")
+        expect(response.body).to include("w-full max-w-xl")
       end
 
       it "shows a supplemental meanings toggle when available" do
@@ -286,6 +287,7 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include('data-card-text-scaling="adaptive"')
         expect(response.body).to include("card-flip")
         expect(response.body).to include("adaptive-card-text")
+        expect(response.body).to include("w-full max-w-xl")
       end
 
       it "renders ease buttons with data-ease attributes for keyboard shortcuts" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to include('data-card-text-scaling="adaptive"')
         expect(response.body).to include("card-flip")
         expect(response.body).to include("adaptive-card-text")
+        expect(response.body).to include("w-full max-w-xl")
       end
 
       it "shows a supplemental meanings toggle when multiple meanings exist" do


### PR DESCRIPTION
Closes #275

## Summary
- reduce mobile top/bottom spacing and counter gaps on learn/review card screens so the card sits higher in the viewport
- switch card wrappers to full-width constrained containers (`w-full max-w-xl`) to keep reveal states visually stable across screen sizes
- add request-spec assertions to lock in the full-width container class on learn and review card responses

## Testing
- `BUNDLE_PATH=vendor/bundle bundle exec rspec spec/requests/learn_spec.rb spec/requests/review_spec.rb` *(examples pass; SimpleCov repo-wide threshold still fails on partial runs)*