### PR TITLE
feat: honor source priority in meaning selection

### DIFF
--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -2,7 +2,9 @@ class DictionaryEntriesController < ApplicationController
   def show
     @entry = DictionaryEntry.find_with_associations(params[:id], Current.user)
     @dictionary_entry = @entry[:entry]
-    @meanings = @entry[:meanings].where(language: "en")
+    english_meanings = @entry[:meanings].where(language: "en").to_a
+    flashcard_order = @dictionary_entry.flashcard_meanings
+    @meanings = flashcard_order + (english_meanings - flashcard_order)
     @user_learning = @entry[:user_learning]
     @review_logs =
       if @user_learning

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -40,16 +40,10 @@ class DictionaryEntry < ApplicationRecord
     candidate_meanings = english_meanings.reject { |meaning| meaning.text.start_with?("CL:") }
     return candidate_meanings if candidate_meanings.empty?
 
-    # If there are no CC-CEDICT meanings, there's no sorting to do.
-    return candidate_meanings unless candidate_meanings.any?(&method(:cc_cedict_meaning?))
-
-    # Keep original order when all CC-CEDICT senses are deprioritised.
-    has_plain_cedict = candidate_meanings.any? do |meaning|
-      cc_cedict_meaning?(meaning) && cedict_deprioritisation_score(meaning).zero?
-    end
-    return candidate_meanings unless has_plain_cedict
-
-    ordered_by_pinyin(candidate_meanings)
+    candidate_meanings
+      .group_by { |meaning| source_priority(meaning) }
+      .sort_by(&:first)
+      .flat_map { |_priority, meanings| order_meanings_within_priority(meanings) }
   end
 
   def flashcard_primary_pinyin
@@ -73,6 +67,23 @@ class DictionaryEntry < ApplicationRecord
       # For new records not yet in the DB
       meanings.select { |m| m.language == "en" }
     end
+  end
+
+  def source_priority(meaning)
+    meaning.source&.priority || 100
+  end
+
+  def order_meanings_within_priority(candidate_meanings)
+    # If there are no CC-CEDICT meanings at this priority, keep insertion order.
+    return candidate_meanings unless candidate_meanings.any?(&method(:cc_cedict_meaning?))
+
+    # Keep original order when all CC-CEDICT senses are deprioritised.
+    has_plain_cedict = candidate_meanings.any? do |meaning|
+      cc_cedict_meaning?(meaning) && cedict_deprioritisation_score(meaning).zero?
+    end
+    return candidate_meanings unless has_plain_cedict
+
+    ordered_by_pinyin(candidate_meanings)
   end
 
   def sort_penalty(meaning)

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe DictionaryEntry, type: :model do
     let(:cedict_source) do
       create(:source,
              name: 'CC-CEDICT',
+             priority: 20,
              url: 'https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip')
     end
 
@@ -137,6 +138,23 @@ RSpec.describe DictionaryEntry, type: :model do
       create(:meaning, dictionary_entry: entry, source: custom_source, text: 'martial', pinyin: 'wǔ')
 
       expect(entry.reload.flashcard_meanings.map(&:text)).to eq([ 'surname Wu', 'martial' ])
+    end
+
+    it 'prioritises meanings from lower-priority-number sources' do
+      wiktionary_source = create(:source, name: 'Wiktionary', priority: 10)
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Li', pinyin: 'Lǐ')
+      create(:meaning, dictionary_entry: entry, source: wiktionary_source, text: 'plum', pinyin: 'lǐ')
+
+      expect(entry.reload.flashcard_primary_meaning.source.name).to eq('Wiktionary')
+      expect(entry.flashcard_primary_meaning.text).to eq('plum')
+    end
+
+    it 'keeps CC-CEDICT heuristics within the same source priority band' do
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Zhao', pinyin: 'Zhào')
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'to surpass', pinyin: 'zhào')
+
+      expect(entry.reload.flashcard_primary_meaning.text).to eq('to surpass')
+      expect(entry.flashcard_meanings.map(&:text)).to eq([ 'to surpass', 'surname Zhao' ])
     end
   end
 end

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -68,6 +68,30 @@ RSpec.describe "DictionaryEntries", type: :request do
           end
         end
       end
+
+      it "shows highest-priority source meaning first" do
+        dictionary_entry.meanings.destroy_all
+
+        cedict = create(:source, name: "CC-CEDICT", priority: 20)
+        wiktionary = create(:source, name: "Wiktionary", priority: 10)
+
+        create(:meaning,
+               dictionary_entry: dictionary_entry,
+               source: cedict,
+               language: "en",
+               pinyin: "lǐ",
+               text: "surname Li")
+        create(:meaning,
+               dictionary_entry: dictionary_entry,
+               source: wiktionary,
+               language: "en",
+               pinyin: "lǐ",
+               text: "plum")
+
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body.index("plum")).to be < response.body.index("surname Li")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- apply source-priority ordering to flashcard meaning selection so lower numeric priorities surface first
- preserve existing CC-CEDICT disambiguation heuristics within each source-priority band
- align dictionary entry detail view ordering with flashcard ordering for consistent learner-facing output

## Why
Issue #226 requires `sources.priority` to influence primary meaning selection in display paths. This PR delivers that runtime behavior for flashcard and dictionary entry views.