### PR TITLE
fix: prioritise learner-friendly flashcard senses

### DIFF
--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -68,7 +68,7 @@ class DictionaryEntry < ApplicationRecord
       meanings.select { |m| m.language == "en" }
     elsif persisted?
       # If not preloaded, fetch from DB
-      meanings.where(language: "en").includes(:source).order(:id)
+      meanings.where(language: "en").includes(:source).order(:id).to_a
     else
       # For new records not yet in the DB
       meanings.select { |m| m.language == "en" }

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -1,5 +1,10 @@
 class DictionaryEntry < ApplicationRecord
-  CEDICT_DEPRIORITISED_SENSE_PATTERN = /\b(?:surname|archaic|classical|literary|dialect|old(?:\s+variant)?|variant(?:\s+of)?|also\s+written)\b/i
+  CEDICT_SENSE_DEPRIORITISATION_RULES = [
+    [ /\b(?:classifier|measure\s+word)\b/i, 10 ],
+    [ /\b(?:archaic|classical|literary|dialect|old\s+name\s+of)\b/i, 20 ],
+    [ /\b(?:old(?:\s+variant)?|variant(?:\s+of)?|also\s+written)\b/i, 40 ],
+    [ /\bsurname\b/i, 50 ]
+  ].freeze
 
   has_many :dictionary_entry_tags, dependent: :destroy
   has_many :tags, through: :dictionary_entry_tags
@@ -28,31 +33,27 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def flashcard_meanings
-    english_meanings = if association(:meanings).loaded?
-      meanings.select { |meaning| meaning.language == "en" }
-    elsif persisted?
-      Meaning.includes(:source).where(dictionary_entry_id: id, language: "en").order(:id).to_a
-    else
-      meanings.select { |meaning| meaning.language == "en" }
-    end
+    english_meanings = fetch_english_meanings
+    return english_meanings if english_meanings.empty?
 
-    if persisted? && association(:meanings).loaded? && english_meanings.empty?
-      english_meanings = Meaning.includes(:source).where(dictionary_entry_id: id, language: "en").order(:id).to_a
-    end
-
+    # First, filter out any classifier-only senses
     candidate_meanings = english_meanings.reject { |meaning| meaning.text.start_with?("CL:") }
+    return candidate_meanings if candidate_meanings.empty?
 
-    if candidate_meanings.any? { |meaning| cc_cedict_meaning?(meaning) }
-      keep_obscure_first = candidate_meanings.none? do |meaning|
-        cc_cedict_meaning?(meaning) && !obscure_cedict_meaning?(meaning)
-      end
+    # If there are no CC-CEDICT meanings, there's no sorting to do.
+    return candidate_meanings unless candidate_meanings.any?(&method(:cc_cedict_meaning?))
 
-      candidate_meanings.each_with_index
-                        .sort_by { |meaning, index| [ deprioritise_obscure?(meaning, keep_obscure_first), index ] }
-                        .map(&:first)
-    else
-      candidate_meanings
+    # Keep original order when all CC-CEDICT senses are deprioritised.
+    has_plain_cedict = candidate_meanings.any? do |meaning|
+      cc_cedict_meaning?(meaning) && cedict_deprioritisation_score(meaning).zero?
     end
+    return candidate_meanings unless has_plain_cedict
+
+    ordered_by_pinyin(candidate_meanings)
+  end
+
+  def flashcard_primary_pinyin
+    flashcard_primary_meaning&.pinyin
   end
 
   def flashcard_primary_meaning
@@ -61,19 +62,59 @@ class DictionaryEntry < ApplicationRecord
 
   private
 
