### PR TITLE
feat: radical breakdown in /learn contextual panel

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -33,6 +33,10 @@ class LearnController < ApplicationController
       target_learning: @user_learning,
       limit: 5
     )
+    @radical_breakdown = RadicalBreakdownBuilder.call(
+      user: Current.user,
+      dictionary_entry: @user_learning.dictionary_entry
+    )
   end
 
   def submit
@@ -184,7 +188,7 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: { meanings: :source })
+           .includes(dictionary_entry: [ { meanings: :source }, { dictionary_entry_radicals: :radical } ])
            .find(id)
   end
 

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -9,6 +9,8 @@ class DictionaryEntry < ApplicationRecord
   has_many :dictionary_entry_tags, dependent: :destroy
   has_many :tags, through: :dictionary_entry_tags
   has_many :meanings, dependent: :destroy
+  has_many :dictionary_entry_radicals, dependent: :destroy
+  has_many :radicals, through: :dictionary_entry_radicals
   has_many :user_learnings, dependent: :destroy
 
   validates :text, presence: true

--- a/app/models/dictionary_entry_radical.rb
+++ b/app/models/dictionary_entry_radical.rb
@@ -1,0 +1,9 @@
+class DictionaryEntryRadical < ApplicationRecord
+  belongs_to :dictionary_entry
+  belongs_to :radical
+
+  validates :position,
+            presence: true,
+            numericality: { only_integer: true, greater_than: 0 },
+            uniqueness: { scope: :dictionary_entry_id }
+end

--- a/app/models/radical.rb
+++ b/app/models/radical.rb
@@ -1,0 +1,7 @@
+class Radical < ApplicationRecord
+  has_many :dictionary_entry_radicals, dependent: :destroy
+  has_many :dictionary_entries, through: :dictionary_entry_radicals
+
+  validates :character, presence: true, uniqueness: true
+  validates :stroke_count, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+end

--- a/app/services/admin/radicals_provisioning_service.rb
+++ b/app/services/admin/radicals_provisioning_service.rb
@@ -1,9 +1,11 @@
 require "json"
+require "set"
 
 module Admin
   class RadicalsProvisioningService
     DICTIONARY_PATH = Rails.root.join("tmp", "makemeahanzi", "dictionary.txt")
     GRAPHICS_PATH = Rails.root.join("tmp", "makemeahanzi", "graphics.txt")
+    BATCH_SIZE = 900
 
     def self.call(dictionary_path: DICTIONARY_PATH.to_s, graphics_path: GRAPHICS_PATH.to_s)
       new(dictionary_path:, graphics_path:).call
@@ -18,7 +20,7 @@ module Admin
       records = parsed_records
       return empty_result if records.empty?
 
-      entry_id_by_text = DictionaryEntry.where(text: records.map { |row| row[:character] }).pluck(:text, :id).to_h
+      entry_id_by_text = dictionary_entry_ids_by_text(records.map { |row| row[:character] })
       records.select! { |row| entry_id_by_text.key?(row[:character]) }
       return empty_result if records.empty?
 
@@ -84,11 +86,12 @@ module Admin
       return {} unless File.exist?(@graphics_path)
 
       lookup = {}
+      component_set = component_characters.to_set
 
       File.foreach(@graphics_path, chomp: true) do |line|
         payload = JSON.parse(line)
         character = payload["character"].to_s
-        next unless component_characters.include?(character)
+        next unless component_set.include?(character)
 
         strokes = payload["strokes"]
         next unless strokes.is_a?(Array) && strokes.any?
@@ -102,16 +105,20 @@ module Admin
     end
 
     def meaning_lookup(component_characters)
-      DictionaryEntry
-        .where(text: component_characters)
-        .includes(meanings: :source)
-        .each_with_object({}) do |entry, lookup|
-          lookup[entry.text] = entry.flashcard_primary_meaning&.text
-        end
+      in_batches(component_characters).each_with_object({}) do |batch, lookup|
+        DictionaryEntry
+          .where(text: batch)
+          .includes(meanings: :source)
+          .each do |entry|
+            lookup[entry.text] = entry.flashcard_primary_meaning&.text
+          end
+      end
     end
 
     def upsert_radicals(component_characters, meaning_by_char, stroke_count_by_char)
