### PR TITLE
fix: improve CC-CEDICT flashcard defaults

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -36,7 +36,7 @@ class LearnController < ApplicationController
                        .joins(:dictionary_entry)
                        .where("dictionary_entries.text LIKE ?", "%#{safe_char}%")
                        .where.not(id: @user_learning.id)
-                       .includes(dictionary_entry: :meanings)
+                       .includes(dictionary_entry: { meanings: :source })
                        .limit(5)
   end
 
@@ -189,14 +189,14 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: :meanings)
+           .includes(dictionary_entry: { meanings: :source })
            .find(id)
   end
 
   def current_review_card
     id = session[:learn_introduced][session[:learn_review_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: :meanings)
+           .includes(dictionary_entry: { meanings: :source })
            .find(id)
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -27,7 +27,7 @@ class ReviewController < ApplicationController
     @learning_session = active_learning_session
     @session_card     = @learning_session.current_card(current_position)
     @user_learning    = UserLearning
-                          .includes(dictionary_entry: [ :meanings, { tags: :parent } ])
+                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent } ])
                           .find(@session_card.user_learning_id)
     @position         = current_position + 1
     @total            = @learning_session.card_count

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -28,23 +28,31 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def flashcard_meanings
-    english_meanings = if persisted?
+    english_meanings = if association(:meanings).loaded?
+      meanings.select { |meaning| meaning.language == "en" }
+    elsif persisted?
       Meaning.includes(:source).where(dictionary_entry_id: id, language: "en").order(:id).to_a
     else
       meanings.select { |meaning| meaning.language == "en" }
     end
 
-    candidate_meanings = english_meanings.reject { |meaning| meaning.text.start_with?("CL:") }
-
-    return candidate_meanings unless candidate_meanings.any? { |meaning| cc_cedict_meaning?(meaning) }
-
-    keep_obscure_first = candidate_meanings.none? do |meaning|
-      cc_cedict_meaning?(meaning) && !obscure_cedict_meaning?(meaning)
+    if persisted? && association(:meanings).loaded? && english_meanings.empty?
+      english_meanings = Meaning.includes(:source).where(dictionary_entry_id: id, language: "en").order(:id).to_a
     end
 
-    candidate_meanings.each_with_index
-                      .sort_by { |meaning, index| [ deprioritise_obscure?(meaning, keep_obscure_first), index ] }
-                      .map(&:first)
+    candidate_meanings = english_meanings.reject { |meaning| meaning.text.start_with?("CL:") }
+
+    if candidate_meanings.any? { |meaning| cc_cedict_meaning?(meaning) }
+      keep_obscure_first = candidate_meanings.none? do |meaning|
+        cc_cedict_meaning?(meaning) && !obscure_cedict_meaning?(meaning)
+      end
+
+      candidate_meanings.each_with_index
+                        .sort_by { |meaning, index| [ deprioritise_obscure?(meaning, keep_obscure_first), index ] }
+                        .map(&:first)
+    else
+      candidate_meanings
+    end
   end
 
   def flashcard_primary_meaning

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -1,4 +1,6 @@
 class DictionaryEntry < ApplicationRecord
+  CEDICT_DEPRIORITISED_SENSE_PATTERN = /\b(?:surname|archaic|classical|literary|dialect|old(?:\s+variant)?|variant(?:\s+of)?|also\s+written)\b/i
+
   has_many :dictionary_entry_tags, dependent: :destroy
   has_many :tags, through: :dictionary_entry_tags
   has_many :meanings, dependent: :destroy
@@ -25,7 +27,46 @@ class DictionaryEntry < ApplicationRecord
     { entry: entry, meanings: meanings, user_learning: user_learning }
   end
 
+  def flashcard_meanings
+    english_meanings = if persisted?
+      Meaning.includes(:source).where(dictionary_entry_id: id, language: "en").order(:id).to_a
+    else
+      meanings.select { |meaning| meaning.language == "en" }
+    end
+
+    candidate_meanings = english_meanings.reject { |meaning| meaning.text.start_with?("CL:") }
+
+    return candidate_meanings unless candidate_meanings.any? { |meaning| cc_cedict_meaning?(meaning) }
+
+    keep_obscure_first = candidate_meanings.none? do |meaning|
+      cc_cedict_meaning?(meaning) && !obscure_cedict_meaning?(meaning)
+    end
+
+    candidate_meanings.each_with_index
+                      .sort_by { |meaning, index| [ deprioritise_obscure?(meaning, keep_obscure_first), index ] }
+                      .map(&:first)
+  end
+
+  def flashcard_primary_meaning
+    flashcard_meanings.first
+  end
+
   private