+  def fetch_english_meanings
+    # Prioritise loaded associations to avoid N+1 queries
+    if association(:meanings).loaded?
+      meanings.select { |m| m.language == "en" }
+    elsif persisted?
+      # If not preloaded, fetch from DB
+      meanings.where(language: "en").includes(:source).order(:id)
+    else
+      # For new records not yet in the DB
+      meanings.select { |m| m.language == "en" }
+    end
+  end
+
+  def sort_penalty(meaning)
+    return 0 unless cc_cedict_meaning?(meaning)
+
+    cedict_deprioritisation_score(meaning)
+  end
+
+  def ordered_by_pinyin(candidate_meanings)
+    indexed = candidate_meanings.each_with_index.to_a
+    grouped = indexed.group_by { |meaning, _index| meaning.pinyin }
+
+    grouped
+      .sort_by { |_pinyin, meanings| pinyin_group_sort_key(meanings) }
+      .flat_map do |_pinyin, meanings|
+        meanings.sort_by { |meaning, index| [ sort_penalty(meaning), index ] }.map(&:first)
+      end
+  end
+
+  def pinyin_group_sort_key(meanings)
+    penalties = meanings.map { |meaning, _index| sort_penalty(meaning) }
+
+    [
+      penalties.min,
+      -penalties.count(0),
+      penalties.sum,
+      meanings.first.last
+    ]
+  end
+
+  def cedict_deprioritisation_score(meaning)
+    text = meaning.text
+
+    CEDICT_SENSE_DEPRIORITISATION_RULES.each do |pattern, score|
+      return score if text.match?(pattern)
+    end
+
+    0
+  end
+
   def cc_cedict_meaning?(meaning)
     meaning.source&.name == "CC-CEDICT"
-  end
-
-  def obscure_cedict_meaning?(meaning)
-    meaning.text.match?(CEDICT_DEPRIORITISED_SENSE_PATTERN)
-  end
-
-  def deprioritise_obscure?(meaning, keep_obscure_first)
-    return 0 unless cc_cedict_meaning?(meaning)
-    return 0 if keep_obscure_first
-
-    obscure_cedict_meaning?(meaning) ? 1 : 0
   end
 
   def must_have_at_least_one_meaning

--- a/spec/factories/dictionary_entries.rb
+++ b/spec/factories/dictionary_entries.rb
@@ -2,8 +2,16 @@ FactoryBot.define do
   factory :dictionary_entry do
     sequence(:text) { |n| "感动#{n}" }
 
-    after(:build) do |entry|
-      entry.meanings << build(:meaning, dictionary_entry: entry)
+    transient do
+      meanings_count { 1 }
+    end
+
+    after(:build) do |entry, evaluator|
+      if entry.meanings.empty? && evaluator.meanings_count > 0
+        evaluator.meanings_count.times do
+          entry.meanings << build(:meaning, dictionary_entry: entry)
+        end
+      end
     end
   end
 end

--- a/spec/factories/meaning.rb
+++ b/spec/factories/meaning.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :meaning do
     association :dictionary_entry
-    association :source
     pinyin { "gǎn dòng" }
     language { "en" }
     text { "to be touched" }
+    source
   end
 end

