### PR TITLE
fix: remove unused radical eager load

### DIFF
--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -188,7 +188,7 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: [ { meanings: :source }, { dictionary_entry_radicals: :radical } ])
+           .includes(dictionary_entry: { meanings: :source })
            .find(id)
   end
 


### PR DESCRIPTION
## Summary
- remove `dictionary_entry_radicals` eager loading from `LearnController#current_card`
- keep only meanings/source eager loading required by the learn card view
- eliminate Bullet `AVOID eager loading detected` noise on `/learn/card` so real query issues stay visible

## Why
Bullet flagged an unnecessary include when rendering the learn card. The radical panel fetches its data through `RadicalBreakdownBuilder`, so preloading radicals in `current_card` is redundant and can mask genuine performance signals during development.