### PR TITLE
feat: add radical fallback across study screens

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary unihan hsk_tags frequency_data].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary unihan hsk_tags frequency_data radicals].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|
@@ -38,7 +38,8 @@ module Admin
         custom_entries:     Meaning.joins(:source).where(sources: { name: "learn_hanzi" }).select(:dictionary_entry_id).distinct.count,
         wiktionary_entries: Meaning.joins(:source).where(sources: { name: "Wiktionary" }).select(:dictionary_entry_id).distinct.count,
         unihan_entries:     Meaning.joins(:source).where(sources: { name: "Unihan" }).select(:dictionary_entry_id).distinct.count,
-        frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count
+        frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count,
+        radical_entries:    DictionaryEntryRadical.select(:dictionary_entry_id).distinct.count
       }
     end
   end

--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -15,5 +15,9 @@ class DictionaryEntriesController < ApplicationController
       else
         ReviewLog.none
       end
+    @radical_breakdown = RadicalBreakdownBuilder.call(
+      user: Current.user,
+      dictionary_entry: @dictionary_entry
+    )
   end
 end

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -64,6 +64,15 @@ class LearnController < ApplicationController
     @user_learning = current_review_card
     @position      = session[:learn_review_index] + 1
     @total         = session[:learn_introduced].size
+    @related_anchors = RelatedAnchorBuilder.call(
+      user: Current.user,
+      target_learning: @user_learning,
+      limit: 5
+    )
+    @radical_breakdown = RadicalBreakdownBuilder.call(
+      user: Current.user,
+      dictionary_entry: @user_learning.dictionary_entry
+    )
   end
 
   def review_submit

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -188,7 +188,7 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: [ { meanings: :source }, { dictionary_entry_radicals: :radical } ])
+           .includes(dictionary_entry: { meanings: :source })
            .find(id)
   end
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -36,6 +36,10 @@ class ReviewController < ApplicationController
       target_learning: @user_learning,
       limit: 5
     )
+    @radical_breakdown = RadicalBreakdownBuilder.call(
+      user: Current.user,
+      dictionary_entry: @user_learning.dictionary_entry
+    )
   end
 
   def submit

--- a/app/jobs/admin/provisioning_job.rb
+++ b/app/jobs/admin/provisioning_job.rb
@@ -8,7 +8,8 @@ module Admin
       "custom_dictionary"  => Admin::CustomDictionaryProvisioningService,
       "frequency_data"     => Admin::FrequencyProvisioningService,
       "wiktionary"         => Admin::WiktionaryProvisioningService,
-      "unihan"             => Admin::UnihanProvisioningService
+      "unihan"             => Admin::UnihanProvisioningService,
+      "radicals"           => Admin::RadicalsProvisioningService
     }.freeze
 
     def perform(task_id)

--- a/app/models/admin_task.rb
+++ b/app/models/admin_task.rb
@@ -1,5 +1,13 @@
 class AdminTask < ApplicationRecord
-  VALID_TASK_TYPES = %w[cc_cedict hsk_tags custom_dictionary frequency_data wiktionary unihan].freeze
+  VALID_TASK_TYPES = %w[
+    cc_cedict
+    hsk_tags
+    custom_dictionary
+    frequency_data
+    wiktionary
+    unihan
+    radicals
+  ].freeze
   VALID_STATES     = %w[pending running complete failed].freeze
 
   validates :task_type, presence: true, inclusion: { in: VALID_TASK_TYPES }

--- a/app/services/radical_breakdown_builder.rb
+++ b/app/services/radical_breakdown_builder.rb
@@ -1,5 +1,6 @@
 class RadicalBreakdownBuilder
-  Result = Data.define(:radical, :position, :mastered)
+  Row = Data.define(:radical, :position, :source_character)
+  Result = Data.define(:radical, :position, :mastered, :source_character)
 
   def self.call(user:, dictionary_entry:)
     new(user:, dictionary_entry:).call
@@ -11,10 +12,8 @@ class RadicalBreakdownBuilder
   end
 
   def call
-    rows = @dictionary_entry
-      .dictionary_entry_radicals
-      .includes(:radical)
-      .order(:position, :id)
+    rows = direct_rows
+    rows = fallback_rows_for_multi_character_entry if rows.empty?
 
     return [] if rows.empty?
 
@@ -24,7 +23,8 @@ class RadicalBreakdownBuilder
       Result.new(
         radical: row.radical,
         position: row.position,
-        mastered: mastered_characters.include?(row.radical.character)
+        mastered: mastered_characters.include?(row.radical.character),
+        source_character: row.source_character
       )
     end
   end
@@ -40,5 +40,38 @@ class RadicalBreakdownBuilder
          .where(dictionary_entries: { text: characters })
          .pluck("dictionary_entries.text")
          .uniq