--- a/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
+++ b/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Flashcard primary meaning selection" do
+RSpec.describe DictionaryEntry, "flashcard primary meaning selection" do
   let(:source) { create(:source, name: "CC-CEDICT") }
 
   def create_entry_with_meanings(text, meanings_attrs)

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -8,15 +8,14 @@ RSpec.describe DictionaryEntry, type: :model do
     it { should have_many(:user_learnings).dependent(:destroy) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { should validate_presence_of(:text) }
     it { should validate_numericality_of(:frequency_rank).only_integer.is_greater_than(0).allow_nil }
 
-    it "requires at least one associated meaning" do
-      dictionary_entry = build(:dictionary_entry)
-      dictionary_entry.meanings.clear # Ensure no meanings
+    it 'requires at least one associated meaning' do
+      dictionary_entry = build(:dictionary_entry, meanings_count: 0)
       expect(dictionary_entry).to_not be_valid
-      expect(dictionary_entry.errors[:dictionary_entry]).to include("must have at least one associated meaning")
+      expect(dictionary_entry.errors[:dictionary_entry]).to include('must have at least one associated meaning')
     end
   end
 
@@ -24,91 +23,120 @@ RSpec.describe DictionaryEntry, type: :model do
     it { should accept_nested_attributes_for(:meanings).allow_destroy(true) }
   end
 
-  describe "#add_tag" do
+  describe '#add_tag' do
     let(:dictionary_entry) { create(:dictionary_entry) }
     let(:tag) { create(:tag) }
 
-    it "adds a tag to the dictionary entry" do
+    it 'adds a tag to the dictionary entry' do
       dictionary_entry.add_tag(tag)
       expect(dictionary_entry.tags).to include(tag)
     end
 
-    it "does not add the same tag twice" do
+    it 'does not add the same tag twice' do
       dictionary_entry.add_tag(tag)
       dictionary_entry.add_tag(tag)
       expect(dictionary_entry.tags.where(id: tag.id).count).to eq(1)
     end
   end
 
-  describe "#user_learning_for" do
+  describe '#user_learning_for' do
     let(:dictionary_entry) { create(:dictionary_entry) }
     let(:user) { create(:user) }
     let!(:user_learning) { create(:user_learning, user: user, dictionary_entry: dictionary_entry) }
 
-    it "returns the user learning for the given user" do
+    it 'returns the user learning for the given user' do
       expect(dictionary_entry.user_learning_for(user)).to eq(user_learning)
     end
 
-    it "returns nil if no user learning exists for the given user" do
+    it 'returns nil if no user learning exists for the given user' do
       other_user = create(:user)
       expect(dictionary_entry.user_learning_for(other_user)).to be_nil
     end
   end
 
-  describe ".find_with_associations" do
+  describe '.find_with_associations' do
     let(:dictionary_entry) { create(:dictionary_entry) }
     let(:user) { create(:user) }
     let!(:user_learning) { create(:user_learning, user: user, dictionary_entry: dictionary_entry) }
-    let!(:meaning) { create(:meaning, dictionary_entry: dictionary_entry) }
 
-    it "returns the dictionary entry with associated tags, meanings, and user learning" do
+    before do
+      # Ensure there's a meaning to be found
+      create(:meaning, dictionary_entry: dictionary_entry) if dictionary_entry.meanings.empty?
+    end
+
+    it 'returns the dictionary entry with associated tags, meanings, and user learning' do
       result = DictionaryEntry.find_with_associations(dictionary_entry.id, user)
       expect(result[:entry]).to eq(dictionary_entry)
-      expect(result[:meanings]).to include(meaning)
+      expect(result[:meanings]).to include(dictionary_entry.meanings.first)
       expect(result[:user_learning]).to eq(user_learning)
     end
   end
 
-  describe "#flashcard_meanings" do
+  describe '#flashcard_meanings' do
     let(:entry) { create(:dictionary_entry) }
     let(:cedict_source) do
       create(:source,
-             name: "CC-CEDICT",
-             url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
+             name: 'CC-CEDICT',
+             url: 'https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip')
     end
 
     before { entry.meanings.destroy_all }
 
-    it "keeps CL senses out of flashcard meanings" do
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "CL:個|个[ge4]", pinyin: "gè")
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "to look", pinyin: "kàn")
+    it 'keeps CL senses out of flashcard meanings' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'CL:個|个[ge4]', pinyin: 'gè')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'to look', pinyin: 'kàn')
 
-      expect(entry.flashcard_meanings.map(&:text)).to eq([ "to look" ])
+      expect(entry.reload.flashcard_meanings.map(&:text)).to eq([ 'to look' ])
     end
 
-    it "de-prioritises obscure CC-CEDICT senses when a plain sense exists" do
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "surname Li", pinyin: "Lǐ")
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "plum", pinyin: "lǐ")
+    it 'de-prioritises obscure CC-CEDICT senses when a plain sense exists' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Li', pinyin: 'Lǐ')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'plum', pinyin: 'lǐ')
 
-      expect(entry.flashcard_primary_meaning.text).to eq("plum")
-      expect(entry.flashcard_primary_meaning.pinyin).to eq("lǐ")
-      expect(entry.flashcard_meanings.map(&:text)).to eq([ "plum", "surname Li" ])
+      expect(entry.reload.flashcard_primary_meaning.text).to eq('plum')
+      expect(entry.flashcard_primary_meaning.pinyin).to eq('lǐ')
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ 'plum', 'surname Li' ])
     end
 
