### PR TITLE
fix: auto-download radicals source files

### DIFF
--- a/app/services/admin/radicals_provisioning_service.rb
+++ b/app/services/admin/radicals_provisioning_service.rb
@@ -3,6 +3,10 @@ require "set"
 
 module Admin
   class RadicalsProvisioningService
+    include ImportFilesHelper
+
+    DICTIONARY_URL = "https://raw.githubusercontent.com/skishore/makemeahanzi/master/dictionary.txt"
+    GRAPHICS_URL = "https://raw.githubusercontent.com/skishore/makemeahanzi/master/graphics.txt"
     DICTIONARY_PATH = Rails.root.join("tmp", "makemeahanzi", "dictionary.txt")
     GRAPHICS_PATH = Rails.root.join("tmp", "makemeahanzi", "graphics.txt")
     BATCH_SIZE = 900
@@ -18,6 +22,8 @@ module Admin
     end
 
     def call
+      ensure_source_files!
+
       records = parsed_records
       return empty_result if records.empty?
 
@@ -47,6 +53,18 @@ module Admin
     end
 
     private
+
+    def ensure_source_files!
+      ensure_source_file!(DICTIONARY_URL, @dictionary_path)
+      ensure_source_file!(GRAPHICS_URL, @graphics_path)
+    end
+
+    def ensure_source_file!(url, path)
+      return if File.exist?(path)
+
+      download_file_to_tmp(url, path)
+      confirm_file_presence(Pathname(path).basename.to_s, Pathname(path).dirname)
+    end
 
     def parsed_records
       return [] unless File.exist?(@dictionary_path)

--- a/spec/services/admin/radicals_provisioning_service_spec.rb
+++ b/spec/services/admin/radicals_provisioning_service_spec.rb
@@ -30,6 +30,39 @@ RSpec.describe Admin::RadicalsProvisioningService do
 
     after { FileUtils.rm_rf(tmp_dir) }
 
+    it "downloads source files when paths are missing" do
+      service = described_class.new(
+        dictionary_path: dictionary_path.to_s,
+        graphics_path: graphics_path.to_s
+      )
+
+      FileUtils.rm_f(dictionary_path)
+      FileUtils.rm_f(graphics_path)
+
+      expect(service).to receive(:download_file_to_tmp)
+        .with(Admin::RadicalsProvisioningService::DICTIONARY_URL, dictionary_path.to_s)
+        .ordered do |_url, dest|
+          File.write(dest, "{\"character\":\"语\",\"decomposition\":\"⿰讠吾\"}\n")
+        end
+
+      expect(service).to receive(:confirm_file_presence)
+        .with("dictionary.txt", dictionary_path.dirname)
+        .ordered
+
+      expect(service).to receive(:download_file_to_tmp)
+        .with(Admin::RadicalsProvisioningService::GRAPHICS_URL, graphics_path.to_s)
+        .ordered do |_url, dest|
+          File.write(dest, "{\"character\":\"吾\",\"strokes\":[\"a\"]}\n")
+        end
+
+      expect(service).to receive(:confirm_file_presence)
+        .with("graphics.txt", graphics_path.dirname)
+        .ordered
+
+      result = service.call
+      expect(result).to include(entries_processed: 1, associations_created: 2)
+    end
+
     it "creates radicals and dictionary entry associations" do
       result = described_class.call(dictionary_path: dictionary_path.to_s, graphics_path: graphics_path.to_s)
 


### PR DESCRIPTION
## Summary
- fix radicals provisioning returning zero processed entries when makemeahanzi source files are missing
- make `Admin::RadicalsProvisioningService` download `dictionary.txt` and `graphics.txt` on demand before parsing
- add service spec coverage for the missing-file path so provisioning still imports rows after download

## Testing
- bundle exec rspec spec/services/admin/radicals_provisioning_service_spec.rb spec/tasks/radicals_spec.rb spec/jobs/admin/provisioning_job_spec.rb
- bundle exec rspec