### PR TITLE
fix: prioritise real pinyin over fallback sources

### DIFF
--- a/app/helpers/dictionary_import_helper.rb
+++ b/app/helpers/dictionary_import_helper.rb
@@ -2,10 +2,12 @@ module DictionaryImportHelper
   CC_CEDICT_REGEX = /^(?<traditional>\S+)\s+(?<simplified>\S+)\s+\[(?<pinyin>[^\]]+)\]\s+(?<meanings>\/.*\/)\s*$/
 
   def find_or_create_cc_cedict_source(source_name, source_url)
-    source = Source.find_or_create_by(name: source_name, url: source_url).tap do |source|
-      source.update(date_accessed: Date.today) if source.date_accessed != Date.today
-    end
-    source.save!
+    source = Source.find_or_create_by(name: source_name, url: source_url)
+    source.update!(
+      url: source_url,
+      date_accessed: Time.zone.today,
+      priority: 20
+    )
     source
   end
 

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -72,7 +72,12 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def source_priority(meaning)
-    meaning.source&.priority || 100
+    base_priority = meaning.source&.priority || 100
+    missing_pinyin?(meaning) ? base_priority + 1_000 : base_priority
+  end
+
+  def missing_pinyin?(meaning)
+    meaning.pinyin.blank? || meaning.pinyin.casecmp("unknown").zero?
   end
 
   def order_meanings_within_priority(candidate_meanings)

--- a/app/services/admin/unihan_provisioning_service.rb
+++ b/app/services/admin/unihan_provisioning_service.rb
@@ -67,13 +67,13 @@ module Admin
       source = Source.find_or_create_by!(name: "Unihan") do |s|
         s.url = UNIHAN_URL
         s.date_accessed = Time.zone.today
-        s.priority = 50
+        s.priority = 200
       end
 
       attrs = {
         url: UNIHAN_URL,
         date_accessed: Time.zone.today,
-        priority: 50
+        priority: 200
       }
       source.update!(attrs) if source.slice(*attrs.keys.map(&:to_s)) != attrs.stringify_keys
       source

--- a/app/services/admin/wiktionary_provisioning_service.rb
+++ b/app/services/admin/wiktionary_provisioning_service.rb
@@ -20,13 +20,13 @@ module Admin
       source = Source.find_or_create_by!(name: "Wiktionary") do |s|
         s.url = WIKTIONARY_URL
         s.date_accessed = Time.zone.today
-        s.priority = 10
+        s.priority = 50
       end
 
       source_attrs = {
         url: WIKTIONARY_URL,
         date_accessed: Time.zone.today,
-        priority: 10
+        priority: 50
       }
       source.update!(source_attrs) if source.slice(*source_attrs.keys.map(&:to_s)) != source_attrs.stringify_keys
 

--- a/db/migrate/20260508191500_backfill_source_priorities.rb
+++ b/db/migrate/20260508191500_backfill_source_priorities.rb
@@ -1,0 +1,15 @@
+class BackfillSourcePriorities < ActiveRecord::Migration[8.1]
+  class MigrationSource < ApplicationRecord
+    self.table_name = "sources"
+  end
+
+  def up
+    MigrationSource.where(name: "CC-CEDICT").update_all(priority: 20)
+    MigrationSource.where(name: "Wiktionary").update_all(priority: 50)
+    MigrationSource.where(name: "Unihan").update_all(priority: 200)
+  end
+
+  def down
+    MigrationSource.where(name: [ "CC-CEDICT", "Wiktionary", "Unihan" ]).update_all(priority: 100)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_164258) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_191500) do
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false