-    it "preserves order when only obscure CC-CEDICT senses are available" do
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "surname Zhao", pinyin: "Zhào")
-      create(:meaning, dictionary_entry: entry, source: cedict_source, text: "variant of 趙|赵", pinyin: "Zhào")
+    it 'applies graded deprioritisation for CC-CEDICT senses' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'to look', pinyin: 'kàn')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'classifier for phrases', pinyin: 'kàn')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'literary usage', pinyin: 'kàn')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Kan', pinyin: 'Kàn')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'variant of 看', pinyin: 'kàn')
 
-      expect(entry.flashcard_meanings.map(&:text)).to eq([ "surname Zhao", "variant of 趙|赵" ])
-      expect(entry.flashcard_primary_meaning.text).to eq("surname Zhao")
+      expect(entry.reload.flashcard_meanings.map(&:text)).to eq([
+        'to look',
+        'classifier for phrases',
+        'literary usage',
+        'variant of 看',
+        'surname Kan'
+      ])
     end
 
-    it "does not reorder non-CC-CEDICT meanings" do
-      custom_source = create(:source, name: "Custom Dictionary")
-      create(:meaning, dictionary_entry: entry, source: custom_source, text: "surname Wu", pinyin: "Wú")
-      create(:meaning, dictionary_entry: entry, source: custom_source, text: "martial", pinyin: "wǔ")
+    it 'prefers pinyin groups with richer plain senses' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'convenient', pinyin: 'biàn yí')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'cheap', pinyin: 'pián yi')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'inexpensive', pinyin: 'pián yi')
 
-      expect(entry.flashcard_meanings.map(&:text)).to eq([ "surname Wu", "martial" ])
+      expect(entry.reload.flashcard_primary_meaning.text).to eq('cheap')
+      expect(entry.flashcard_primary_pinyin).to eq('pián yi')
+    end
+
+    it 'preserves order when only obscure CC-CEDICT senses are available' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Zhao', pinyin: 'Zhào')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'variant of 趙|赵', pinyin: 'Zhào')
+
+      expect(entry.reload.flashcard_meanings.map(&:text)).to eq([ 'surname Zhao', 'variant of 趙|赵' ])
+      expect(entry.flashcard_primary_meaning.text).to eq('surname Zhao')
+    end
+
+    it 'does not reorder non-CC-CEDICT meanings' do
+      custom_source = create(:source, name: 'Custom Dictionary')
+      create(:meaning, dictionary_entry: entry, source: custom_source, text: 'surname Wu', pinyin: 'Wú')
+      create(:meaning, dictionary_entry: entry, source: custom_source, text: 'martial', pinyin: 'wǔ')
+
+      expect(entry.reload.flashcard_meanings.map(&:text)).to eq([ 'surname Wu', 'martial' ])
     end
   end
 end

