### PR TITLE
feat: expand related anchors in card views

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -28,16 +28,11 @@ class LearnController < ApplicationController
     @user_learning = current_card
     @position      = session[:learn_index] + 1
     @total         = session[:learn_queue].size
-
-    char      = @user_learning.dictionary_entry.text
-    safe_char = ActiveRecord::Base.sanitize_sql_like(char)
-    @related  = Current.user.user_learnings
-                       .mastered
-                       .joins(:dictionary_entry)
-                       .where("dictionary_entries.text LIKE ?", "%#{safe_char}%")
-                       .where.not(id: @user_learning.id)
-                       .includes(dictionary_entry: { meanings: :source })
-                       .limit(5)
+    @related_anchors = RelatedAnchorBuilder.call(
+      user: Current.user,
+      target_learning: @user_learning,
+      limit: 5
+    )
   end
 
   def submit

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -31,6 +31,11 @@ class ReviewController < ApplicationController
                           .find(@session_card.user_learning_id)
     @position         = current_position + 1
     @total            = @learning_session.card_count
+    @related_anchors  = RelatedAnchorBuilder.call(
+      user: Current.user,
+      target_learning: @user_learning,
+      limit: 5
+    )
   end
 
   def submit

--- a/app/services/related_anchor_builder.rb
+++ b/app/services/related_anchor_builder.rb
@@ -14,82 +14,62 @@ class RelatedAnchorBuilder
   end
 
   def call
-    matches = build_match_map.values
+    return [] if limit <= 0
 
-    matches
-      .sort_by { |result| sort_key(result) }
-      .first(limit)
+    results = full_token_results
+    remaining = limit - results.size
+    return results if remaining <= 0
+
+    results + per_character_results(excluding_ids: results.map { |result| result.user_learning.id }, limit: remaining)
   end
 
   private
 
   attr_reader :user, :target_learning, :limit
 
-  def build_match_map
-    map = {}
-
-    full_token_matches.each do |learning|
-      map[learning.id] = Result.new(
-        user_learning: learning,
-        full_token_match: true,
-        matched_characters: []
-      )
-    end
-
-    per_character_matches.each do |learning, chars|
-      existing = map[learning.id]
-      if existing
-        existing.matched_characters = chars
-      else
-        map[learning.id] = Result.new(
-          user_learning: learning,
-          full_token_match: false,
-          matched_characters: chars
-        )
-      end
-    end
-
-    map
-  end
-
-  def full_token_matches
+  def full_token_results
     target = target_text
     return [] if target.blank?
 
-    mastered_scope
+    ordered_mastered_scope
       .where("dictionary_entries.text LIKE ?", "%#{escape_like(target)}%")
+      .limit(limit)
       .to_a
+      .map do |learning|
+        Result.new(
+          user_learning: learning,
+          full_token_match: true,
+          matched_characters: matching_characters_for(learning, target_characters)
+        )
+      end
   end
 
-  def per_character_matches
+  def per_character_results(excluding_ids:, limit:)
     chars = target_characters
     return [] if chars.empty?
 
     pattern = chars.map { "dictionary_entries.text LIKE ?" }.join(" OR ")
     values = chars.map { |char| "%#{escape_like(char)}%" }
 
-    mastered_scope
+    scope = ordered_mastered_scope
       .where(pattern, *values)
+    scope = scope.where.not(id: excluding_ids) if excluding_ids.any?
+
+    scope
+      .limit(limit)
       .to_a
-      .map { |learning| [ learning, matching_characters_for(learning, chars) ] }
+      .map do |learning|
+        Result.new(
+          user_learning: learning,
+          full_token_match: false,
+          matched_characters: matching_characters_for(learning, chars)
+        )
+      end
   end
 
   def matching_characters_for(learning, chars)
     text = learning.dictionary_entry.text
     chars.select { |char| text.include?(char) }
-  end
-
-  def sort_key(result)
-    [
-      result.full_token_match ? 0 : 1,
-      frequency_presence_rank(result.user_learning.dictionary_entry),
-      result.user_learning.dictionary_entry.frequency_rank || Float::INFINITY,
-      result.user_learning.dictionary_entry.text
-    ]
-  end
-
-  def frequency_presence_rank(entry)
-    entry.frequency_rank.present? ? 0 : 1
   end
 
   def target_text
@@ -100,11 +80,14 @@ class RelatedAnchorBuilder
     target_text.to_s.each_char.uniq
   end
 
