### PR TITLE
feat: replace dashboard new-count with HSK milestone

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -20,6 +20,7 @@ class DashboardController < ApplicationController
 
     @new_cards_count = @state_counts[:new]
     @next_hsk_milestone = build_next_hsk_milestone
+    @mastered_characters_count = count_mastered_characters(user_learnings)
 
     @vocabulary_sections = build_vocabulary_sections
   end
@@ -127,5 +128,20 @@ class DashboardController < ApplicationController
 
     number = name[/\d+/]&.to_i
     [ number || 9_998, 0 ]
+  end
+
+  def count_mastered_characters(user_learnings)
+    texts = user_learnings
+      .mastered
+      .joins(:dictionary_entry)
+      .distinct
+      .pluck("dictionary_entries.text")
+
+    seen = {}
+    texts.each do |text|
+      text.to_s.each_char { |char| seen[char] = true }
+    end
+
+    seen.size
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -83,43 +83,37 @@ class DashboardController < ApplicationController
   end
 
   def build_next_hsk_milestone
-    hsk3 = Tag.find_by(name: "HSK 3.0")
+    hsk_root = Tag.find_by(name: "HSK", parent_id: nil)
+    return nil unless hsk_root
+
+    hsk3 = hsk_root.children.find_by(name: "HSK 3.0")
     return nil unless hsk3
 
     levels = hsk3.children.sort_by { |tag| hsk_level_sort_key(tag.name) }
     return nil if levels.empty?
 
-    level_ids = levels.map(&:id)
-
-    entry_counts = DictionaryEntryTag
-      .where(tag_id: level_ids)
-      .group(:tag_id)
-      .count
-
-    mastered_counts = UserLearning
-      .where(user: Current.user, state: "mastered")
-      .joins(dictionary_entry: :dictionary_entry_tags)
-      .where(dictionary_entry_tags: { tag_id: level_ids })
-      .group("dictionary_entry_tags.tag_id")
-      .count
+    level_stats = level_tag_stats(levels)
+    return nil if level_stats.values.all? { |stats| stats[:total].zero? }
 
     next_level = levels.find do |level|
-      total = entry_counts[level.id] || 0
+      stats = level_stats[level.id]
+      total = stats[:total]
       next false if total.zero?
 
-      mastered = mastered_counts[level.id] || 0
+      mastered = stats[:mastered]
       mastered < total
     end
 
     return { complete: true } unless next_level
 
-    total = entry_counts[next_level.id] || 0
-    mastered = mastered_counts[next_level.id] || 0
+    stats = level_stats[next_level.id]
+    total = stats[:total]
+    mastered = stats[:mastered]
 
     {
       complete: false,
       tier_name: next_level.name,
-      remaining_words: total - mastered
+      remaining_words: [ total - mastered, 0 ].max
     }
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -19,6 +19,7 @@ class DashboardController < ApplicationController
     }
 
     @new_cards_count = @state_counts[:new]
+    @next_hsk_milestone = build_next_hsk_milestone
 
     @vocabulary_sections = build_vocabulary_sections
   end
@@ -78,5 +79,53 @@ class DashboardController < ApplicationController
     %i[total mastered learning new_count not_started].each_with_object({}) do |key, agg|
       agg[key] = stats_list.sum { |s| s[key] }
     end
