### PR TITLE
fix: show heteronym readings on cards

### DIFF
--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -57,7 +57,7 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def flashcard_meaning_groups
-    flashcard_meanings.group_by(&:pinyin).values
+    flashcard_meanings.group_by { |meaning| normalized_pinyin_group_key(meaning.pinyin) }.values
   end
 
   private
@@ -82,6 +82,10 @@ class DictionaryEntry < ApplicationRecord
 
   def missing_pinyin?(meaning)
     meaning.pinyin.blank? || meaning.pinyin.casecmp("unknown").zero?
+  end
+
+  def normalized_pinyin_group_key(pinyin)
+    pinyin.to_s.downcase
   end
 
   def order_meanings_within_priority(candidate_meanings)

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -56,6 +56,10 @@ class DictionaryEntry < ApplicationRecord
     flashcard_meanings.first
   end
 
+  def flashcard_meaning_groups
+    flashcard_meanings.group_by(&:pinyin).values
+  end
+
   private
 
   def fetch_english_meanings

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -6,10 +6,21 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  meanings = entry.flashcard_meanings
-  primary_meaning       = meanings.first
-  pinyin   = primary_meaning&.pinyin
-  supplemental_meanings = meanings.drop(1)
+  meaning_groups = entry.flashcard_meaning_groups
+  primary_group = meaning_groups.first || []
+  primary_meaning = primary_group.first
+  pinyin = primary_meaning&.pinyin
+  supplemental_meaning_groups = []
+
+  if primary_group.drop(1).any?
+    supplemental_meaning_groups << [ pinyin, primary_group.drop(1) ]
+  end
+
+  meaning_groups.drop(1).each do |group|
+    supplemental_meaning_groups << [ group.first&.pinyin, group ]
+  end
+
+  multiple_readings = meaning_groups.filter_map { |group| group.first&.pinyin.presence }.uniq.many?
 %>
 
 <div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
@@ -31,18 +42,28 @@
           <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
           <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
 
-          <% if supplemental_meanings.any? %>
+          <% if supplemental_meaning_groups.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
               <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>
 
-              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-gray-600 dark:text-gray-300 text-sm">
-                <% supplemental_meanings.each do |meaning| %>
-                  <li><%= meaning.text %></li>
+              <div data-collapsible-target="content" class="hidden mt-3 space-y-3 text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meaning_groups.each do |group_pinyin, group_meanings| %>
+                  <div>
+                    <% if multiple_readings && group_pinyin.present? %>
+                      <p class="mb-1 text-xs uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500"><%= group_pinyin %></p>
+                    <% end %>
+
+                    <ul class="space-y-2">
+                      <% group_meanings.each do |meaning| %>
+                        <li><%= meaning.text %></li>
+                      <% end %>
+                    </ul>
+                  </div>
                 <% end %>
-              </ul>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/learn/show.html.erb
+++ b/app/views/learn/show.html.erb
@@ -6,10 +6,21 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  meanings = entry.flashcard_meanings
-  primary_meaning       = meanings.first
-  pinyin   = primary_meaning&.pinyin
-  supplemental_meanings = meanings.drop(1)
+  meaning_groups = entry.flashcard_meaning_groups
+  primary_group = meaning_groups.first || []
+  primary_meaning = primary_group.first
+  pinyin = primary_meaning&.pinyin
+  supplemental_meaning_groups = []
+
+  if primary_group.drop(1).any?
+    supplemental_meaning_groups << [ pinyin, primary_group.drop(1) ]
+  end
+
+  meaning_groups.drop(1).each do |group|
+    supplemental_meaning_groups << [ group.first&.pinyin, group ]
+  end
+
+  multiple_readings = meaning_groups.filter_map { |group| group.first&.pinyin.presence }.uniq.many?
 %>
 
 <div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="learn-card adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
@@ -30,18 +41,28 @@
         <div data-learn-card-target="meaning" class="hidden mt-4">
           <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
 
-          <% if supplemental_meanings.any? %>
+          <% if supplemental_meaning_groups.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4 text-left">
               <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>
 
