### PR TITLE
feat: add Unihan kDefinition provisioning task

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary hsk_tags frequency_data].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary unihan hsk_tags frequency_data].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|
@@ -37,6 +37,7 @@ module Admin
         hsk_tags:           Tag.where(category: "HSK").count,
         custom_entries:     Meaning.joins(:source).where(sources: { name: "learn_hanzi" }).select(:dictionary_entry_id).distinct.count,
         wiktionary_entries: Meaning.joins(:source).where(sources: { name: "Wiktionary" }).select(:dictionary_entry_id).distinct.count,
+        unihan_entries:     Meaning.joins(:source).where(sources: { name: "Unihan" }).select(:dictionary_entry_id).distinct.count,
         frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count
       }
     end

--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -2,7 +2,10 @@ class DictionaryEntriesController < ApplicationController
   def show
     @entry = DictionaryEntry.find_with_associations(params[:id], Current.user)
     @dictionary_entry = @entry[:entry]
-    english_meanings = @entry[:meanings].where(language: "en").to_a
+    preloaded_meanings = @entry[:meanings].to_a
+    @dictionary_entry.association(:meanings).target = preloaded_meanings
+
+    english_meanings = preloaded_meanings.select { |meaning| meaning.language == "en" }
     flashcard_order = @dictionary_entry.flashcard_meanings
     @meanings = flashcard_order + (english_meanings - flashcard_order)
     @user_learning = @entry[:user_learning]

--- a/app/jobs/admin/provisioning_job.rb
+++ b/app/jobs/admin/provisioning_job.rb
@@ -7,7 +7,8 @@ module Admin
       "hsk_tags"           => Admin::HskTagsProvisioningService,
       "custom_dictionary"  => Admin::CustomDictionaryProvisioningService,
       "frequency_data"     => Admin::FrequencyProvisioningService,
-      "wiktionary"         => Admin::WiktionaryProvisioningService
+      "wiktionary"         => Admin::WiktionaryProvisioningService,
+      "unihan"             => Admin::UnihanProvisioningService
     }.freeze
 
     def perform(task_id)

--- a/app/models/admin_task.rb
+++ b/app/models/admin_task.rb
@@ -1,5 +1,5 @@
 class AdminTask < ApplicationRecord
-  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data wiktionary].freeze
+  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data wiktionary unihan].freeze
   VALID_STATES     = %w[pending running complete failed].freeze
 
   validates :task_type, presence: true, inclusion: { in: VALID_TASK_TYPES }

