### PR TITLE
fix: place 'I know this' button on right

### DIFF
--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -66,16 +66,16 @@
 
     <%# Phase 3: binary buttons %>
     <div data-learn-card-target="binaryButtons" class="hidden mt-6 flex gap-3">
-      <%= button_to learn_card_path, params: { know_it: "true" },
-            class: "relative flex-1 pt-7 pb-4 px-4 bg-green-50 dark:bg-green-900/40 text-green-700 dark:text-green-400 font-semibold rounded-xl hover:bg-green-100 dark:hover:bg-green-900/60 transition-colors" do %>
-        <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">1</span>
-        I know this
-      <% end %>
       <button data-action="click->learn-card#needToLearn"
               class="relative flex-1 py-3 px-4 bg-amber-50 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 font-semibold rounded-xl hover:bg-amber-100 dark:hover:bg-amber-900/60 transition-colors">
         <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">2</span>
         I need to learn this
       </button>
+      <%= button_to learn_card_path, params: { know_it: "true" },
+            class: "relative flex-1 pt-7 pb-4 px-4 bg-green-50 dark:bg-green-900/40 text-green-700 dark:text-green-400 font-semibold rounded-xl hover:bg-green-100 dark:hover:bg-green-900/60 transition-colors" do %>
+        <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">1</span>
+        I know this
+      <% end %>
     </div>
 
     <%# Contextual panel (shown after "I need to learn this") %>


### PR DESCRIPTION
## Summary
- swap the visual order of the learn-screen binary action buttons so `I know this` renders on the right
- keep all existing behavior the same (shortcuts remain `1` for know, `2` for need to learn)

## Testing
- not run (layout-only view ordering change)