+  end
+
+  def build_next_hsk_milestone
+    hsk3 = Tag.find_by(name: "HSK 3.0")
+    return nil unless hsk3
+
+    levels = hsk3.children.sort_by { |tag| hsk_level_sort_key(tag.name) }
+    return nil if levels.empty?
+
+    level_ids = levels.map(&:id)
+
+    entry_counts = DictionaryEntryTag
+      .where(tag_id: level_ids)
+      .group(:tag_id)
+      .count
+
+    mastered_counts = UserLearning
+      .where(user: Current.user, state: "mastered")
+      .joins(dictionary_entry: :dictionary_entry_tags)
+      .where(dictionary_entry_tags: { tag_id: level_ids })
+      .group("dictionary_entry_tags.tag_id")
+      .count
+
+    next_level = levels.find do |level|
+      total = entry_counts[level.id] || 0
+      next false if total.zero?
+
+      mastered = mastered_counts[level.id] || 0
+      mastered < total
+    end
+
+    return { complete: true } unless next_level
+
+    total = entry_counts[next_level.id] || 0
+    mastered = mastered_counts[next_level.id] || 0
+
+    {
+      complete: false,
+      tier_name: next_level.name,
+      remaining_words: total - mastered
+    }
+  end
+
+  def hsk_level_sort_key(name)
+    return [ 9_999, 0 ] if name.include?("7-9")
+
+    number = name[/\d+/]&.to_i
+    [ number || 9_998, 0 ]
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -48,7 +48,15 @@
     <%# Learn panel %>
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col">
       <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-1">Learn</h2>
-      <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">New characters to introduce</p>
+      <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">
+        <% if @next_hsk_milestone.nil? %>
+          New words to introduce
+        <% elsif @next_hsk_milestone[:complete] %>
+          All HSK 3.0 tiers mastered
+        <% else %>
+          <%= @next_hsk_milestone[:remaining_words] %> words until <%= @next_hsk_milestone[:tier_name] %> mastery
+        <% end %>
+      </p>
       <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6"><%= @new_cards_count %></div>
       <%= link_to learn_path,
             class: "mt-auto inline-block text-center bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-5 py-3 transition-colors" do %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -54,7 +54,7 @@
         <% elsif @next_hsk_milestone[:complete] %>
           HSK 3.0 tiers mastered
         <% else %>
-          words until <%= @next_hsk_milestone[:tier_name] %> mastery
+          <%= pluralize(@next_hsk_milestone[:remaining_words], "word") %> until <%= @next_hsk_milestone[:tier_name] %> mastery
         <% end %>
       </p>
       <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6 text-center">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -46,7 +46,7 @@
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
 
     <%# Learn panel %>
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col text-center">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col">
       <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-1">Learn</h2>
       <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">
         <% if @next_hsk_milestone.nil? %>
@@ -57,7 +57,7 @@
           words until <%= @next_hsk_milestone[:tier_name] %> mastery
         <% end %>
       </p>
-      <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">
+      <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6 text-center">
         <% if @next_hsk_milestone.nil? %>
           <%= @new_cards_count %>
         <% elsif @next_hsk_milestone[:complete] %>
@@ -97,7 +97,7 @@
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col">
       <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-1">Progress</h2>
       <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">Your learning state breakdown</p>
-      <dl class="space-y-3 flex-grow">
+      <dl class="space-y-3">
         <div class="flex justify-between items-center">
           <dt class="text-gray-600 dark:text-gray-400">Mastered</dt>
           <dd class="font-bold text-green-600 text-lg"><%= @state_counts[:mastered] %></dd>
@@ -106,11 +106,11 @@
           <dt class="text-gray-600 dark:text-gray-400">Learning</dt>
           <dd class="font-bold text-amber-500 text-lg"><%= @state_counts[:learning] %></dd>
         </div>
-        <div class="flex justify-between items-center">
-          <dt class="text-gray-600 dark:text-gray-400">New</dt>
-          <dd class="font-bold text-gray-400 text-lg"><%= @state_counts[:new] %></dd>
-        </div>
       </dl>
+      <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-between items-center">
+        <span class="text-gray-600 dark:text-gray-400">Characters mastered</span>
+        <span class="font-bold text-gray-900 dark:text-gray-100 text-lg"><%= @mastered_characters_count %></span>
+      </div>
     </div>
 
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -52,12 +52,20 @@
         <% if @next_hsk_milestone.nil? %>
           New words to introduce
         <% elsif @next_hsk_milestone[:complete] %>
-          All HSK 3.0 tiers mastered
+          HSK 3.0 tiers mastered
         <% else %>