+  end
+
+  def direct_rows
+    @dictionary_entry
+      .dictionary_entry_radicals
+      .includes(:radical)
+      .order(:position, :id)
+      .map { |row| Row.new(radical: row.radical, position: row.position, source_character: nil) }
+  end
+
+  def fallback_rows_for_multi_character_entry
+    characters = @dictionary_entry.text.scan(/\p{Han}/u)
+    return [] unless characters.size > 1
+
+    entries_by_text = DictionaryEntry
+      .where(text: characters.uniq)
+      .includes(dictionary_entry_radicals: :radical)
+      .index_by(&:text)
+
+    characters.flat_map do |character|
+      entry = entries_by_text[character]
+      next [] unless entry
+
+      entry.dictionary_entry_radicals
+           .sort_by { |row| [ row.position, row.id ] }
+           .map do |row|
+             Row.new(
+               radical: row.radical,
+               position: row.position,
+               source_character: character
+             )
+           end
+    end
   end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -62,6 +62,14 @@
           unit:      "ranked entries",
           requires_dictionary: @db_stats[:dictionary_entries].zero? %>
 
+    <%= render "task_card",
+          label:     "Radical breakdowns",
+          task_type: "radicals",
+          task:      @tasks_by_type["radicals"],
+          db_count:  @db_stats[:radical_entries],
+          unit:      "entries with radicals",
+          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+
   </div>
 
   <%# History log %>

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -259,18 +259,11 @@
   <%# ── Future sections ──────────────────────────────────── %>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
 
-    <div class="de-future rounded-xl p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
-          Radical Breakdown
-        </h2>
-        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
-          SOON
-        </span>
-      </div>
-      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
-        Component radicals and stroke order will appear here.
-      </p>
+    <div class="bg-gray-800/40 border border-gray-700/40 rounded-xl p-6">
+      <h2 class="de-lora text-[10px] text-red-500 uppercase tracking-[0.2em] font-semibold mb-3">
+        Radical Breakdown
+      </h2>
+      <%= render "shared/radical_breakdown_panel", radical_breakdown: @radical_breakdown %>
     </div>
 
     <div class="de-future rounded-xl p-6">

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -256,7 +256,7 @@
     <% end %>
   </div>
 
-  <%# ── Future sections ──────────────────────────────────── %>
+  <%# ── Character enrichment ─────────────────────────────── %>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
 
     <div class="bg-gray-800/40 border border-gray-700/40 rounded-xl p-6">

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -71,6 +71,10 @@
       <div class="mt-6">
         <%= render "shared/related_anchors_panel", entry: entry, related_anchors: @related_anchors %>
       </div>
+
+      <div class="mt-3">
+        <%= render "shared/radical_breakdown_panel", radical_breakdown: @radical_breakdown %>
+      </div>
     </div>
 
   </div>

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -98,6 +98,10 @@
       <div class="mt-6">
         <%= render "shared/related_anchors_panel", entry: entry, related_anchors: @related_anchors %>
       </div>
+
+      <div class="mt-3">
+        <%= render "shared/radical_breakdown_panel", radical_breakdown: @radical_breakdown %>
+      </div>
     </div>
 
   </div>

--- a/app/views/shared/_radical_breakdown_panel.html.erb
+++ b/app/views/shared/_radical_breakdown_panel.html.erb
@@ -7,29 +7,55 @@
     <p class="text-base font-medium text-gray-600 dark:text-gray-400 mb-3">
       Character components:
     </p>
-    <ul class="space-y-3">
-      <% radical_breakdown.each do |item| %>
-        <li class="text-base">
-          <% if show_character_groups && item.source_character.present? %>
-            <div class="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">
-              Character <span class="font-hanzi text-sm normal-case"><%= item.source_character %></span>
+    <% if show_character_groups %>
+      <div class="space-y-3">
+        <% grouped_by_character.each do |source_character, items| %>
+          <div class="rounded-xl border border-gray-200 dark:border-gray-500/70 overflow-hidden bg-white/80 dark:bg-gray-800/40 shadow-sm">
+            <div class="px-3 py-2 bg-gray-100 dark:bg-gray-500/25 border-b border-gray-200 dark:border-gray-500/60">
+              <span class="text-[10px] uppercase tracking-[0.12em] text-gray-500 dark:text-gray-300">Character</span>
+              <span class="font-hanzi text-base text-gray-800 dark:text-gray-100 ml-2"><%= source_character %></span>
             </div>