-  def mastered_scope
+  def ordered_mastered_scope
     user.user_learnings
         .mastered
         .joins(:dictionary_entry)
         .where.not(id: target_learning.id)
+        .order(Arel.sql("CASE WHEN dictionary_entries.frequency_rank IS NULL THEN 1 ELSE 0 END"))
+        .order("dictionary_entries.frequency_rank ASC")
+        .order("dictionary_entries.text ASC")
         .includes(dictionary_entry: { meanings: :source })
   end
 

--- a/app/services/related_anchor_builder.rb
+++ b/app/services/related_anchor_builder.rb
@@ -1,0 +1,114 @@
+class RelatedAnchorBuilder
+  Result = Struct.new(:user_learning, :full_token_match, :matched_characters, keyword_init: true)
+
+  class << self
+    def call(user:, target_learning:, limit: 5)
+      new(user: user, target_learning: target_learning, limit: limit).call
+    end
+  end
+
+  def initialize(user:, target_learning:, limit:)
+    @user = user
+    @target_learning = target_learning
+    @limit = limit
+  end
+
+  def call
+    matches = build_match_map.values
+
+    matches
+      .sort_by { |result| sort_key(result) }
+      .first(limit)
+  end
+
+  private
+
+  attr_reader :user, :target_learning, :limit
+
+  def build_match_map
+    map = {}
+
+    full_token_matches.each do |learning|
+      map[learning.id] = Result.new(
+        user_learning: learning,
+        full_token_match: true,
+        matched_characters: []
+      )
+    end
+
+    per_character_matches.each do |learning, chars|
+      existing = map[learning.id]
+      if existing
+        existing.matched_characters = chars
+      else
+        map[learning.id] = Result.new(
+          user_learning: learning,
+          full_token_match: false,
+          matched_characters: chars
+        )
+      end
+    end
+
+    map
+  end
+
+  def full_token_matches
+    target = target_text
+    return [] if target.blank?
+
+    mastered_scope
+      .where("dictionary_entries.text LIKE ?", "%#{escape_like(target)}%")
+      .to_a
+  end
+
+  def per_character_matches
+    chars = target_characters
+    return [] if chars.empty?
+
+    pattern = chars.map { "dictionary_entries.text LIKE ?" }.join(" OR ")
+    values = chars.map { |char| "%#{escape_like(char)}%" }
+
+    mastered_scope
+      .where(pattern, *values)
+      .to_a
+      .map { |learning| [ learning, matching_characters_for(learning, chars) ] }
+  end
+
+  def matching_characters_for(learning, chars)
+    text = learning.dictionary_entry.text
+    chars.select { |char| text.include?(char) }
+  end
+
+  def sort_key(result)
+    [
+      result.full_token_match ? 0 : 1,
+      frequency_presence_rank(result.user_learning.dictionary_entry),
+      result.user_learning.dictionary_entry.frequency_rank || Float::INFINITY,
+      result.user_learning.dictionary_entry.text
+    ]
+  end
+
+  def frequency_presence_rank(entry)
+    entry.frequency_rank.present? ? 0 : 1
+  end
+
+  def target_text
+    target_learning.dictionary_entry.text
+  end
+
+  def target_characters
+    target_text.to_s.each_char.uniq
+  end
+
+  def mastered_scope
+    user.user_learnings
+        .mastered
+        .joins(:dictionary_entry)
+        .where.not(id: target_learning.id)
+        .includes(dictionary_entry: { meanings: :source })
+  end
+
+  def escape_like(value)
+    ActiveRecord::Base.sanitize_sql_like(value)
+  end
+end

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -81,27 +81,7 @@
     <%# Contextual panel (shown after "I need to learn this") %>
     <div data-learn-card-target="contextual" class="hidden mt-6 space-y-3">
 
-      <div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4">
-        <% if @related.any? %>
-          <p class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-3">
-            Words you already know containing <span class="font-hanzi text-lg"><%= entry.text %></span>:
-          </p>
-          <ul class="space-y-2">
-            <% @related.each do |rel| %>
-              <% rel_meaning = rel.dictionary_entry.flashcard_primary_meaning %>
-              <li class="flex items-baseline gap-2 text-sm">
-                <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= rel.dictionary_entry.text %></span>
-                <span class="text-gray-400"><%= rel_meaning&.pinyin %></span>
-                <span class="text-gray-600 dark:text-gray-400"><%= rel_meaning&.text %></span>
-              </li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-sm text-gray-400 text-center">
-            No related words in your mastered vocabulary yet.
-          </p>
-        <% end %>
-      </div>
+      <%= render "shared/related_anchors_panel", entry: entry, related_anchors: @related_anchors %>
 
       <%# Radical breakdown placeholder — see issue #146 %>
       <div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-3 text-center opacity-40">

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -55,6 +55,10 @@
               <% end %>
             </div>
           <% end %>