+
+  def cc_cedict_meaning?(meaning)
+    meaning.source&.name == "CC-CEDICT"
+  end
+
+  def obscure_cedict_meaning?(meaning)
+    meaning.text.match?(CEDICT_DEPRIORITISED_SENSE_PATTERN)
+  end
+
+  def deprioritise_obscure?(meaning, keep_obscure_first)
+    return 0 unless cc_cedict_meaning?(meaning)
+    return 0 if keep_obscure_first
+
+    obscure_cedict_meaning?(meaning) ? 1 : 0
+  end
 
   def must_have_at_least_one_meaning
     errors.add(:dictionary_entry, "must have at least one associated meaning") if meanings.empty?

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -6,9 +6,9 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  pinyin   = entry.meanings.first&.pinyin
-  meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  primary_meaning       = meanings.first
+  meanings = entry.flashcard_meanings
+  primary_meaning       = entry.flashcard_primary_meaning
+  pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>
 

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -7,7 +7,7 @@
 <%
   entry    = @user_learning.dictionary_entry
   meanings = entry.flashcard_meanings
-  primary_meaning       = entry.flashcard_primary_meaning
+  primary_meaning       = meanings.first
   pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -7,7 +7,7 @@
 <%
   entry    = @user_learning.dictionary_entry
   meanings = entry.flashcard_meanings
-  primary_meaning       = entry.flashcard_primary_meaning
+  primary_meaning       = meanings.first
   pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -6,9 +6,9 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  pinyin   = entry.meanings.first&.pinyin
-  meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  primary_meaning       = meanings.first
+  meanings = entry.flashcard_meanings
+  primary_meaning       = entry.flashcard_primary_meaning
+  pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>
 
@@ -88,10 +88,10 @@
           </p>
           <ul class="space-y-2">
             <% @related.each do |rel| %>
-              <% rel_meaning = rel.dictionary_entry.meanings.reject { |m| m.text.start_with?("CL:") }.first %>
+              <% rel_meaning = rel.dictionary_entry.flashcard_primary_meaning %>
               <li class="flex items-baseline gap-2 text-sm">
                 <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= rel.dictionary_entry.text %></span>
-                <span class="text-gray-400"><%= rel.dictionary_entry.meanings.first&.pinyin %></span>
+                <span class="text-gray-400"><%= rel_meaning&.pinyin %></span>
                 <span class="text-gray-600 dark:text-gray-400"><%= rel_meaning&.text %></span>
               </li>
             <% end %>

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -6,9 +6,9 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  pinyin   = entry.meanings.first&.pinyin
-  meanings = entry.meanings.reject { |m| m.text.start_with?("CL:") }
-  primary_meaning      = meanings.first
+  meanings = entry.flashcard_meanings
+  primary_meaning      = entry.flashcard_primary_meaning
+  pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>
 

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -7,7 +7,7 @@
 <%
   entry    = @user_learning.dictionary_entry
   meanings = entry.flashcard_meanings
-  primary_meaning      = entry.flashcard_primary_meaning
+  primary_meaning      = meanings.first
   pinyin   = primary_meaning&.pinyin
   supplemental_meanings = meanings.drop(1)
 %>

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -71,7 +71,11 @@ RSpec.describe DictionaryEntry, type: :model do
 
   describe "#flashcard_meanings" do
     let(:entry) { create(:dictionary_entry) }
