### PR TITLE
perf: batch wiktionary provisions to speed up task

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary hsk_tags frequency_data].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary hsk_tags wiktionary frequency_data].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|
@@ -36,6 +36,7 @@ module Admin
         dictionary_entries: DictionaryEntry.count,
         hsk_tags:           Tag.where(category: "HSK").count,
         custom_entries:     Meaning.joins(:source).where(sources: { name: "learn_hanzi" }).select(:dictionary_entry_id).distinct.count,
+        wiktionary_entries: Meaning.joins(:source).where(sources: { name: "Wiktionary" }).select(:dictionary_entry_id).distinct.count,
         frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count
       }
     end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary hsk_tags wiktionary frequency_data].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary hsk_tags frequency_data].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|

--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -4,7 +4,7 @@ require "zip"
 module ImportFilesHelper
   def download_file_to_tmp(url, destination)
     FileUtils.mkdir_p(File.dirname(destination))
-    URI.open(url) do |remote_file|
+    URI(url).open do |remote_file|
       File.open(destination, "wb") do |local_file|
         IO.copy_stream(remote_file, local_file)
       end

--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -4,8 +4,10 @@ require "zip"
 module ImportFilesHelper
   def download_file_to_tmp(url, destination)
     FileUtils.mkdir_p(File.dirname(destination))
-    File.open(destination, "wb") do |file|
-      file.write(URI(url).open.read)
+    URI.open(url) do |remote_file|
+      File.open(destination, "wb") do |local_file|
+        IO.copy_stream(remote_file, local_file)
+      end
     end
   end
 

--- a/app/jobs/admin/provisioning_job.rb
+++ b/app/jobs/admin/provisioning_job.rb
@@ -6,7 +6,8 @@ module Admin
       "cc_cedict"          => Admin::CcCedictProvisioningService,
       "hsk_tags"           => Admin::HskTagsProvisioningService,
       "custom_dictionary"  => Admin::CustomDictionaryProvisioningService,
-      "frequency_data"     => Admin::FrequencyProvisioningService
+      "frequency_data"     => Admin::FrequencyProvisioningService,
+      "wiktionary"         => Admin::WiktionaryProvisioningService
     }.freeze
 
     def perform(task_id)
@@ -22,6 +23,7 @@ module Admin
         summary:      result.to_json
       )
     rescue => e
+      Sentry.capture_exception(e) if defined?(Sentry)
       Rails.logger.error(
         [
           "Admin::ProvisioningJob failed for task_id=#{task_id}",

--- a/app/models/admin_task.rb
+++ b/app/models/admin_task.rb
@@ -1,5 +1,5 @@
 class AdminTask < ApplicationRecord
-  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data].freeze
+  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data wiktionary].freeze
   VALID_STATES     = %w[pending running complete failed].freeze
 
   validates :task_type, presence: true, inclusion: { in: VALID_TASK_TYPES }

--- a/app/services/admin/wiktionary_provisioning_service.rb
+++ b/app/services/admin/wiktionary_provisioning_service.rb
@@ -19,10 +19,16 @@ module Admin
 
       source = Source.find_or_create_by!(name: "Wiktionary") do |s|
         s.url = WIKTIONARY_URL
-        s.date_accessed = Time.current
+        s.date_accessed = Time.zone.today
         s.priority = 10
       end
-      source.update!(priority: 10) if source.priority != 10
+
+      source_attrs = {
+        url: WIKTIONARY_URL,
+        date_accessed: Time.zone.today,
+        priority: 10
+      }
+      source.update!(source_attrs) if source.slice(*source_attrs.keys.map(&:to_s)) != source_attrs.stringify_keys
 
       created_meanings = 0
       batch = []