-      existing = Radical.where(character: component_characters).index_by(&:character)
+      existing = in_batches(component_characters).each_with_object({}) do |batch, lookup|
+        lookup.merge!(Radical.where(character: batch).index_by(&:character))
+      end
       radicals_created = 0
 
       component_characters.each do |character|
@@ -157,9 +164,21 @@ module Admin
 
     def sync_dictionary_entry_radicals(entry_ids, rows)
       DictionaryEntryRadical.transaction do
-        DictionaryEntryRadical.where(dictionary_entry_id: entry_ids).delete_all
+        in_batches(entry_ids) do |batch|
+          DictionaryEntryRadical.where(dictionary_entry_id: batch).delete_all
+        end
         DictionaryEntryRadical.insert_all(rows) if rows.any?
       end
+    end
+
+    def dictionary_entry_ids_by_text(texts)
+      in_batches(texts.uniq).each_with_object({}) do |batch, lookup|
+        lookup.merge!(DictionaryEntry.where(text: batch).pluck(:text, :id).to_h)
+      end
+    end
+
+    def in_batches(values)
+      values.each_slice(BATCH_SIZE)
     end
 
     def empty_result

--- a/app/services/admin/radicals_provisioning_service.rb
+++ b/app/services/admin/radicals_provisioning_service.rb
@@ -6,6 +6,7 @@ module Admin
     DICTIONARY_PATH = Rails.root.join("tmp", "makemeahanzi", "dictionary.txt")
     GRAPHICS_PATH = Rails.root.join("tmp", "makemeahanzi", "graphics.txt")
     BATCH_SIZE = 900
+    INSERT_BATCH_SIZE = 150
 
     def self.call(dictionary_path: DICTIONARY_PATH.to_s, graphics_path: GRAPHICS_PATH.to_s)
       new(dictionary_path:, graphics_path:).call
@@ -167,7 +168,9 @@ module Admin
         in_batches(entry_ids) do |batch|
           DictionaryEntryRadical.where(dictionary_entry_id: batch).delete_all
         end
-        DictionaryEntryRadical.insert_all(rows) if rows.any?
+        rows.each_slice(INSERT_BATCH_SIZE) do |slice|
+          DictionaryEntryRadical.insert_all(slice)
+        end
       end
     end
 