+
+          <div class="mt-6">
+            <%= render "shared/related_anchors_panel", entry: entry, related_anchors: @related_anchors %>
+          </div>
         </div>
       </div>
 

--- a/app/views/shared/_related_anchors_panel.html.erb
+++ b/app/views/shared/_related_anchors_panel.html.erb
@@ -1,0 +1,33 @@
+<div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4">
+  <% if related_anchors.any? %>
+    <p class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-3">
+      Words you already know related to
+      <span class="font-hanzi text-lg"><%= entry.text %></span>:
+    </p>
+    <ul class="space-y-3">
+      <% related_anchors.each do |anchor| %>
+        <% rel_entry = anchor.user_learning.dictionary_entry %>
+        <% rel_meaning = rel_entry.flashcard_primary_meaning %>
+        <li class="text-sm">
+          <div class="flex items-baseline gap-2">
+            <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= rel_entry.text %></span>
+            <span class="text-gray-400"><%= rel_meaning&.pinyin %></span>
+            <span class="text-gray-600 dark:text-gray-400"><%= rel_meaning&.text %></span>
+          </div>
+          <div class="mt-1 flex flex-wrap gap-1">
+            <% if anchor.full_token_match %>
+              <span class="text-[11px] px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">Full token</span>
+            <% end %>
+            <% anchor.matched_characters.each do |character| %>
+              <span class="text-[11px] px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">Char <%= character %></span>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-sm text-gray-400 text-center">
+      No related words in your mastered vocabulary yet.
+    </p>
+  <% end %>
+</div>

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -224,6 +224,35 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include("plum")
         expect(response.body).to include("lǐ")
       end
+
+      it "shows full-token and per-character related anchors with labels" do
+        new_card.dictionary_entry.update!(text: "学习")
+
+        full_entry = create(:dictionary_entry, text: "学习者", frequency_rank: 120)
+        per_entry = create(:dictionary_entry, text: "学校", frequency_rank: 10)
+
+        create(:user_learning, user: user, dictionary_entry: full_entry, state: "mastered")
+        create(:user_learning, user: user, dictionary_entry: per_entry, state: "mastered")
+
+        get learn_card_path
+
+        expect(response.body).to include("Full token")
+        expect(response.body).to include("Char 学")
+      end
+
+      it "orders related anchors by match type then frequency rank" do
+        new_card.dictionary_entry.update!(text: "学习")
+
+        full_entry = create(:dictionary_entry, text: "学习者", frequency_rank: 999)
+        per_entry = create(:dictionary_entry, text: "学校", frequency_rank: 1)
+
+        create(:user_learning, user: user, dictionary_entry: per_entry, state: "mastered")
+        create(:user_learning, user: user, dictionary_entry: full_entry, state: "mastered")
+
+        get learn_card_path
+
+        expect(response.body.index("学习者")).to be < response.body.index("学校")
+      end
     end
 
     context "when authenticated without an active learn session" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -230,6 +230,32 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to include("king")
         expect(response.body).to include("wáng")
       end
+
+      it "shows the related anchors panel with match labels" do
+        user_learning.dictionary_entry.update!(text: "学习")
+
+        full_entry = create(:dictionary_entry, text: "学习者")
+        per_entry = create(:dictionary_entry, text: "学校")
+
+        create(:user_learning, user: user, dictionary_entry: full_entry, state: "mastered")
+        create(:user_learning, user: user, dictionary_entry: per_entry, state: "mastered")
+
+        get review_card_path
+
+        expect(response.body).to include("Words you already know related to")
+        expect(response.body).to include("Full token")
+        expect(response.body).to include("Char 学")
+      end
+
+      it "shows each related entry once even when matching both strategies" do
+        user_learning.dictionary_entry.update!(text: "学习")
+        overlap_entry = create(:dictionary_entry, text: "学习班")
+        create(:user_learning, user: user, dictionary_entry: overlap_entry, state: "mastered")
+
+        get review_card_path
+
+        expect(response.body.scan("学习班").size).to eq(1)
+      end
     end
   end
 