--- a/spec/helpers/dictionary_import_helper_spec.rb
+++ b/spec/helpers/dictionary_import_helper_spec.rb
@@ -21,7 +21,8 @@ describe "DictionaryImportHelper" do
       source = Source.find_by(name: "CC-CEDICT")
       expect(source).to be_present
       expect(source.url).to eq("https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
-      expect(source.date_accessed).to eq(Date.today)
+      expect(source.date_accessed).to eq(Time.zone.today)
+      expect(source.priority).to eq(20)
     end
 
     it "updates the date_accessed for an existing source" do
@@ -34,7 +35,8 @@ describe "DictionaryImportHelper" do
       find_or_create_cc_cedict_source("CC-CEDICT", "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
       existing_source.reload
 
-      expect(existing_source.date_accessed).to eq(Date.today)
+      expect(existing_source.date_accessed).to eq(Time.zone.today)
+      expect(existing_source.priority).to eq(20)
     end
   end
 

--- a/spec/models/dictionary_entry_spec.rb
+++ b/spec/models/dictionary_entry_spec.rb
@@ -143,12 +143,21 @@ RSpec.describe DictionaryEntry, type: :model do
     end
 
     it 'prioritises meanings from lower-priority-number sources' do
-      wiktionary_source = create(:source, name: 'Wiktionary', priority: 10)
+      wiktionary_source = create(:source, name: 'Wiktionary', priority: 50)
       create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'surname Li', pinyin: 'Lǐ')
       create(:meaning, dictionary_entry: entry, source: wiktionary_source, text: 'plum', pinyin: 'lǐ')
 
-      expect(entry.reload.flashcard_primary_meaning.source.name).to eq('Wiktionary')
-      expect(entry.flashcard_primary_meaning.text).to eq('plum')
+      expect(entry.reload.flashcard_primary_meaning.source.name).to eq('CC-CEDICT')
+      expect(entry.flashcard_primary_meaning.text).to eq('surname Li')
+    end
+
+    it 'deprioritises unknown pinyin even in a higher-priority source' do
+      wiktionary_source = create(:source, name: 'Wiktionary', priority: 50)
+      create(:meaning, dictionary_entry: entry, source: cedict_source, text: 'to study', pinyin: 'xué')
+      create(:meaning, dictionary_entry: entry, source: wiktionary_source, text: 'to study', pinyin: 'Unknown')
+
+      expect(entry.reload.flashcard_primary_meaning.source.name).to eq('CC-CEDICT')
+      expect(entry.flashcard_primary_pinyin).to eq('xué')
     end
 
     it 'keeps CC-CEDICT heuristics within the same source priority band' do

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "DictionaryEntries", type: :request do
         dictionary_entry.meanings.destroy_all
 
         cedict = create(:source, name: "CC-CEDICT", priority: 20)
-        wiktionary = create(:source, name: "Wiktionary", priority: 10)
+        wiktionary = create(:source, name: "Wiktionary", priority: 50)
 
         create(:meaning,
                dictionary_entry: dictionary_entry,
@@ -90,7 +90,7 @@ RSpec.describe "DictionaryEntries", type: :request do
 
         get dictionary_entry_path(dictionary_entry)
 
-        expect(response.body.index("plum")).to be < response.body.index("surname Li")
+        expect(response.body.index("surname Li")).to be < response.body.index("plum")
       end
 
       it "shows radical breakdown details" do

--- a/spec/services/admin/unihan_provisioning_service_spec.rb
+++ b/spec/services/admin/unihan_provisioning_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Admin::UnihanProvisioningService do
 
     it "creates a Unihan source with expected priority" do
       expect { result }.to change { Source.where(name: "Unihan").count }.by(1)
-      expect(Source.find_by(name: "Unihan").priority).to eq(50)
+      expect(Source.find_by(name: "Unihan").priority).to eq(200)
     end
 
     it "imports only kDefinition rows for Han characters" do
@@ -46,7 +46,7 @@ RSpec.describe Admin::UnihanProvisioningService do
     end
 
     it "skips importing meanings when higher-priority source meaning exists" do
-      wiktionary = create(:source, name: "Wiktionary", priority: 10)
+      wiktionary = create(:source, name: "Wiktionary", priority: 50)
       entry = create(:dictionary_entry, text: "你")
       entry.meanings.destroy_all
       create(:meaning,


### PR DESCRIPTION
## Summary
- Rebalance dictionary source priorities so CC-CEDICT is preferred for flashcard primary meanings, with Wiktionary secondary and Unihan as fallback.
- Add a migration to backfill existing `sources.priority` values to the new ordering.
- Deprioritise meanings with blank/`Unknown` pinyin during primary meaning selection, and add regression specs for ordering and pinyin fallback behaviour.

## Testing
- `bin/rails db:migrate`
- `bundle exec rspec spec/models/dictionary_entry_spec.rb spec/helpers/dictionary_import_helper_spec.rb spec/services/admin/unihan_provisioning_service_spec.rb spec/services/admin/wiktionary_provisioning_service_spec.rb spec/requests/dictionary_entries_spec.rb`