--- a/app/services/admin/radicals_provisioning_service.rb
+++ b/app/services/admin/radicals_provisioning_service.rb
@@ -1,0 +1,173 @@
+require "json"
+
+module Admin
+  class RadicalsProvisioningService
+    DICTIONARY_PATH = Rails.root.join("tmp", "makemeahanzi", "dictionary.txt")
+    GRAPHICS_PATH = Rails.root.join("tmp", "makemeahanzi", "graphics.txt")
+
+    def self.call(dictionary_path: DICTIONARY_PATH.to_s, graphics_path: GRAPHICS_PATH.to_s)
+      new(dictionary_path:, graphics_path:).call
+    end
+
+    def initialize(dictionary_path:, graphics_path:)
+      @dictionary_path = dictionary_path
+      @graphics_path = graphics_path
+    end
+
+    def call
+      records = parsed_records
+      return empty_result if records.empty?
+
+      entry_id_by_text = DictionaryEntry.where(text: records.map { |row| row[:character] }).pluck(:text, :id).to_h
+      records.select! { |row| entry_id_by_text.key?(row[:character]) }
+      return empty_result if records.empty?
+
+      component_characters = records.flat_map { |row| row[:components] }.uniq
+      stroke_count_by_char = stroke_count_lookup(component_characters)
+      meaning_by_char = meaning_lookup(component_characters)
+
+      radical_id_by_char, radicals_created = upsert_radicals(
+        component_characters,
+        meaning_by_char,
+        stroke_count_by_char
+      )
+
+      entry_ids = records.map { |row| entry_id_by_text[row[:character]] }
+      rows = build_join_rows(records, entry_id_by_text, radical_id_by_char)
+      sync_dictionary_entry_radicals(entry_ids, rows)
+
+      {
+        entries_processed: entry_ids.size,
+        radicals_created: radicals_created,
+        associations_created: rows.size
+      }
+    end
+
+    private
+
+    def parsed_records
+      return [] unless File.exist?(@dictionary_path)
+
+      rows = []
+
+      File.foreach(@dictionary_path, chomp: true) do |line|
+        parsed = parse_dictionary_line(line)
+        rows << parsed if parsed
+      end
+
+      rows
+    end
+
+    def parse_dictionary_line(line)
+      payload = JSON.parse(line)
+      character = payload["character"].to_s
+      return nil unless character.match?(/\A\p{Han}\z/u)
+
+      components = extract_components(payload["decomposition"])
+      return nil if components.empty?
+
+      { character: character, components: components }
+    rescue JSON::ParserError
+      nil
+    end
+
+    def extract_components(decomposition)
+      return [] if decomposition.blank?
+
+      decomposition.each_char.with_object([]) do |char, components|
+        next unless char.match?(/\p{Han}/u)
+        components << char
+      end
+    end
+
+    def stroke_count_lookup(component_characters)
+      return {} unless File.exist?(@graphics_path)
+
+      lookup = {}
+
+      File.foreach(@graphics_path, chomp: true) do |line|
+        payload = JSON.parse(line)
+        character = payload["character"].to_s
+        next unless component_characters.include?(character)
+
+        strokes = payload["strokes"]
+        next unless strokes.is_a?(Array) && strokes.any?
+
+        lookup[character] = strokes.size
+      rescue JSON::ParserError
+        next
+      end
+
+      lookup
+    end
+
+    def meaning_lookup(component_characters)
+      DictionaryEntry
+        .where(text: component_characters)
+        .includes(meanings: :source)
+        .each_with_object({}) do |entry, lookup|
+          lookup[entry.text] = entry.flashcard_primary_meaning&.text
+        end
+    end
+
+    def upsert_radicals(component_characters, meaning_by_char, stroke_count_by_char)
+      existing = Radical.where(character: component_characters).index_by(&:character)
+      radicals_created = 0
+
+      component_characters.each do |character|
+        radical = existing[character]
+
+        if radical.nil?
+          radical = Radical.create!(
+            character: character,
+            meaning: meaning_by_char[character],
+            stroke_count: stroke_count_by_char[character]
+          )
+          existing[character] = radical
+          radicals_created += 1
+          next
+        end
+
+        attrs = {}
+        attrs[:meaning] = meaning_by_char[character] if radical.meaning.blank? && meaning_by_char[character].present?
+        attrs[:stroke_count] = stroke_count_by_char[character] if radical.stroke_count.nil? && stroke_count_by_char[character].present?
+        radical.update!(attrs) if attrs.any?
+      end
+
+      [ existing.transform_values(&:id), radicals_created ]
+    end
+
+    def build_join_rows(records, entry_id_by_text, radical_id_by_char)
+      timestamp = Time.current
+
+      records.flat_map do |record|
+        entry_id = entry_id_by_text[record[:character]]
+
+        record[:components].each_with_index.map do |component, index|
+          {
+            dictionary_entry_id: entry_id,
+            radical_id: radical_id_by_char.fetch(component),
+            position: index + 1,
+            created_at: timestamp,
+            updated_at: timestamp
+          }
+        end
+      end
+    end
+
+    def sync_dictionary_entry_radicals(entry_ids, rows)
+      DictionaryEntryRadical.transaction do
+        DictionaryEntryRadical.where(dictionary_entry_id: entry_ids).delete_all
+        DictionaryEntryRadical.insert_all(rows) if rows.any?
+      end
+    end
+
+    def empty_result
+      {
+        entries_processed: 0,
+        radicals_created: 0,
+        associations_created: 0
+      }
+    end
+  end
+end

--- a/app/services/radical_breakdown_builder.rb
+++ b/app/services/radical_breakdown_builder.rb
@@ -13,7 +13,7 @@ class RadicalBreakdownBuilder
   def call
     rows = @dictionary_entry
       .dictionary_entry_radicals
-      .sort_by { |row| [ row.position || Float::INFINITY, row.id ] }
+      .order(:position, :id)
 
     return [] if rows.empty?
 