--- a/spec/services/related_anchor_builder_spec.rb
+++ b/spec/services/related_anchor_builder_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe RelatedAnchorBuilder do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:target_entry) { create(:dictionary_entry, text: "学习") }
+    let(:target_learning) do
+      create(:user_learning, user: user, dictionary_entry: target_entry, state: "new")
+    end
+
+    it "deduplicates entries that match both full token and characters" do
+      overlapping_entry = create(:dictionary_entry, text: "学习班")
+      overlapping_learning = create(:user_learning, user: user, dictionary_entry: overlapping_entry, state: "mastered")
+
+      results = described_class.call(user: user, target_learning: target_learning, limit: 5)
+
+      expect(results.count { |result| result.user_learning == overlapping_learning }).to eq(1)
+    end
+
+    it "orders full-token matches before per-character matches" do
+      per_char_entry = create(:dictionary_entry, text: "学校", frequency_rank: 1)
+      full_token_entry = create(:dictionary_entry, text: "学习者", frequency_rank: 300)
+
+      per_char_learning = create(:user_learning, user: user, dictionary_entry: per_char_entry, state: "mastered")
+      full_token_learning = create(:user_learning, user: user, dictionary_entry: full_token_entry, state: "mastered")
+
+      results = described_class.call(user: user, target_learning: target_learning, limit: 5)
+
+      expect(results.first.user_learning).to eq(full_token_learning)
+      expect(results.second.user_learning).to eq(per_char_learning)
+    end
+
+    it "applies frequency rank and then text ordering within each bucket" do
+      full_ranked_high = create(:dictionary_entry, text: "学习班", frequency_rank: 20)
+      full_ranked_low = create(:dictionary_entry, text: "学习者", frequency_rank: 100)
+      full_no_rank = create(:dictionary_entry, text: "学习力", frequency_rank: nil)
+
+      per_ranked = create(:dictionary_entry, text: "学校", frequency_rank: 5)
+      per_no_rank_b = create(:dictionary_entry, text: "习惯", frequency_rank: nil)
+      per_no_rank_a = create(:dictionary_entry, text: "学子", frequency_rank: nil)
+
+      create(:user_learning, user: user, dictionary_entry: full_ranked_low, state: "mastered")
+      create(:user_learning, user: user, dictionary_entry: per_no_rank_b, state: "mastered")
+      create(:user_learning, user: user, dictionary_entry: per_ranked, state: "mastered")
+      create(:user_learning, user: user, dictionary_entry: full_ranked_high, state: "mastered")
+      create(:user_learning, user: user, dictionary_entry: full_no_rank, state: "mastered")
+      create(:user_learning, user: user, dictionary_entry: per_no_rank_a, state: "mastered")
+
+      results = described_class.call(user: user, target_learning: target_learning, limit: 10)
+
+      expect(results.map { |result| result.user_learning.dictionary_entry.text }).to eq(
+        [ "学习班", "学习者", "学习力", "学校", "习惯", "学子" ]
+      )
+    end
+
+    it "includes matched character metadata" do
+      both_chars_entry = create(:dictionary_entry, text: "习学")
+      create(:user_learning, user: user, dictionary_entry: both_chars_entry, state: "mastered")
+
+      result = described_class.call(user: user, target_learning: target_learning, limit: 5).first
+
+      expect(result.full_token_match).to be(false)
+      expect(result.matched_characters).to eq([ "学", "习" ])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `RelatedAnchorBuilder` to merge full-token and per-character mastered-word matches into a single deduplicated list with match metadata
- order related anchors by match strategy first (full token before per-character), then by frequency rank and text, and cap results to five
- render the related-anchor panel in both learn and review card screens with compact chips (`Full token`, `Char <x>`) and add request/service specs for ordering and deduplication

## Testing
- `bundle exec rspec spec/services/related_anchor_builder_spec.rb spec/requests/learn_spec.rb spec/requests/review_spec.rb` (examples pass; process exits non-zero under subset run because SimpleCov minimum is enforced globally)
- `bin/rubocop app/controllers/learn_controller.rb app/controllers/review_controller.rb app/services/related_anchor_builder.rb spec/services/related_anchor_builder_spec.rb spec/requests/learn_spec.rb spec/requests/review_spec.rb`