-    let(:cedict_source) { create(:source, name: "CC-CEDICT") }
+    let(:cedict_source) do
+      create(:source,
+             name: "CC-CEDICT",
+             url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
+    end
 
     before { entry.meanings.destroy_all }
 

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -68,4 +68,43 @@ RSpec.describe DictionaryEntry, type: :model do
       expect(result[:user_learning]).to eq(user_learning)
     end
   end
+
+  describe "#flashcard_meanings" do
+    let(:entry) { create(:dictionary_entry) }
+    let(:cedict_source) { create(:source, name: "CC-CEDICT") }
+
+    before { entry.meanings.destroy_all }
+
+    it "keeps CL senses out of flashcard meanings" do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "CL:個|个[ge4]", pinyin: "gè")
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "to look", pinyin: "kàn")
+
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ "to look" ])
+    end
+
+    it "de-prioritises obscure CC-CEDICT senses when a plain sense exists" do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "surname Li", pinyin: "Lǐ")
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "plum", pinyin: "lǐ")
+
+      expect(entry.flashcard_primary_meaning.text).to eq("plum")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("lǐ")
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ "plum", "surname Li" ])
+    end
+
+    it "preserves order when only obscure CC-CEDICT senses are available" do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "surname Zhao", pinyin: "Zhào")
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "variant of 趙|赵", pinyin: "Zhào")
+
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ "surname Zhao", "variant of 趙|赵" ])
+      expect(entry.flashcard_primary_meaning.text).to eq("surname Zhao")
+    end
+
+    it "does not reorder non-CC-CEDICT meanings" do
+      custom_source = create(:source, name: "Custom Dictionary")
+      create(:meaning, dictionary_entry: entry, source: custom_source, text: "surname Wu", pinyin: "Wú")
+      create(:meaning, dictionary_entry: entry, source: custom_source, text: "martial", pinyin: "wǔ")
+
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ "surname Wu", "martial" ])
+    end
+  end
 end

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -209,7 +209,9 @@ RSpec.describe "Learn", type: :request do
 
       it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
         new_card.dictionary_entry.meanings.destroy_all
-        cedict_source = create(:source, name: "CC-CEDICT")
+        cedict_source = create(:source,
+                               name: "CC-CEDICT",
+                               url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
         create(:meaning, dictionary_entry: new_card.dictionary_entry,
                          source: cedict_source,
                          text: "surname Li", pinyin: "Lǐ")

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -206,6 +206,22 @@ RSpec.describe "Learn", type: :request do
 
         expect(response.body).to include("Show more meanings")
       end
+
+      it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
+        new_card.dictionary_entry.meanings.destroy_all
+        cedict_source = create(:source, name: "CC-CEDICT")
+        create(:meaning, dictionary_entry: new_card.dictionary_entry,
+                         source: cedict_source,
+                         text: "surname Li", pinyin: "Lǐ")
+        create(:meaning, dictionary_entry: new_card.dictionary_entry,
+                         source: cedict_source,
+                         text: "plum", pinyin: "lǐ")
+
+        get learn_card_path
+
+        expect(response.body).to include("plum")
+        expect(response.body).to include("lǐ")
+      end
     end
 
     context "when authenticated without an active learn session" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -215,7 +215,9 @@ RSpec.describe "Review", type: :request do
 
       it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
         user_learning.dictionary_entry.meanings.destroy_all
-        cedict_source = create(:source, name: "CC-CEDICT")
+        cedict_source = create(:source,
+                               name: "CC-CEDICT",
+                               url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
         create(:meaning, dictionary_entry: user_learning.dictionary_entry,
                          source: cedict_source,
                          text: "surname Wang", pinyin: "Wáng")

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -212,6 +212,22 @@ RSpec.describe "Review", type: :request do
 
         expect(response.body).to include("Show more meanings")
       end
+
+      it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
+        user_learning.dictionary_entry.meanings.destroy_all
+        cedict_source = create(:source, name: "CC-CEDICT")
+        create(:meaning, dictionary_entry: user_learning.dictionary_entry,
+                         source: cedict_source,
+                         text: "surname Wang", pinyin: "Wáng")
+        create(:meaning, dictionary_entry: user_learning.dictionary_entry,
+                         source: cedict_source,
+                         text: "king", pinyin: "wáng")
+
+        get review_card_path
+
+        expect(response.body).to include("king")
+        expect(response.body).to include("wáng")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- add deterministic flashcard meaning ranking on `DictionaryEntry` to keep classifier senses out of defaults and de-prioritize obscure CC-CEDICT senses (surname/archaic/literary/variant/dialect) when a plain modern sense exists
- align flashcard pinyin with the selected primary meaning in learn/review card views, while preserving supplemental meanings for detail
- eager-load `meaning.source` in learn/review controllers and add model/request specs covering ambiguous entries and primary pinyin selection

## Testing
- bundle exec rspec