--- a/app/services/radical_breakdown_builder.rb
+++ b/app/services/radical_breakdown_builder.rb
@@ -1,0 +1,43 @@
+class RadicalBreakdownBuilder
+  Result = Data.define(:radical, :position, :mastered)
+
+  def self.call(user:, dictionary_entry:)
+    new(user:, dictionary_entry:).call
+  end
+
+  def initialize(user:, dictionary_entry:)
+    @user = user
+    @dictionary_entry = dictionary_entry
+  end
+
+  def call
+    rows = @dictionary_entry
+      .dictionary_entry_radicals
+      .sort_by { |row| [ row.position || Float::INFINITY, row.id ] }
+
+    return [] if rows.empty?
+
+    mastered_characters = mastered_characters(rows)
+
+    rows.map do |row|
+      Result.new(
+        radical: row.radical,
+        position: row.position,
+        mastered: mastered_characters.include?(row.radical.character)
+      )
+    end
+  end
+
+  private
+
+  def mastered_characters(rows)
+    characters = rows.map { |row| row.radical.character }.uniq
+
+    @user.user_learnings
+         .where(state: "mastered")
+         .joins(:dictionary_entry)
+         .where(dictionary_entries: { text: characters })
+         .pluck("dictionary_entries.text")
+         .uniq
+  end
+end

--- a/app/services/radical_breakdown_builder.rb
+++ b/app/services/radical_breakdown_builder.rb
@@ -13,6 +13,7 @@ class RadicalBreakdownBuilder
   def call
     rows = @dictionary_entry
       .dictionary_entry_radicals
+      .includes(:radical)
       .order(:position, :id)
 
     return [] if rows.empty?

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -83,10 +83,7 @@
 
       <%= render "shared/related_anchors_panel", entry: entry, related_anchors: @related_anchors %>
 
-      <%# Radical breakdown placeholder — see issue #146 %>
-      <div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-3 text-center opacity-40">
-        <p class="text-xs text-gray-400">Radical breakdown coming soon</p>
-      </div>
+      <%= render "shared/radical_breakdown_panel", radical_breakdown: @radical_breakdown %>
 
       <%= button_to learn_card_path, params: { know_it: "false" },
             class: "relative w-full py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors" do %>

--- a/app/views/shared/_radical_breakdown_panel.html.erb
+++ b/app/views/shared/_radical_breakdown_panel.html.erb
@@ -11,7 +11,7 @@
           <div class="flex items-baseline gap-2">
             <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
             <% if item.radical.stroke_count.present? %>
-              <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= item.radical.stroke_count %> strokes</span>
+              <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= pluralize(item.radical.stroke_count, "stroke") %></span>
             <% end %>
             <% if item.mastered %>
               <span class="text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">Mastered</span>

--- a/app/views/shared/_radical_breakdown_panel.html.erb
+++ b/app/views/shared/_radical_breakdown_panel.html.erb
@@ -1,0 +1,31 @@
+<% radical_breakdown ||= [] %>
+
+<div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4">
+  <% if radical_breakdown.any? %>
+    <p class="text-base font-medium text-gray-600 dark:text-gray-400 mb-3">
+      Character components:
+    </p>
+    <ul class="space-y-3">
+      <% radical_breakdown.each do |item| %>
+        <li class="text-base">
+          <div class="flex items-baseline gap-2">
+            <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
+            <% if item.radical.stroke_count.present? %>
+              <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= item.radical.stroke_count %> strokes</span>
+            <% end %>
+            <% if item.mastered %>
+              <span class="text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">Mastered</span>
+            <% end %>
+          </div>
+          <% if item.radical.meaning.present? %>
+            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= item.radical.meaning %></div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-base text-gray-400 text-center">
+      No radical breakdown available for this character yet.
+    </p>
+  <% end %>
+</div>

--- a/db/migrate/20260508164256_create_radicals.rb
+++ b/db/migrate/20260508164256_create_radicals.rb
@@ -1,0 +1,13 @@
+class CreateRadicals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :radicals do |t|
+      t.string :character, null: false
+      t.string :meaning
+      t.integer :stroke_count
+
+      t.timestamps
+    end
+
+    add_index :radicals, :character, unique: true
+  end
+end