-          <% end %>
-          <div class="flex items-baseline gap-2">
-            <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
-            <% if item.radical.stroke_count.present? %>
-              <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= pluralize(item.radical.stroke_count, "stroke") %></span>
-            <% end %>
-            <% if item.mastered %>
-              <span class="text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">Mastered</span>
-            <% end %>
+            <ul class="p-3 space-y-3 bg-gray-50/80 dark:bg-gray-800/30">
+              <% items.each do |item| %>
+                <li class="text-base">
+                  <div class="flex items-baseline gap-2">
+                    <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
+                    <% if item.radical.stroke_count.present? %>
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= pluralize(item.radical.stroke_count, "stroke") %></span>
+                    <% end %>
+                    <% if item.mastered %>
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">Mastered</span>
+                    <% end %>
+                  </div>
+                  <% if item.radical.meaning.present? %>
+                    <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= item.radical.meaning %></div>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
           </div>
-          <% if item.radical.meaning.present? %>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= item.radical.meaning %></div>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+        <% end %>
+      </div>
+    <% else %>
+      <ul class="space-y-3">
+        <% radical_breakdown.each do |item| %>
+          <li class="text-base">
+            <div class="flex items-baseline gap-2">
+              <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
+              <% if item.radical.stroke_count.present? %>
+                <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200"><%= pluralize(item.radical.stroke_count, "stroke") %></span>
+              <% end %>
+              <% if item.mastered %>
+                <span class="text-xs px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300">Mastered</span>
+              <% end %>
+            </div>
+            <% if item.radical.meaning.present? %>
+              <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= item.radical.meaning %></div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   <% else %>
     <p class="text-base text-gray-400 text-center">
       No radical breakdown available for this character yet.

--- a/app/views/shared/_radical_breakdown_panel.html.erb
+++ b/app/views/shared/_radical_breakdown_panel.html.erb
@@ -1,4 +1,6 @@
 <% radical_breakdown ||= [] %>
+<% grouped_by_character = radical_breakdown.group_by(&:source_character) %>
+<% show_character_groups = grouped_by_character.keys.any?(&:present?) %>
 
 <div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4">
   <% if radical_breakdown.any? %>
@@ -8,6 +10,11 @@
     <ul class="space-y-3">
       <% radical_breakdown.each do |item| %>
         <li class="text-base">
+          <% if show_character_groups && item.source_character.present? %>
+            <div class="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">
+              Character <span class="font-hanzi text-sm normal-case"><%= item.source_character %></span>
+            </div>
+          <% end %>
           <div class="flex items-baseline gap-2">
             <span class="font-hanzi text-xl text-gray-800 dark:text-gray-200"><%= item.radical.character %></span>
             <% if item.radical.stroke_count.present? %>

--- a/app/views/shared/_radical_breakdown_panel.html.erb
+++ b/app/views/shared/_radical_breakdown_panel.html.erb
@@ -1,6 +1,6 @@
 <% radical_breakdown ||= [] %>
-<% grouped_by_character = radical_breakdown.group_by(&:source_character) %>
-<% show_character_groups = grouped_by_character.keys.any?(&:present?) %>
+<% show_character_groups = radical_breakdown.any? { |item| item.source_character.present? } %>
+<% grouped_by_character = show_character_groups ? radical_breakdown.group_by(&:source_character) : {} %>
 
 <div class="bg-gray-50 dark:bg-gray-700 rounded-xl p-4">
   <% if radical_breakdown.any? %>

--- a/spec/jobs/admin/provisioning_job_spec.rb
+++ b/spec/jobs/admin/provisioning_job_spec.rb
@@ -100,4 +100,17 @@ RSpec.describe Admin::ProvisioningJob, type: :job do
 
     include_examples "a provisioning job", Admin::UnihanProvisioningService
   end
+
+  describe "#perform for radicals" do
+    let(:task_type) { "radicals" }
+    let(:summary_result) do
+      {
+        entries_processed: 120_000,
+        radicals_created: 380,
+        associations_created: 240_000
+      }
+    end
+
+    include_examples "a provisioning job", Admin::RadicalsProvisioningService
+  end
 end

--- a/spec/models/admin_task_spec.rb
+++ b/spec/models/admin_task_spec.rb
@@ -85,6 +85,10 @@ RSpec.describe AdminTask, type: :model do
     it "includes unihan for admin provisioning" do
       expect(AdminTask::VALID_TASK_TYPES).to include("unihan")
     end
+
+    it "includes radicals for admin provisioning" do
+      expect(AdminTask::VALID_TASK_TYPES).to include("radicals")
+    end
   end
 
   describe ".in_progress" do

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Admin::Dashboard", type: :request do
         expect(response.body).to include("CC-CEDICT")
         expect(response.body).to include("HSK")
         expect(response.body).to include("Frequency data")
+        expect(response.body).to include("Radical breakdowns")
       end
 
       it "shows task history" do
@@ -81,13 +82,13 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
 
       it "enqueues a job for each unlocked task type" do
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(6).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(7).times
         post admin_provision_all_path
       end
 
       it "does not enqueue a job for a locked task type" do
         create(:admin_task, task_type: "cc_cedict", state: "running")
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(5).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(6).times
         post admin_provision_all_path
       end
 

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -92,6 +92,18 @@ RSpec.describe "DictionaryEntries", type: :request do
 
         expect(response.body.index("plum")).to be < response.body.index("surname Li")
       end