--- a/app/services/admin/wiktionary_provisioning_service.rb
+++ b/app/services/admin/wiktionary_provisioning_service.rb
@@ -1,0 +1,129 @@
+require "zlib"
+require "json"
+
+module Admin
+  class WiktionaryProvisioningService
+    include ImportFilesHelper
+
+    WIKTIONARY_URL = "https://kaikki.org/dictionary/Chinese/kaikki.org-dictionary-Chinese.jsonl.gz"
+    WIKTIONARY_FILE = Rails.root.join("tmp", "kaikki_chinese.jsonl.gz")
+
+    def self.call
+      new.call
+    end
+
+    def call
+      entries_before = Meaning.joins(:source).where(sources: { name: "Wiktionary" }).count
+
+      download_file_to_tmp(WIKTIONARY_URL, WIKTIONARY_FILE)
+
+      source = Source.find_or_create_by!(name: "Wiktionary") do |s|
+        s.url = WIKTIONARY_URL
+        s.date_accessed = Time.current
+        s.priority = 10
+      end
+      source.update!(priority: 10) if source.priority != 10
+
+      created_meanings = 0
+      batch = []
+
+      Zlib::GzipReader.open(WIKTIONARY_FILE) do |gz|
+        gz.each_line do |line|
+          begin
+            parsed = JSON.parse(line)
+            next unless parsed["lang"] == "Chinese"
+
+            word = parsed["word"]
+            next if word.blank?
+
+            # Extract glosses (meanings)
+            senses = parsed["senses"]&.flat_map { |s| s["glosses"] }&.compact
+            next if senses.blank?
+
+            # Extract pinyin
+            pinyin = "Unknown"
+            if parsed["sounds"]
+              pinyin_sound = parsed["sounds"].find do |sound|
+                tags = sound["tags"] || []
+                tags.include?("Mandarin") && tags.include?("Pinyin") && sound["zh_pron"]
+              end
+              if pinyin_sound
+                # Clean up "jū (ju¹)" -> "jū"
+                pinyin = pinyin_sound["zh_pron"].sub(/\s*\(.*\)$/, "").strip
+              end
+            end
+
+            # Skip entries with no hanzi characters
+            next unless word.match?(/\p{Han}/)
+
+            meaning_text = senses.join("; ")
+
+            batch << {
+              word: word,
+              meaning_text: meaning_text,
+              pinyin: pinyin
+            }
+
+            if batch.size >= 1000
+              created_meanings += process_batch(batch, source)
+              batch.clear
+            end
+
+          rescue JSON::ParserError
+            # skip malformed lines
+            next
+          end
+        end
+      end
+
+      # Process remaining items in the last batch
+      if batch.any?
+        created_meanings += process_batch(batch, source)
+        batch.clear
+      end
+
+      entries_after = Meaning.joins(:source).where(sources: { name: "Wiktionary" }).count
+
+      { entries_before: entries_before, entries_after: entries_after, created_meanings: created_meanings }
+    end
+
+    private
+
+    def process_batch(batch, source)
+      words = batch.map { |item| item[:word] }.uniq
+
+      DictionaryEntry.insert_all(
+        words.map { |w| { text: w } },
+        unique_by: :text
+      )
+
+      entry_id_map = DictionaryEntry.where(text: words).pluck(:text, :id).to_h
+
+      meaning_rows = batch.filter_map do |item|
+        entry_id = entry_id_map[item[:word]]
+        next unless entry_id
+
+        {
+          dictionary_entry_id: entry_id,
+          text: item[:meaning_text],
+          language: "en",
+          pinyin: item[:pinyin],
+          source_id: source.id
+        }
+      end
+
+      # Ensure no duplicate meaning rows within the batch itself
+      meaning_rows.uniq! { |m| [ m[:dictionary_entry_id], m[:language], m[:text], m[:pinyin], m[:source_id] ] }
+
+      if meaning_rows.any?
+        result = Meaning.insert_all(
+          meaning_rows,
+          unique_by: [ :dictionary_entry_id, :language, :text, :pinyin, :source_id ]
+        )
+        result.count
+      else
+        0
+      end
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <%# Task cards %>
-  <div class="grid gap-4 sm:grid-cols-4">
+  <div class="grid gap-4 sm:grid-cols-5">
 
     <%= render "task_card",
           label:     "CC-CEDICT dictionary",
@@ -30,6 +30,13 @@
           task_type: "custom_dictionary",
           task:      @tasks_by_type["custom_dictionary"],
           db_count:  @db_stats[:custom_entries],
+          unit:      "entries" %>
+
+    <%= render "task_card",
+          label:     "Wiktionary entries",
+          task_type: "wiktionary",
+          task:      @tasks_by_type["wiktionary"],
+          db_count:  @db_stats[:wiktionary_entries],
           unit:      "entries" %>
 
     <%= render "task_card",