--- a/db/migrate/20260508164258_create_dictionary_entry_radicals.rb
+++ b/db/migrate/20260508164258_create_dictionary_entry_radicals.rb
@@ -1,0 +1,16 @@
+class CreateDictionaryEntryRadicals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :dictionary_entry_radicals do |t|
+      t.references :dictionary_entry, null: false, foreign_key: true
+      t.references :radical, null: false, foreign_key: true
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :dictionary_entry_radicals,
+              [ :dictionary_entry_id, :position ],
+              unique: true,
+              name: "index_unique_radical_position_on_entry"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_144551) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_164258) do
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -45,6 +45,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_144551) do
     t.datetime "updated_at", null: false
     t.index ["frequency_rank"], name: "index_dictionary_entries_on_frequency_rank"
     t.index ["text"], name: "index_dictionary_entries_on_text", unique: true
+  end
+
+  create_table "dictionary_entry_radicals", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "dictionary_entry_id", null: false
+    t.integer "position", null: false
+    t.integer "radical_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dictionary_entry_id", "position"], name: "index_unique_radical_position_on_entry", unique: true
+    t.index ["dictionary_entry_id"], name: "index_dictionary_entry_radicals_on_dictionary_entry_id"
+    t.index ["radical_id"], name: "index_dictionary_entry_radicals_on_radical_id"
   end
 
   create_table "dictionary_entry_tags", force: :cascade do |t|
@@ -93,6 +104,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_144551) do
     t.index ["dictionary_entry_id", "language", "text", "pinyin", "source_id"], name: "index_meanings_on_dictionary_entry_source_and_content", unique: true
     t.index ["dictionary_entry_id"], name: "index_meanings_on_dictionary_entry_id"
     t.index ["source_id"], name: "index_meanings_on_source_id"
+  end
+
+  create_table "radicals", force: :cascade do |t|
+    t.string "character", null: false
+    t.datetime "created_at", null: false
+    t.string "meaning"
+    t.integer "stroke_count"
+    t.datetime "updated_at", null: false
+    t.index ["character"], name: "index_radicals_on_character", unique: true
   end
 
   create_table "review_logs", force: :cascade do |t|
@@ -170,6 +190,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_144551) do
   end
 
   add_foreign_key "anki_imports", "users"
+  add_foreign_key "dictionary_entry_radicals", "dictionary_entries"
+  add_foreign_key "dictionary_entry_radicals", "radicals"
   add_foreign_key "dictionary_entry_tags", "dictionary_entries"
   add_foreign_key "dictionary_entry_tags", "tags"
   add_foreign_key "learning_session_cards", "learning_sessions"

--- a/lib/tasks/makemeahanzi.rake
+++ b/lib/tasks/makemeahanzi.rake
@@ -1,0 +1,21 @@
+require_relative "../../app/helpers/import_files_helper"
+
+include ImportFilesHelper
+
+namespace :makemeahanzi do
+  DICTIONARY_URL = "https://raw.githubusercontent.com/skishore/makemeahanzi/master/dictionary.txt"
+  GRAPHICS_URL = "https://raw.githubusercontent.com/skishore/makemeahanzi/master/graphics.txt"
+
+  desc "Download makemeahanzi dictionary and graphics data"
+  task download: :environment do
+    output_dir = Rails.root.join("tmp", "makemeahanzi")
+
+    dictionary_path = output_dir.join("dictionary.txt")
+    graphics_path = output_dir.join("graphics.txt")
+
+    ImportFilesHelper.download_file_to_tmp(DICTIONARY_URL, dictionary_path)
+    ImportFilesHelper.download_file_to_tmp(GRAPHICS_URL, graphics_path)
+    ImportFilesHelper.confirm_file_presence("dictionary.txt", output_dir)
+    ImportFilesHelper.confirm_file_presence("graphics.txt", output_dir)
+  end
+end

--- a/lib/tasks/makemeahanzi.rake
+++ b/lib/tasks/makemeahanzi.rake
@@ -13,9 +13,9 @@ namespace :makemeahanzi do
     dictionary_path = output_dir.join("dictionary.txt")
     graphics_path = output_dir.join("graphics.txt")
 
-    ImportFilesHelper.download_file_to_tmp(DICTIONARY_URL, dictionary_path)
-    ImportFilesHelper.download_file_to_tmp(GRAPHICS_URL, graphics_path)
-    ImportFilesHelper.confirm_file_presence("dictionary.txt", output_dir)
-    ImportFilesHelper.confirm_file_presence("graphics.txt", output_dir)
+    download_file_to_tmp(DICTIONARY_URL, dictionary_path)
+    download_file_to_tmp(GRAPHICS_URL, graphics_path)
+    confirm_file_presence("dictionary.txt", output_dir)
+    confirm_file_presence("graphics.txt", output_dir)
   end
 end