-          <%= @next_hsk_milestone[:remaining_words] %> words until <%= @next_hsk_milestone[:tier_name] %> mastery
+          words until <%= @next_hsk_milestone[:tier_name] %> mastery
         <% end %>
       </p>
-      <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6"><%= @new_cards_count %></div>
+      <div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">
+        <% if @next_hsk_milestone.nil? %>
+          <%= @new_cards_count %>
+        <% elsif @next_hsk_milestone[:complete] %>
+          0
+        <% else %>
+          <%= @next_hsk_milestone[:remaining_words] %>
+        <% end %>
+      </div>
       <%= link_to learn_path,
             class: "mt-auto inline-block text-center bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-5 py-3 transition-colors" do %>
         <%= @new_cards_count > 0 ? "Start learning" : "Nothing new today" %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -46,7 +46,7 @@
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
 
     <%# Learn panel %>
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 flex flex-col text-center">
       <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-1">Learn</h2>
       <p class="text-gray-500 dark:text-gray-400 text-sm mb-4">
         <% if @next_hsk_milestone.nil? %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Dashboard", type: :request do
         it "shows words remaining until the next incomplete HSK tier" do
           get root_path
           expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6 text-center">\s*1\s*</div>})
-          expect(response.body).to include("words until HSK 1 mastery")
+          expect(response.body).to include("1 word until HSK 1 mastery")
         end
 
         context "when all HSK 3.0 tiers are mastered" do
@@ -222,6 +222,36 @@ RSpec.describe "Dashboard", type: :request do
           it "falls back to the default learn panel copy" do
             get root_path
             expect(response.body).to include("New words to introduce")
+          end
+        end
+
+        context "when HSK 3.0 tiers exist but have no tagged entries" do
+          let!(:hsk3_empty)   { create(:tag, name: "HSK 3.0", parent: hsk_root) }
+          let!(:hsk3_empty_1) { create(:tag, name: "HSK 1", parent: hsk3_empty) }
+
+          before do
+            hsk3.destroy!
+          end
+
+          it "falls back to the default learn panel copy" do
+            get root_path
+            expect(response.body).to include("New words to introduce")
+          end
+        end
+
+        context "when another orphan HSK 3.0 tag exists" do
+          before do
+            orphan_hsk3 = create(:tag, name: "HSK 3.0")
+            orphan_level = create(:tag, name: "HSK 1", parent: orphan_hsk3)
+            orphan_entry = create(:dictionary_entry)
+            orphan_entry.tags << orphan_level
+            create(:user_learning, user: user, dictionary_entry: orphan_entry,
+                   state: "new")
+          end
+
+          it "uses the HSK root hierarchy for milestone calculations" do
+            get root_path
+            expect(response.body).to include("1 word until HSK 1 mastery")
           end
         end
       end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -177,6 +177,52 @@ RSpec.describe "Dashboard", type: :request do
           end
         end
       end
+
+      context "with HSK 3.0 milestone data" do
+        let!(:hsk_root)    { create(:tag, name: "HSK") }
+        let!(:hsk3)        { create(:tag, name: "HSK 3.0", parent: hsk_root) }
+        let!(:hsk1)        { create(:tag, name: "HSK 1", parent: hsk3) }
+        let!(:hsk2)        { create(:tag, name: "HSK 2", parent: hsk3) }
+        let!(:hsk1_entry_a) { create(:dictionary_entry).tap { |e| e.tags << hsk1 } }
+        let!(:hsk1_entry_b) { create(:dictionary_entry).tap { |e| e.tags << hsk1 } }
+        let!(:hsk2_entry)   { create(:dictionary_entry).tap { |e| e.tags << hsk2 } }
+
+        before do
+          create(:user_learning, user: user, dictionary_entry: hsk1_entry_a,
+                 state: "mastered")
+          create(:user_learning, user: user, dictionary_entry: hsk1_entry_b,
+                 state: "new")
+          create(:user_learning, user: user, dictionary_entry: hsk2_entry,
+                 state: "new")
+        end
+
+        it "shows words remaining until the next incomplete HSK tier" do
+          get root_path
+          expect(response.body).to include("1 words until HSK 1 mastery")
+        end
+
+        context "when all HSK 3.0 tiers are mastered" do
+          before do
+            UserLearning.where(user: user).update_all(state: "mastered")
+          end
+
+          it "shows a clear completion state" do
+            get root_path
+            expect(response.body).to include("All HSK 3.0 tiers mastered")
+          end
+        end
+
+        context "when HSK 3.0 tags are missing" do
+          before do
+            hsk3.destroy!
+          end
+
+          it "falls back to the default learn panel copy" do
+            get root_path
+            expect(response.body).to include("New words to introduce")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe "Dashboard", type: :request do
 
         it "shows words remaining until the next incomplete HSK tier" do
           get root_path