-              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-gray-600 dark:text-gray-300 text-sm">
-                <% supplemental_meanings.each do |meaning| %>
-                  <li><%= meaning.text %></li>
+              <div data-collapsible-target="content" class="hidden mt-3 space-y-3 text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meaning_groups.each do |group_pinyin, group_meanings| %>
+                  <div>
+                    <% if multiple_readings && group_pinyin.present? %>
+                      <p class="mb-1 text-xs uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500"><%= group_pinyin %></p>
+                    <% end %>
+
+                    <ul class="space-y-2">
+                      <% group_meanings.each do |meaning| %>
+                        <li><%= meaning.text %></li>
+                      <% end %>
+                    </ul>
+                  </div>
                 <% end %>
-              </ul>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -6,10 +6,21 @@
 
 <%
   entry    = @user_learning.dictionary_entry
-  meanings = entry.flashcard_meanings
-  primary_meaning      = meanings.first
-  pinyin   = primary_meaning&.pinyin
-  supplemental_meanings = meanings.drop(1)
+  meaning_groups = entry.flashcard_meaning_groups
+  primary_group = meaning_groups.first || []
+  primary_meaning = primary_group.first
+  pinyin = primary_meaning&.pinyin
+  supplemental_meaning_groups = []
+
+  if primary_group.drop(1).any?
+    supplemental_meaning_groups << [ pinyin, primary_group.drop(1) ]
+  end
+
+  meaning_groups.drop(1).each do |group|
+    supplemental_meaning_groups << [ group.first&.pinyin, group ]
+  end
+
+  multiple_readings = meaning_groups.filter_map { |group| group.first&.pinyin.presence }.uniq.many?
 %>
 
 <div class="w-full flex flex-col items-center pt-6 sm:pt-12 pb-8 sm:pb-12" data-controller="card-flip adaptive-card-text" data-card-layout="fixed" data-card-text-scaling="adaptive">
@@ -31,18 +42,28 @@
           <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
           <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
 
-          <% if supplemental_meanings.any? %>
+          <% if supplemental_meaning_groups.any? %>
             <div data-controller="collapsible" data-collapsible-open-value="false" class="mt-4">
               <button type="button" data-collapsible-target="button" data-action="click->collapsible#toggle" class="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <span>Show more meanings</span>
                 <span data-collapsible-target="chevron" class="inline-block transition-transform">▸</span>
               </button>
 
-              <ul data-collapsible-target="content" class="hidden mt-3 space-y-2 text-left text-gray-600 dark:text-gray-300 text-sm">
-                <% supplemental_meanings.each do |meaning| %>
-                  <li><%= meaning.text %></li>
+              <div data-collapsible-target="content" class="hidden mt-3 space-y-3 text-left text-gray-600 dark:text-gray-300 text-sm">
+                <% supplemental_meaning_groups.each do |group_pinyin, group_meanings| %>
+                  <div>
+                    <% if multiple_readings && group_pinyin.present? %>
+                      <p class="mb-1 text-xs uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500"><%= group_pinyin %></p>
+                    <% end %>
+
+                    <ul class="space-y-2">
+                      <% group_meanings.each do |meaning| %>
+                        <li><%= meaning.text %></li>
+                      <% end %>
+                    </ul>
+                  </div>
                 <% end %>
-              </ul>
+              </div>
             </div>
           <% end %>
 

--- a/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
+++ b/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe DictionaryEntry, "flashcard primary meaning selection" do
       expect(grouped_pinyin).to contain_exactly([ "jiǎ" ], [ "jià" ])
       expect(grouped_text).to include([ "fake" ], [ "holiday", "vacation" ])
     end
+
+    it "treats pinyin that differs only by case as one reading" do
+      entry = create_entry_with_meanings("王", [
+        { pinyin: "Wáng", text: "surname Wang" },
+        { pinyin: "wáng", text: "king" }
+      ])
+
+      groups = entry.flashcard_meaning_groups
+
+      expect(groups.size).to eq(1)
+      expect(groups.first.map(&:text)).to eq([ "king", "surname Wang" ])
+      expect(groups.first.map(&:pinyin)).to eq([ "wáng", "Wáng" ])
+    end
   end
 
   describe "for an entry where one reading has several plain senses" do