--- a/lib/tasks/radicals.rake
+++ b/lib/tasks/radicals.rake
@@ -8,6 +8,10 @@ namespace :radicals do
       raise "Dictionary file not found at #{dictionary_path}"
     end
 
+    unless File.exist?(graphics_path)
+      raise "Graphics file not found at #{graphics_path}. Run `bin/rails makemeahanzi:download` to download the required source files."
+    end
+
     puts "Importing radicals from #{dictionary_path}..."
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/lib/tasks/radicals.rake
+++ b/lib/tasks/radicals.rake
@@ -1,0 +1,25 @@
+namespace :radicals do
+  desc "Import radical decomposition from makemeahanzi dictionary.txt"
+  task :import, [ :dictionary_path, :graphics_path ] => :environment do |_task, args|
+    dictionary_path = args[:dictionary_path] || Rails.root.join("tmp", "makemeahanzi", "dictionary.txt").to_s
+    graphics_path = args[:graphics_path] || Rails.root.join("tmp", "makemeahanzi", "graphics.txt").to_s
+
+    unless File.exist?(dictionary_path)
+      raise "Dictionary file not found at #{dictionary_path}"
+    end
+
+    puts "Importing radicals from #{dictionary_path}..."
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    result = Admin::RadicalsProvisioningService.call(
+      dictionary_path: dictionary_path,
+      graphics_path: graphics_path
+    )
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+    puts "Done! Completed in #{elapsed.round(2)}s"
+    puts "Entries processed: #{result[:entries_processed]}"
+    puts "Radicals created: #{result[:radicals_created]}"
+    puts "Associations created: #{result[:associations_created]}"
+  end
+end

--- a/spec/factories/dictionary_entry_radicals.rb
+++ b/spec/factories/dictionary_entry_radicals.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :dictionary_entry_radical do
+    association :dictionary_entry
+    association :radical
+    sequence(:position)
+  end
+end

--- a/spec/factories/radicals.rb
+++ b/spec/factories/radicals.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :radical do
+    sequence(:character) { |n| "部#{n}" }
+    meaning { "component" }
+    stroke_count { 4 }
+  end
+end

--- a/spec/models/dictionary_entry_radical_spec.rb
+++ b/spec/models/dictionary_entry_radical_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe DictionaryEntryRadical, type: :model do
+  describe "associations" do
+    it { should belong_to(:dictionary_entry) }
+    it { should belong_to(:radical) }
+  end
+
+  describe "validations" do
+    subject(:dictionary_entry_radical) { build(:dictionary_entry_radical) }
+
+    it { should validate_presence_of(:position) }
+    it { should validate_numericality_of(:position).only_integer.is_greater_than(0) }
+  end
+
+  describe "database indexes" do
+    it {
+      should have_db_index([ :dictionary_entry_id, :position ])
+        .unique(true)
+    }
+  end
+end

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe DictionaryEntry, type: :model do
     it { should have_many(:dictionary_entry_tags).dependent(:destroy) }
     it { should have_many(:tags).through(:dictionary_entry_tags) }
     it { should have_many(:meanings).dependent(:destroy) }
+    it { should have_many(:dictionary_entry_radicals).dependent(:destroy) }
+    it { should have_many(:radicals).through(:dictionary_entry_radicals) }
     it { should have_many(:user_learnings).dependent(:destroy) }
   end
 

--- a/spec/models/radical_spec.rb
+++ b/spec/models/radical_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Radical, type: :model do
+  describe "associations" do
+    it { should have_many(:dictionary_entry_radicals).dependent(:destroy) }
+    it { should have_many(:dictionary_entries).through(:dictionary_entry_radicals) }
+  end
+
+  describe "validations" do
+    subject(:radical) { build(:radical, character: "A") }
+
+    it { should validate_presence_of(:character) }
+    it { should validate_uniqueness_of(:character) }
+    it { should validate_numericality_of(:stroke_count).only_integer.is_greater_than(0).allow_nil }
+  end
+
+  describe "database indexes" do
+    it { should have_db_index(:character).unique(true) }
+  end
+end

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -253,6 +253,34 @@ RSpec.describe "Learn", type: :request do
 
         expect(response.body.index("学习者")).to be < response.body.index("学校")
       end
