### PR TITLE
fix: prevent mobile radical clipping

### DIFF
--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -19,7 +19,7 @@
 
   <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
-    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
+    <div class="min-h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
       <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 
       <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6 flex-1 min-h-0">

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -19,7 +19,7 @@
   <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
     <%# Card %>
-    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
+    <div class="min-h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
       <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 
       <div class="mt-6 w-full border-t border-gray-100 dark:border-gray-700 pt-6 flex-1 min-h-0 overflow-y-auto pr-1">

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -18,7 +18,7 @@
 
   <div class="w-full max-w-xl flex flex-col items-stretch px-4 sm:px-0">
 
-    <div class="h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
+    <div class="min-h-[28rem] md:h-[30rem] bg-white dark:bg-gray-800 rounded-2xl shadow-lg flex flex-col items-center px-8 md:px-10 pt-12 pb-10 text-center">
 
       <span data-adaptive-card-text-target="hanzi" class="text-9xl font-hanzi text-gray-900 dark:text-gray-100 select-none whitespace-nowrap antialiased"><%= entry.text %></span>
 

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -190,13 +190,14 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include(new_card.dictionary_entry.text)
       end
 
-      it "renders a fixed-height adaptive card container" do
+      it "renders a responsive adaptive card container" do
         get learn_card_path
         expect(response.body).to include('data-card-layout="fixed"')
         expect(response.body).to include('data-card-text-scaling="adaptive"')
         expect(response.body).to include("learn-card")
         expect(response.body).to include("adaptive-card-text")
         expect(response.body).to include("w-full max-w-xl")
+        expect(response.body).to include("min-h-[28rem] md:h-[30rem]")
       end
 
       it "shows a supplemental meanings toggle when available" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -196,13 +196,14 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to include("1 / 1")
       end
 
-      it "renders a fixed-height adaptive card" do
+      it "renders a responsive adaptive card" do
         get review_card_path
         expect(response.body).to include('data-card-layout="fixed"')
         expect(response.body).to include('data-card-text-scaling="adaptive"')
         expect(response.body).to include("card-flip")
         expect(response.body).to include("adaptive-card-text")
         expect(response.body).to include("w-full max-w-xl")
+        expect(response.body).to include("min-h-[28rem] md:h-[30rem]")
       end
 
       it "shows a supplemental meanings toggle when multiple meanings exist" do


### PR DESCRIPTION
## Summary
- let learn and review cards grow beyond their mobile minimum height so the character components panel is no longer clipped at the bottom
- keep the existing fixed desktop height while preserving the adaptive card layout on larger screens
- update request specs to assert the responsive card shell classes on learn and review pages

## Testing
- bundle exec rspec spec/requests/learn_spec.rb spec/requests/review_spec.rb

Closes #295