--- a/db/migrate/20260508144551_add_priority_to_sources.rb
+++ b/db/migrate/20260508144551_add_priority_to_sources.rb
@@ -1,0 +1,5 @@
+class AddPriorityToSources < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sources, :priority, :integer, default: 100, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_144551) do
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -125,6 +125,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
     t.datetime "created_at", null: false
     t.date "date_accessed"
     t.string "name"
+    t.integer "priority", default: 100, null: false
     t.datetime "updated_at", null: false
     t.string "url"
   end

--- a/lib/tasks/dictionary_import.rake
+++ b/lib/tasks/dictionary_import.rake
@@ -83,7 +83,7 @@ namespace :dictionary_import do
 
     elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
     puts "\nDone! Completed in #{elapsed.round(2)}s"
-    puts "Wiktionary meanings created/updated: #{result[:created_meanings]}"
+    puts "Wiktionary meanings created: #{result[:created_meanings]}"
     puts "Total Wiktionary meanings in database: #{result[:entries_after]}"
   end
 end

--- a/lib/tasks/dictionary_import.rake
+++ b/lib/tasks/dictionary_import.rake
@@ -73,4 +73,17 @@ namespace :dictionary_import do
 
     puts "Done! #{created} entries created, #{updated} already existed."
   end
+
+  desc "Import Wiktionary dictionary entries from kaikki.org JSONL"
+  task wiktionary: :environment do
+    puts "Starting Wiktionary import..."
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    result = Admin::WiktionaryProvisioningService.call
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+    puts "\nDone! Completed in #{elapsed.round(2)}s"
+    puts "Wiktionary meanings created/updated: #{result[:created_meanings]}"
+    puts "Total Wiktionary meanings in database: #{result[:entries_after]}"
+  end
 end

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -81,13 +81,13 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
 
       it "enqueues a job for each unlocked task type" do
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(4).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(5).times
         post admin_provision_all_path
       end
 
       it "does not enqueue a job for a locked task type" do
         create(:admin_task, task_type: "cc_cedict", state: "running")
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(3).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(4).times
         post admin_provision_all_path
       end
 

--- a/spec/services/admin/wiktionary_provisioning_service_spec.rb
+++ b/spec/services/admin/wiktionary_provisioning_service_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Admin::WiktionaryProvisioningService do
+  describe ".call" do
+    subject(:result) { described_class.call }
+
+    let(:jsonl_content) do
+      [
+        { "lang" => "English", "word" => "skip_me" }.to_json,
+        { "lang" => "Chinese", "word" => "abc", "senses" => [{"glosses" => ["skip non hanzi"]}] }.to_json,
+        {
+          "lang" => "Chinese",
+          "word" => "好",
+          "senses" => [{"glosses" => ["good"]}],
+          "sounds" => [{"tags" => ["Mandarin", "Pinyin"], "zh_pron" => "hǎo (hao3)"}]
+        }.to_json,
+        {
+          "lang" => "Chinese",
+          "word" => "不好",
+          "senses" => [{"glosses" => ["bad"]}],
+          "sounds" => [{"tags" => ["Mandarin", "Pinyin"], "zh_pron" => "bù hǎo"}]
+        }.to_json,
+        "invalid json {"
+      ].join("\n")
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:download_file_to_tmp)
+      
+      mock_gz = instance_double(Zlib::GzipReader)
+      allow(Zlib::GzipReader).to receive(:open).and_yield(mock_gz)
+      allow(mock_gz).to receive(:each_line).and_yield(jsonl_content.split("\n")[0])
+                                            .and_yield(jsonl_content.split("\n")[1])
+                                            .and_yield(jsonl_content.split("\n")[2])
+                                            .and_yield(jsonl_content.split("\n")[3])
+                                            .and_yield(jsonl_content.split("\n")[4])
+    end
+
+    it "creates a wiktionary source if it does not exist" do
+      expect { result }.to change { Source.where(name: "Wiktionary").count }.by(1)
+    end
+
+    it "creates dictionary entries and meanings for valid chinese hanzi records" do
+      expect { result }.to change { DictionaryEntry.count }.by(2)
+                       .and change { Meaning.count }.by(2)
+                       
+      entry = DictionaryEntry.find_by(text: "好")
+      meaning = entry.meanings.first
+      expect(meaning.text).to eq("good")
+      expect(meaning.pinyin).to eq("hǎo")
+      expect(meaning.source.name).to eq("Wiktionary")
+    end
+
+    it "returns the before, after, and created counts" do
+      expect(result).to include(
+        entries_before: 0,
+        entries_after: 2,
+        created_meanings: 2
+      )
+    end
+    
+    it "handles BATCH_SIZE correctly by flushing batches" do
+      stub_const("Admin::WiktionaryProvisioningService::BATCH_SIZE", 1)
+      expect { result }.to change { DictionaryEntry.count }.by(2)
+                       .and change { Meaning.count }.by(2)
+    end
+  end
+end