--- a/app/services/admin/unihan_provisioning_service.rb
+++ b/app/services/admin/unihan_provisioning_service.rb
@@ -1,0 +1,157 @@
+require "set"
+
+module Admin
+  class UnihanProvisioningService
+    include ImportFilesHelper
+
+    UNIHAN_URL = "https://www.unicode.org/Public/UCD/latest/ucd/Unihan.zip"
+    UNIHAN_ZIP = Rails.root.join("tmp", "unihan", "Unihan.zip")
+    UNIHAN_DIR = Rails.root.join("tmp", "unihan")
+    UNIHAN_READINGS_FILE = Rails.root.join("tmp", "unihan", "Unihan_Readings.txt")
+    BATCH_SIZE = 1000
+
+    def self.call
+      new.call
+    end
+
+    def call
+      meanings_before = Meaning.joins(:source).where(sources: { name: "Unihan" }).count
+
+      download_file_to_tmp(UNIHAN_URL, UNIHAN_ZIP)
+      unzip_file(UNIHAN_ZIP, UNIHAN_DIR)
+      confirm_file_presence("Unihan_Readings.txt", UNIHAN_DIR)
+
+      source = find_or_sync_source
+
+      parsed_rows = 0
+      created_meanings = 0
+      skipped_higher_priority = 0
+      batch = []
+
+      File.foreach(UNIHAN_READINGS_FILE, chomp: true) do |line|
+        parsed = parse_kdefinition_line(line)
+        next unless parsed
+
+        parsed_rows += 1
+        batch << parsed
+
+        next unless batch.size >= BATCH_SIZE
+
+        result = process_batch(batch, source)
+        created_meanings += result[:created_meanings]
+        skipped_higher_priority += result[:skipped_higher_priority]
+        batch.clear
+      end
+
+      if batch.any?
+        result = process_batch(batch, source)
+        created_meanings += result[:created_meanings]
+        skipped_higher_priority += result[:skipped_higher_priority]
+        batch.clear
+      end
+
+      meanings_after = Meaning.joins(:source).where(sources: { name: "Unihan" }).count
+
+      {
+        definitions_parsed: parsed_rows,
+        meanings_before: meanings_before,
+        meanings_after: meanings_after,
+        meanings_created: created_meanings,
+        skipped_higher_priority: skipped_higher_priority
+      }
+    end
+
+    private
+
+    def find_or_sync_source
+      source = Source.find_or_create_by!(name: "Unihan") do |s|
+        s.url = UNIHAN_URL
+        s.date_accessed = Time.zone.today
+        s.priority = 50
+      end
+
+      attrs = {
+        url: UNIHAN_URL,
+        date_accessed: Time.zone.today,
+        priority: 50
+      }
+      source.update!(attrs) if source.slice(*attrs.keys.map(&:to_s)) != attrs.stringify_keys
+      source
+    end
+
+    def parse_kdefinition_line(line)
+      return if line.start_with?("#")
+
+      codepoint, property, value = line.split("\t", 3)
+      return unless property == "kDefinition"
+      return if codepoint.blank? || value.blank?
+
+      match = codepoint.match(/\AU\+([0-9A-F]{4,6})\z/)
+      return unless match
+
+      char = [ match[1].to_i(16) ].pack("U")
+      return unless char.match?(/\p{Han}/)
+
+      definition = value.strip
+      return if definition.blank?
+
+      { word: char, definition: definition }
+    end
+
+    def process_batch(batch, source)
+      words = batch.map { |row| row[:word] }.uniq
+
+      DictionaryEntry.insert_all(
+        words.map { |word| { text: word } },
+        unique_by: :text
+      )
+
+      entry_id_map = DictionaryEntry.where(text: words).pluck(:text, :id).to_h
+      blocked_entry_ids = entry_ids_with_higher_priority_meanings(entry_id_map.values, source.priority)
+
+      meaning_rows = batch.filter_map do |row|
+        entry_id = entry_id_map[row[:word]]
+        next unless entry_id
+        next if blocked_entry_ids.include?(entry_id)
+
+        {
+          dictionary_entry_id: entry_id,
+          text: row[:definition],
+          language: "en",
+          pinyin: "Unknown",
+          source_id: source.id
+        }
+      end
+
+      meaning_rows.uniq! { |row| [ row[:dictionary_entry_id], row[:language], row[:text], row[:pinyin], row[:source_id] ] }
+
+      if meaning_rows.any?
+        result = Meaning.insert_all(
+          meaning_rows,
+          unique_by: [ :dictionary_entry_id, :language, :text, :pinyin, :source_id ]
+        )
+        created = result.count
+      else
+        created = 0
+      end
+
+      {
+        created_meanings: created,
+        skipped_higher_priority: batch.size - meaning_rows.size
+      }
+    end
+
+    def entry_ids_with_higher_priority_meanings(entry_ids, source_priority)
+      return Set.new if entry_ids.empty?
+
+      Meaning
+        .joins(:source)
+        .where(dictionary_entry_id: entry_ids)
+        .where(language: "en")
+        .where("sources.priority < ?", source_priority)
+        .distinct
+        .pluck(:dictionary_entry_id)
+        .to_set
+    end
+  end
+end

--- a/app/services/admin/unihan_provisioning_service.rb
+++ b/app/services/admin/unihan_provisioning_service.rb
@@ -108,11 +108,15 @@ module Admin
 
       entry_id_map = DictionaryEntry.where(text: words).pluck(:text, :id).to_h
       blocked_entry_ids = entry_ids_with_higher_priority_meanings(entry_id_map.values, source.priority)
+      skipped_higher_priority = 0
 
       meaning_rows = batch.filter_map do |row|
         entry_id = entry_id_map[row[:word]]
         next unless entry_id