-          expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">\s*1\s*</div>})
+          expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6 text-center">\s*1\s*</div>})
           expect(response.body).to include("words until HSK 1 mastery")
         end
 
@@ -210,7 +210,7 @@ RSpec.describe "Dashboard", type: :request do
           it "shows a clear completion state" do
             get root_path
             expect(response.body).to include("HSK 3.0 tiers mastered")
-            expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">\s*0\s*</div>})
+            expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6 text-center">\s*0\s*</div>})
           end
         end
 
@@ -223,6 +223,35 @@ RSpec.describe "Dashboard", type: :request do
             get root_path
             expect(response.body).to include("New words to introduce")
           end
+        end
+      end
+
+      context "with mastered vocabulary containing overlapping characters" do
+        let!(:entry_hello) { create(:dictionary_entry, text: "你好") }
+        let!(:entry_you)   { create(:dictionary_entry, text: "你") }
+        let!(:entry_good)  { create(:dictionary_entry, text: "好") }
+        let!(:entry_new)   { create(:dictionary_entry, text: "学") }
+
+        before do
+          create(:user_learning, user: user, dictionary_entry: entry_hello,
+                 state: "mastered")
+          create(:user_learning, user: user, dictionary_entry: entry_you,
+                 state: "mastered")
+          create(:user_learning, user: user, dictionary_entry: entry_good,
+                 state: "mastered")
+          create(:user_learning, user: user, dictionary_entry: entry_new,
+                 state: "new")
+        end
+
+        it "shows deduplicated mastered character count in progress" do
+          get root_path
+          expect(response.body).to include("Characters mastered")
+          expect(response.body).to match(%r{Characters mastered</span>\s*<span[^>]*>2</span>})
+        end
+
+        it "does not render the old New row in progress" do
+          get root_path
+          expect(response.body).not_to include("New</dt>")
         end
       end
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe "Dashboard", type: :request do
 
         it "shows words remaining until the next incomplete HSK tier" do
           get root_path
-          expect(response.body).to include("1 words until HSK 1 mastery")
+          expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">\s*1\s*</div>})
+          expect(response.body).to include("words until HSK 1 mastery")
         end
 
         context "when all HSK 3.0 tiers are mastered" do
@@ -208,7 +209,8 @@ RSpec.describe "Dashboard", type: :request do
 
           it "shows a clear completion state" do
             get root_path
-            expect(response.body).to include("All HSK 3.0 tiers mastered")
+            expect(response.body).to include("HSK 3.0 tiers mastered")
+            expect(response.body).to match(%r{<div class="text-6xl font-extrabold text-gray-900 dark:text-gray-100 mb-6">\s*0\s*</div>})
           end
         end
 


### PR DESCRIPTION
## Summary
- replace the Learn panel's overwhelming aggregate copy with a progress-oriented HSK 3.0 milestone
- compute the first incomplete HSK 3.0 tier and render `{n} words until HSK {x} mastery`
- add request specs for milestone rendering, full-completion state, and fallback behavior when HSK 3.0 tags are missing

## Testing
- bundle exec rspec

Closes #288