+
+      it "shows radical breakdown details in the contextual panel" do
+        radical_yan = create(:radical, character: "讠", meaning: "speech", stroke_count: 2)
+        radical_wu = create(:radical, character: "吾", meaning: "I", stroke_count: 7)
+
+        create(:dictionary_entry_radical, dictionary_entry: new_card.dictionary_entry, radical: radical_yan, position: 1)
+        create(:dictionary_entry_radical, dictionary_entry: new_card.dictionary_entry, radical: radical_wu, position: 2)
+
+        get learn_card_path
+
+        expect(response.body).to include("Character components")
+        expect(response.body).to include("讠")
+        expect(response.body).to include("2 strokes")
+        expect(response.body).to include("speech")
+        expect(response.body).to include("吾")
+        expect(response.body).to include("7 strokes")
+      end
+
+      it "marks a radical as mastered when the learner knows it" do
+        radical_wu = create(:radical, character: "吾", meaning: "I", stroke_count: 7)
+        radical_entry = create(:dictionary_entry, text: "吾")
+        create(:user_learning, user: user, dictionary_entry: radical_entry, state: "mastered")
+        create(:dictionary_entry_radical, dictionary_entry: new_card.dictionary_entry, radical: radical_wu, position: 1)
+
+        get learn_card_path
+
+        expect(response.body).to include("Mastered")
+      end
     end
 
     context "when authenticated without an active learn session" do

--- a/spec/services/admin/radicals_provisioning_service_spec.rb
+++ b/spec/services/admin/radicals_provisioning_service_spec.rb
@@ -53,5 +53,23 @@ RSpec.describe Admin::RadicalsProvisioningService do
       expect(result).to include(entries_processed: 1, associations_created: 2)
       expect(entry.reload.dictionary_entry_radicals.order(:position).map { |row| row.radical.character }).to eq([ "讠", "吾" ])
     end
+
+    it "imports in insert batches for larger datasets" do
+      many_entries = 200.times.map do |idx|
+        character = [ 0x4E00 + idx ].pack("U")
+        create(:dictionary_entry, text: character)
+        { "character" => character, "decomposition" => "⿰讠吾" }
+      end
+
+      File.write(
+        dictionary_path,
+        many_entries.map(&:to_json).join("\n") + "\n"
+      )
+
+      result = described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
+
+      expect(result).to include(entries_processed: 200, associations_created: 400)
+      expect(DictionaryEntryRadical.count).to eq(400)
+    end
   end
 end

--- a/spec/services/admin/radicals_provisioning_service_spec.rb
+++ b/spec/services/admin/radicals_provisioning_service_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Admin::RadicalsProvisioningService do
+  describe ".call" do
+    let(:tmp_dir) { Rails.root.join("tmp", "radicals_spec") }
+    let(:dictionary_path) { tmp_dir.join("dictionary.txt") }
+    let(:graphics_path) { tmp_dir.join("graphics.txt") }
+
+    let!(:entry) { create(:dictionary_entry, text: "语") }
+    let!(:component_entry) { create(:dictionary_entry, text: "吾") }
+
+    before do
+      FileUtils.mkdir_p(tmp_dir)
+
+      File.write(
+        dictionary_path,
+        <<~JSONL
+          {"character":"语","decomposition":"⿰讠吾"}
+        JSONL
+      )
+
+      File.write(
+        graphics_path,
+        <<~JSONL
+          {"character":"讠","strokes":["a","b"]}
+          {"character":"吾","strokes":["a","b","c","d","e","f","g"]}
+        JSONL
+      )
+    end
+
+    after { FileUtils.rm_rf(tmp_dir) }
+
+    it "creates radicals and dictionary entry associations" do
+      result = described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
+
+      expect(result).to include(entries_processed: 1, radicals_created: 2, associations_created: 2)
+      expect(entry.reload.dictionary_entry_radicals.order(:position).map { |row| row.radical.character }).to eq([ "讠", "吾" ])
+    end
+
+    it "populates radical meanings from existing dictionary entries when available" do
+      result = described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
+
+      expect(result).to include(entries_processed: 1)
+      expect(Radical.find_by!(character: "讠").meaning).to be_nil
+      expect(Radical.find_by!(character: "吾").meaning).to eq(component_entry.flashcard_primary_meaning.text)
+    end
+
+    it "replaces existing rows for repeated imports" do
+      described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
+
+      result = described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
+
+      expect(result).to include(entries_processed: 1, associations_created: 2)
+      expect(entry.reload.dictionary_entry_radicals.order(:position).map { |row| row.radical.character }).to eq([ "讠", "吾" ])
+    end
+  end
+end