-        next if blocked_entry_ids.include?(entry_id)
+        if blocked_entry_ids.include?(entry_id)
+          skipped_higher_priority += 1
+          next
+        end
 
         {
           dictionary_entry_id: entry_id,
@@ -137,7 +141,7 @@ module Admin
 
       {
         created_meanings: created,
-        skipped_higher_priority: batch.size - meaning_rows.size
+        skipped_higher_priority: skipped_higher_priority
       }
     end
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <%# Task cards %>
-  <div class="grid gap-4 sm:grid-cols-5">
+  <div class="grid gap-4 sm:grid-cols-6">
 
     <%= render "task_card",
           label:     "CC-CEDICT dictionary",
@@ -37,6 +37,13 @@
           task_type: "wiktionary",
           task:      @tasks_by_type["wiktionary"],
           db_count:  @db_stats[:wiktionary_entries],
+          unit:      "entries" %>
+
+    <%= render "task_card",
+          label:     "Unihan definitions",
+          task_type: "unihan",
+          task:      @tasks_by_type["unihan"],
+          db_count:  @db_stats[:unihan_entries],
           unit:      "entries" %>
 
     <%= render "task_card",

--- a/lib/tasks/dictionary_import.rake
+++ b/lib/tasks/dictionary_import.rake
@@ -86,4 +86,19 @@ namespace :dictionary_import do
     puts "Wiktionary meanings created: #{result[:created_meanings]}"
     puts "Total Wiktionary meanings in database: #{result[:entries_after]}"
   end
+
+  desc "Import Unihan kDefinition data"
+  task unihan: :environment do
+    puts "Starting Unihan import..."
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    result = Admin::UnihanProvisioningService.call
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+    puts "\nDone! Completed in #{elapsed.round(2)}s"
+    puts "Unihan definitions parsed: #{result[:definitions_parsed]}"
+    puts "Unihan meanings created: #{result[:meanings_created]}"
+    puts "Skipped due to higher-priority meanings: #{result[:skipped_higher_priority]}"
+    puts "Total Unihan meanings in database: #{result[:meanings_after]}"
+  end
 end

--- a/spec/jobs/admin/provisioning_job_spec.rb
+++ b/spec/jobs/admin/provisioning_job_spec.rb
@@ -85,4 +85,19 @@ RSpec.describe Admin::ProvisioningJob, type: :job do
 
     include_examples "a provisioning job", Admin::FrequencyProvisioningService
   end
+
+  describe "#perform for unihan" do
+    let(:task_type) { "unihan" }
+    let(:summary_result) do
+      {
+        definitions_parsed: 2,
+        meanings_before: 0,
+        meanings_after: 2,
+        meanings_created: 2,
+        skipped_higher_priority: 0
+      }
+    end
+
+    include_examples "a provisioning job", Admin::UnihanProvisioningService
+  end
 end

--- a/spec/models/admin_task_spec.rb
+++ b/spec/models/admin_task_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe AdminTask, type: :model do
     it "includes frequency_data for admin provisioning" do
       expect(AdminTask::VALID_TASK_TYPES).to include("frequency_data")
     end
+
+    it "includes unihan for admin provisioning" do
+      expect(AdminTask::VALID_TASK_TYPES).to include("unihan")
+    end
   end
 
   describe ".in_progress" do

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -81,13 +81,13 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
 
       it "enqueues a job for each unlocked task type" do
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(5).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(6).times
         post admin_provision_all_path
       end
 
       it "does not enqueue a job for a locked task type" do
         create(:admin_task, task_type: "cc_cedict", state: "running")
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(4).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(5).times
         post admin_provision_all_path
       end
 

--- a/spec/services/admin/unihan_provisioning_service_spec.rb
+++ b/spec/services/admin/unihan_provisioning_service_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Admin::UnihanProvisioningService do
+  describe ".call" do
+    subject(:result) { described_class.call }
+
+    let(:readings_path) { Admin::UnihanProvisioningService::UNIHAN_READINGS_FILE }
+
+    let(:readings_content) do
+      <<~TXT
+        # Unihan test subset
+        U+4F60\tkDefinition\tyou, second person pronoun
+        U+597D\tkDefinition\tgood, well
+        U+0061\tkDefinition\tlatin letter a
+        U+597D\tkMandarin\thao3
+      TXT
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:download_file_to_tmp)
+      allow_any_instance_of(described_class).to receive(:unzip_file)
+      allow_any_instance_of(described_class).to receive(:confirm_file_presence)
+
+      FileUtils.mkdir_p(File.dirname(readings_path))
+      File.write(readings_path, readings_content)
+    end
+
+    after do
+      FileUtils.rm_f(readings_path)
+    end
+
+    it "creates a Unihan source with expected priority" do
+      expect { result }.to change { Source.where(name: "Unihan").count }.by(1)
+      expect(Source.find_by(name: "Unihan").priority).to eq(50)
+    end
+
+    it "imports only kDefinition rows for Han characters" do
+      expect { result }.to change { DictionaryEntry.count }.by(2)
+                       .and change { Meaning.count }.by(2)
+
+      ni = DictionaryEntry.find_by!(text: "你")
+      hao = DictionaryEntry.find_by!(text: "好")
+
+      expect(ni.meanings.first.text).to eq("you, second person pronoun")
+      expect(hao.meanings.first.text).to eq("good, well")
+    end
+
+    it "skips importing meanings when higher-priority source meaning exists" do
+      wiktionary = create(:source, name: "Wiktionary", priority: 10)
+      entry = create(:dictionary_entry, text: "你")
+      entry.meanings.destroy_all
+      create(:meaning,
+             dictionary_entry: entry,
+             source: wiktionary,
+             language: "en",
+             pinyin: "nǐ",
+             text: "you")
+
+      expect { result }.to change { Meaning.count }.by(1)
+      expect(result[:skipped_higher_priority]).to eq(1)
+      expect(entry.reload.meanings.where(source: Source.find_by(name: "Unihan")).count).to eq(0)
+    end
+
+    it "returns import summary stats" do
+      expect(result).to include(
+        definitions_parsed: 2,
+        meanings_created: 2,
+        skipped_higher_priority: 0
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `Admin::UnihanProvisioningService` to import Unihan `kDefinition` data in batches
- add `dictionary_import:unihan` rake task and wire Unihan into admin provisioning jobs/task types/dashboard
- skip Unihan meaning inserts when a higher-priority source already has English meanings for the same entry
- add specs covering service behavior and admin task integration

## Why
Issue #226 requires a Unihan fallback source for single-character entries. This PR adds the import pipeline and operational wiring while respecting the source-priority hierarchy.

## Notes
This branch includes commit(s) from #282 and should be merged after #282.