--- a/spec/services/flashcard_primary_meaning_selector_spec.rb
+++ b/spec/services/flashcard_primary_meaning_selector_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe "Flashcard primary meaning selection" do
+  let(:source) { create(:source, name: "CC-CEDICT") }
+
+  def create_entry_with_meanings(text, meanings_attrs)
+    entry = build(:dictionary_entry, text: text, meanings_count: 0)
+    meanings_attrs.each do |attrs|
+      entry.meanings << build(:meaning, attrs.merge(source: source, dictionary_entry: entry))
+    end
+    entry.save!
+    entry
+  end
+
+  describe "for a simple entry with one reading" do
+    it "returns the only meaning" do
+      entry = create_entry_with_meanings("猫", [ { pinyin: "māo", text: "cat" } ])
+      expect(entry.flashcard_primary_meaning.text).to eq("cat")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("māo")
+    end
+  end
+
+  describe "for an entry with a deprioritised surname sense" do
+    it "prefers the common meaning over the surname" do
+      entry = create_entry_with_meanings("赵", [
+        { pinyin: "Zhào", text: "surname Zhao" },
+        { pinyin: "zhào", text: "to surpass" }
+      ])
+      expect(entry.flashcard_primary_meaning.text).to eq("to surpass")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("zhào")
+    end
+  end
+
+  describe "for an entry with a deprioritised literary sense" do
+    it "prefers the common meaning over the literary one" do
+      entry = create_entry_with_meanings("曰", [
+        { pinyin: "yuē", text: "to say (classical literary)" },
+        { pinyin: "yuē", text: "to speak" }
+      ])
+      expect(entry.flashcard_primary_meaning.text).to eq("to speak")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("yuē")
+    end
+  end
+
+  describe "for an entry with an 'also written' variant" do
+    it "prefers the main form" do
+      entry = create_entry_with_meanings("筆畫", [
+        { pinyin: "bǐ huà", text: "stroke (of a Chinese character)" },
+        { pinyin: "bǐ huà", text: "also written 笔画" }
+      ])
+      expect(entry.flashcard_primary_meaning.text).to eq("stroke (of a Chinese character)")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("bǐ huà")
+    end
+  end
+
+  describe "for an entry with multiple pinyin readings" do
+    it "prefers the most common pinyin and its corresponding meaning" do
+      entry = create_entry_with_meanings("好", [
+        { pinyin: "hǎo", text: "good" },
+        { pinyin: "hào", text: "to be fond of" }
+      ])
+      expect(entry.flashcard_primary_meaning.text).to eq("good")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("hǎo")
+    end
+  end
+
+  describe "for an entry where one reading has several plain senses" do
+    it "prefers that reading over a single plain alternative" do
+      entry = create_entry_with_meanings("便宜", [
+        { pinyin: "biàn yí", text: "convenient" },
+        { pinyin: "pián yi", text: "cheap" },
+        { pinyin: "pián yi", text: "inexpensive" }
+      ])
+
+      expect(entry.flashcard_primary_meaning.text).to eq("cheap")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("pián yi")
+    end
+  end
+
+  describe "for a word with a classifier variant" do
+    it "deprioritises the classifier sense" do
+      entry = create_entry_with_meanings("家", [
+        { pinyin: "jiā", text: "home" },
+        { pinyin: "jiā", text: "classifier for families or businesses" }
+      ])
+      expect(entry.flashcard_primary_meaning.text).to eq("home")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("jiā")
+    end
+  end
+
+  describe "when all senses are obscure" do
+    it "returns the first available sense rather than nothing" do
+      entry = create_entry_with_meanings("裔", [ { pinyin: "yì", text: "surname Yi" } ])
+      expect(entry.flashcard_primary_meaning.text).to eq("surname Yi")
+      expect(entry.flashcard_primary_meaning.pinyin).to eq("yì")
+    end
+  end
+end


### PR DESCRIPTION
Closes #274

## Summary
- add focused specs for flashcard meaning selection, including obscurity filters, pinyin-linked primary selection, and the `便宜` polyphonic case
- update `DictionaryEntry#flashcard_meanings` to rank CC-CEDICT senses with weighted penalties and pinyin-group scoring so the default reading aligns with learner-friendly meanings
- keep all dictionary senses available while only changing flashcard default ordering and primary pinyin selection

## Deliberate decisions
- Keep ranking in the application layer rather than adding schema fields in this PR.
  - Why: we needed a fast, reversible fix for learner-facing defaults without a data migration.
  - How: derive priorities from existing `Meaning` text, pinyin, and source metadata at read time.
  - Side effects: rules are explicit in Ruby and easy to tune, but remain heuristic and text-pattern based.
- Use pinyin-group scoring before per-sense scoring.
  - Why: sense-level sorting alone still chose awkward readings for polyphonic entries (for example, `便宜` surfacing `biàn yí` over `pián yi`).
  - How: rank pinyin groups by minimum penalty, number of plain senses, and aggregate penalty, then rank senses within the winning group.
  - Side effects: defaults shift toward readings with richer learner-friendly senses while preserving all meanings.
- Preserve fallback ordering when every CC-CEDICT sense is deprioritised.
  - Why: some entries only have surname/variant/literary senses and should still show a stable default.
  - How: if no plain CC-CEDICT sense exists, retain insertion order after classifier filtering.
  - Side effects: avoids empty or over-engineered fallbacks, though rare entries may still be less intuitive until we add richer metadata.

## Testing
- bundle exec rspec