+
+      it "shows radical breakdown details" do
+        radical_yan = create(:radical, character: "讠", meaning: "speech", stroke_count: 2)
+        create(:dictionary_entry_radical, dictionary_entry: dictionary_entry, radical: radical_yan, position: 1)
+
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body).to include("Radical Breakdown")
+        expect(response.body).to include("Character components")
+        expect(response.body).to include("讠")
+        expect(response.body).to include("speech")
+      end
     end
   end
 

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -372,6 +372,17 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include('data-ease="3"')
         expect(response.body).to include('data-ease="4"')
       end
+
+      it "shows radical breakdown in learn review" do
+        radical_yan = create(:radical, character: "讠", meaning: "speech", stroke_count: 2)
+        create(:dictionary_entry_radical, dictionary_entry: new_card.dictionary_entry, radical: radical_yan, position: 1)
+
+        get learn_review_path
+
+        expect(response.body).to include("Character components")
+        expect(response.body).to include("讠")
+        expect(response.body).to include("speech")
+      end
     end
 
     context "when authenticated without an active review phase" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -256,6 +256,17 @@ RSpec.describe "Review", type: :request do
 
         expect(response.body.scan("学习班").size).to eq(1)
       end
+
+      it "shows radical breakdown details" do
+        radical_yan = create(:radical, character: "讠", meaning: "speech", stroke_count: 2)
+        create(:dictionary_entry_radical, dictionary_entry: user_learning.dictionary_entry, radical: radical_yan, position: 1)
+
+        get review_card_path
+
+        expect(response.body).to include("Character components")
+        expect(response.body).to include("讠")
+        expect(response.body).to include("speech")
+      end
     end
   end
 

--- a/spec/services/radical_breakdown_builder_spec.rb
+++ b/spec/services/radical_breakdown_builder_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe RadicalBreakdownBuilder do
+  describe ".call" do
+    let(:user) { create(:user) }
+
+    it "returns direct radical rows for single-character entries" do
+      entry = create(:dictionary_entry, text: "语")
+      radical = create(:radical, character: "讠", meaning: "speech", stroke_count: 2)
+      create(:dictionary_entry_radical, dictionary_entry: entry, radical: radical, position: 1)
+
+      result = described_class.call(user: user, dictionary_entry: entry)
+
+      expect(result.size).to eq(1)
+      expect(result.first.radical.character).to eq("讠")
+      expect(result.first.source_character).to be_nil
+    end
+
+    it "falls back to per-character breakdown for multi-character vocab" do
+      phrase = create(:dictionary_entry, text: "学校")
+
+      xue_entry = create(:dictionary_entry, text: "学")
+      xue_radical = create(:radical, character: "子", meaning: "child", stroke_count: 3)
+      create(:dictionary_entry_radical, dictionary_entry: xue_entry, radical: xue_radical, position: 1)
+
+      xiao_entry = create(:dictionary_entry, text: "校")
+      xiao_radical = create(:radical, character: "木", meaning: "wood", stroke_count: 4)
+      create(:dictionary_entry_radical, dictionary_entry: xiao_entry, radical: xiao_radical, position: 1)
+
+      result = described_class.call(user: user, dictionary_entry: phrase)
+
+      expect(result.map { |row| [ row.source_character, row.radical.character ] }).to eq(
+        [ [ "学", "子" ], [ "校", "木" ] ]
+      )
+    end
+
+    it "marks fallback radicals as mastered when user knows the character" do
+      phrase = create(:dictionary_entry, text: "学校")
+
+      xue_entry = create(:dictionary_entry, text: "学")
+      radical = create(:radical, character: "子", meaning: "child", stroke_count: 3)
+      create(:dictionary_entry_radical, dictionary_entry: xue_entry, radical: radical, position: 1)
+
+      create(:user_learning, user: user, dictionary_entry: create(:dictionary_entry, text: "子"), state: "mastered")
+
+      result = described_class.call(user: user, dictionary_entry: phrase)
+
+      expect(result.first.mastered).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add radicals as an admin provisioning task so imports can be run from `/admin`
- render radical breakdown panels in learn review, review card, and dictionary entry views
- support multi-character vocabulary by falling back to per-character radical rows when direct phrase rows are missing

## Why
Radical data was only visible in part of the product, and multi-character entries often looked empty despite having usable component data for each character. This change makes radicals operationally importable and consistently visible where learners study cards and inspect vocabulary details.

The fallback strategy favors a deterministic learner experience over strict phrase-only decomposition. It does add some extra lookup work for multi-character entries, but keeps behavior predictable and covered by request/service specs.