--- a/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
+++ b/spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe DictionaryEntry, "flashcard primary meaning selection" do
     end
   end
 
+  describe "flashcard meaning groups" do
+    it "keeps alternate readings grouped by pinyin in flashcard order" do
+      entry = create_entry_with_meanings("假", [
+        { pinyin: "jiǎ", text: "fake" },
+        { pinyin: "jià", text: "holiday" },
+        { pinyin: "jià", text: "vacation" }
+      ])
+
+      groups = entry.flashcard_meaning_groups
+      grouped_pinyin = groups.map { |group| group.map(&:pinyin).uniq }
+      grouped_text = groups.map { |group| group.map(&:text) }
+
+      expect(grouped_pinyin.first).to eq([ entry.flashcard_primary_meaning.pinyin ])
+      expect(grouped_pinyin).to contain_exactly([ "jiǎ" ], [ "jià" ])
+      expect(grouped_text).to include([ "fake" ], [ "holiday", "vacation" ])
+    end
+  end
+
   describe "for an entry where one reading has several plain senses" do
     it "prefers that reading over a single plain alternative" do
       entry = create_entry_with_meanings("便宜", [

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -207,6 +207,25 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include("Show more meanings")
       end
 
+      it "shows alternate reading pinyin alongside heteronym meanings" do
+        new_card.dictionary_entry.meanings.destroy_all
+        cedict_source = create(:source,
+                               name: "CC-CEDICT",
+                               url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
+        create(:meaning, dictionary_entry: new_card.dictionary_entry,
+                         source: cedict_source,
+                         text: "fake", pinyin: "jiǎ")
+        create(:meaning, dictionary_entry: new_card.dictionary_entry,
+                         source: cedict_source,
+                         text: "holiday", pinyin: "jià")
+
+        get learn_card_path
+
+        expect(response.body).to include("fake")
+        expect(response.body).to include("jià")
+        expect(response.body).to include("holiday")
+      end
+
       it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
         new_card.dictionary_entry.meanings.destroy_all
         cedict_source = create(:source,

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -213,6 +213,25 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to include("Show more meanings")
       end
 
+      it "shows alternate reading pinyin alongside heteronym meanings" do
+        user_learning.dictionary_entry.meanings.destroy_all
+        cedict_source = create(:source,
+                               name: "CC-CEDICT",
+                               url: "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip")
+        create(:meaning, dictionary_entry: user_learning.dictionary_entry,
+                         source: cedict_source,
+                         text: "fake", pinyin: "jiǎ")
+        create(:meaning, dictionary_entry: user_learning.dictionary_entry,
+                         source: cedict_source,
+                         text: "holiday", pinyin: "jià")
+
+        get review_card_path
+
+        expect(response.body).to include("fake")
+        expect(response.body).to include("jià")
+        expect(response.body).to include("holiday")
+      end
+
       it "uses learner-friendly CC-CEDICT meaning and pinyin as primary" do
         user_learning.dictionary_entry.meanings.destroy_all
         cedict_source = create(:source,


### PR DESCRIPTION
## Summary
- group supplemental flashcard meanings by pinyin so alternate readings stay attached to their own senses
- label alternate readings in the learn and review card UIs when an entry has multiple pronunciations
- add request and model coverage for heteronym flashcards such as 假

## Testing
- SIMPLECOV_DISABLE=1 bundle exec rspec spec/models/dictionary_entry/flashcard_primary_meaning_selector_spec.rb spec/requests/learn_spec.rb spec/requests/review_spec.rb

## Notes
- the focused spec run passes all examples, but the repo's global SimpleCov minimum still makes partial runs exit non-zero

## Deliberate decisions
- Kept the meaning-group preparation inline in the three card templates rather than introducing a presenter/helper in this PR. The logic is still small and tightly coupled to these specific templates, while the review fix here was primarily about heteronym visibility and the case-normalization bug.