--- a/spec/services/admin/wiktionary_provisioning_service_spec.rb
+++ b/spec/services/admin/wiktionary_provisioning_service_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe Admin::WiktionaryProvisioningService do
     let(:jsonl_content) do
       [
         { "lang" => "English", "word" => "skip_me" }.to_json,
-        { "lang" => "Chinese", "word" => "abc", "senses" => [{"glosses" => ["skip non hanzi"]}] }.to_json,
+        { "lang" => "Chinese", "word" => "abc", "senses" => [ { "glosses" => [ "skip non hanzi" ] } ] }.to_json,
         {
           "lang" => "Chinese",
           "word" => "好",
-          "senses" => [{"glosses" => ["good"]}],
-          "sounds" => [{"tags" => ["Mandarin", "Pinyin"], "zh_pron" => "hǎo (hao3)"}]
+          "senses" => [ { "glosses" => [ "good" ] } ],
+          "sounds" => [ { "tags" => [ "Mandarin", "Pinyin" ], "zh_pron" => "hǎo (hao3)" } ]
         }.to_json,
         {
           "lang" => "Chinese",
           "word" => "不好",
-          "senses" => [{"glosses" => ["bad"]}],
-          "sounds" => [{"tags" => ["Mandarin", "Pinyin"], "zh_pron" => "bù hǎo"}]
+          "senses" => [ { "glosses" => [ "bad" ] } ],
+          "sounds" => [ { "tags" => [ "Mandarin", "Pinyin" ], "zh_pron" => "bù hǎo" } ]
         }.to_json,
         "invalid json {"
       ].join("\n")
@@ -26,7 +26,7 @@ RSpec.describe Admin::WiktionaryProvisioningService do
 
     before do
       allow_any_instance_of(described_class).to receive(:download_file_to_tmp)
-      
+
       mock_gz = instance_double(Zlib::GzipReader)
       allow(Zlib::GzipReader).to receive(:open).and_yield(mock_gz)
       allow(mock_gz).to receive(:each_line).and_yield(jsonl_content.split("\n")[0])
@@ -43,7 +43,7 @@ RSpec.describe Admin::WiktionaryProvisioningService do
     it "creates dictionary entries and meanings for valid chinese hanzi records" do
       expect { result }.to change { DictionaryEntry.count }.by(2)
                        .and change { Meaning.count }.by(2)
-                       
+
       entry = DictionaryEntry.find_by(text: "好")
       meaning = entry.meanings.first
       expect(meaning.text).to eq("good")
@@ -58,7 +58,7 @@ RSpec.describe Admin::WiktionaryProvisioningService do
         created_meanings: 2
       )
     end
-    
+
     it "handles BATCH_SIZE correctly by flushing batches" do
       stub_const("Admin::WiktionaryProvisioningService::BATCH_SIZE", 1)
       expect { result }.to change { DictionaryEntry.count }.by(2)


### PR DESCRIPTION
## Summary
* Integrates the Wiktionary import service with the Admin provisioning dashboard
* Highly optimizes the Wiktionary parsing loop to accumulate 1000 items in memory at a time and uses `insert_all` to significantly reduce database overhead.
* Keeps the memory footprint extremely low by streaming the JSONL GZ file, ensuring it never loads the entire file into memory (more efficient than the current CC-CEDICT strategy).
* Fixes broken test expectations in `dashboard_spec.rb` caused by the addition of the 5th task type.