--- a/spec/tasks/makemeahanzi_spec.rb
+++ b/spec/tasks/makemeahanzi_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "makemeahanzi", type: :task do
+  before do
+    Rake.application.rake_require("tasks/makemeahanzi")
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "download" do
+    let(:output_dir) { Rails.root.join("tmp", "makemeahanzi") }
+    let(:dictionary_path) { output_dir.join("dictionary.txt") }
+    let(:graphics_path) { output_dir.join("graphics.txt") }
+
+    before do
+      stub_request(:get, "https://raw.githubusercontent.com/skishore/makemeahanzi/master/dictionary.txt")
+        .to_return(body: "{\"character\":\"语\",\"decomposition\":\"⿰讠吾\"}\n")
+
+      stub_request(:get, "https://raw.githubusercontent.com/skishore/makemeahanzi/master/graphics.txt")
+        .to_return(body: "{\"character\":\"吾\",\"strokes\":[\"a\"]}\n")
+
+      FileUtils.rm_rf(output_dir)
+    end
+
+    after do
+      FileUtils.rm_rf(output_dir)
+      Rake::Task["makemeahanzi:download"].reenable
+    end
+
+    it "downloads dictionary.txt and graphics.txt" do
+      silence_output { Rake::Task["makemeahanzi:download"].invoke }
+
+      expect(File.exist?(dictionary_path)).to be(true)
+      expect(File.exist?(graphics_path)).to be(true)
+    end
+  end
+end

--- a/spec/tasks/radicals_spec.rb
+++ b/spec/tasks/radicals_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "radicals", type: :task do
+  before do
+    Rake.application.rake_require("tasks/radicals")
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "import" do
+    let(:tmp_dir) { Rails.root.join("tmp", "radicals_task_spec") }
+    let(:dictionary_path) { tmp_dir.join("dictionary.txt") }
+    let(:graphics_path) { tmp_dir.join("graphics.txt") }
+
+    before do
+      FileUtils.mkdir_p(tmp_dir)
+      File.write(dictionary_path, "{\"character\":\"语\",\"decomposition\":\"⿰讠吾\"}\n")
+      File.write(graphics_path, "{\"character\":\"吾\",\"strokes\":[\"a\"]}\n")
+      create(:dictionary_entry, text: "语")
+    end
+
+    after do
+      FileUtils.rm_rf(tmp_dir)
+      Rake::Task["radicals:import"].reenable
+    end
+
+    it "imports radicals via the provisioning service" do
+      output = capture_output do
+        Rake::Task["radicals:import"].invoke(dictionary_path.to_s, graphics_path.to_s)
+      end
+
+      expect(output).to include("Entries processed: 1")
+      expect(DictionaryEntryRadical.count).to eq(2)
+    end
+
+    it "raises when the dictionary file is missing" do
+      expect {
+        Rake::Task["radicals:import"].invoke("/tmp/missing_dictionary.txt", graphics_path.to_s)
+      }.to raise_error(/Dictionary file not found/)
+
+      Rake::Task["radicals:import"].reenable
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `Radical` and `DictionaryEntryRadical` models/migrations and wire `DictionaryEntry` associations for component decomposition
- add shared makemeahanzi pipeline tasks (`makemeahanzi:download`, `radicals:import`) plus `Admin::RadicalsProvisioningService` to import decomposition + stroke metadata
- replace the `/learn` radical placeholder with a rendered breakdown panel showing component character, stroke count, meaning, and mastered status
- add model, service, task, and request specs covering import behavior and learn-panel rendering

## Testing
- `bundle exec rspec spec/models/radical_spec.rb spec/models/dictionary_entry_radical_spec.rb spec/services/admin/radicals_provisioning_service_spec.rb spec/tasks/makemeahanzi_spec.rb spec/tasks/radicals_spec.rb spec/requests/learn_spec.rb`

Closes #146