### PR TITLE
feat: add pronunciation audio

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DashboardController < BaseController
-    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary unihan makemeahanzi_source hsk_tags frequency_data radicals stroke_order].freeze
+    TASK_TYPES_IN_ORDER = %w[cc_cedict custom_dictionary wiktionary unihan makemeahanzi_source hsk_tags audio_pronunciations frequency_data radicals stroke_order].freeze
 
     def index
       @tasks_by_type = AdminTask::VALID_TASK_TYPES.index_with do |type|
@@ -42,6 +42,7 @@ module Admin
           Admin::MakemeahanziSourceProvisioningService.dictionary_path,
           Admin::MakemeahanziSourceProvisioningService.graphics_path
         ].count(&:exist?),
+        audio_pronunciations: AudioPronunciation.count,
         frequency_entries:  DictionaryEntry.where.not(frequency_rank: nil).count,
         radical_entries:    DictionaryEntryRadical.select(:dictionary_entry_id).distinct.count,
         stroke_order_entries: StrokeOrderDatum.count

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -199,14 +199,14 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: { meanings: :source })
+           .includes(dictionary_entry: [ { meanings: :source }, { audio_pronunciations: { audio_attachment: :blob } } ])
            .find(id)
   end
 
   def current_review_card
     id = session[:learn_introduced][session[:learn_review_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: { meanings: :source })
+           .includes(dictionary_entry: [ { meanings: :source }, { audio_pronunciations: { audio_attachment: :blob } } ])
            .find(id)
   end
 end

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -199,14 +199,14 @@ class LearnController < ApplicationController
   def current_card
     id = session[:learn_queue][session[:learn_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: [ { meanings: :source }, { audio_pronunciations: { audio_attachment: :blob } } ])
+           .includes(dictionary_entry: [ { meanings: :source }, :audio_pronunciations ])
            .find(id)
   end
 
   def current_review_card
     id = session[:learn_introduced][session[:learn_review_index]]
     Current.user.user_learnings
-           .includes(dictionary_entry: [ { meanings: :source }, { audio_pronunciations: { audio_attachment: :blob } } ])
+           .includes(dictionary_entry: [ { meanings: :source }, :audio_pronunciations ])
            .find(id)
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -27,7 +27,7 @@ class ReviewController < ApplicationController
     @learning_session = active_learning_session
     @session_card     = @learning_session.current_card(current_position)
     @user_learning    = UserLearning
-                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent }, { audio_pronunciations: { audio_attachment: :blob } } ])
+                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent }, :audio_pronunciations ])
                           .find(@session_card.user_learning_id)
     @position         = current_position + 1
     @total            = @learning_session.card_count

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -27,7 +27,7 @@ class ReviewController < ApplicationController
     @learning_session = active_learning_session
     @session_card     = @learning_session.current_card(current_position)
     @user_learning    = UserLearning
-                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent } ])
+                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent }, { audio_pronunciations: { audio_attachment: :blob } } ])
                           .find(@session_card.user_learning_id)
     @position         = current_position + 1
     @total            = @learning_session.card_count

--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -18,7 +18,19 @@ module ImportFilesHelper
     Zip::File.open(temp_zip_path) do |zip_file|
       zip_file.each do |entry|
         puts "Extracting #{entry.name} to #{unzip_dir}..."
-        entry.extract(destination_directory: unzip_dir) { true }
+        destination_path = File.join(unzip_dir, entry.name)
+
+        if entry.directory?
+          FileUtils.mkdir_p(destination_path)
+          next
+        end
+
+        FileUtils.mkdir_p(File.dirname(destination_path))
+        entry.get_input_stream do |input_stream|
+          File.open(destination_path, "wb") do |output_file|
+            IO.copy_stream(input_stream, output_file)
+          end
+        end
       end
     end
   end

--- a/app/helpers/import_files_helper.rb
+++ b/app/helpers/import_files_helper.rb
@@ -14,11 +14,13 @@ module ImportFilesHelper
   def unzip_file(temp_zip_path, unzip_dir)
     FileUtils.mkdir_p(unzip_dir)
     puts "Unzipping files to #{unzip_dir}..."
+    base_path = File.expand_path(unzip_dir)
 
     Zip::File.open(temp_zip_path) do |zip_file|
       zip_file.each do |entry|
         puts "Extracting #{entry.name} to #{unzip_dir}..."
-        destination_path = File.join(unzip_dir, entry.name)
+        destination_path = File.expand_path(File.join(unzip_dir, entry.name))
+        ensure_within_directory!(destination_path, base_path)
 
         if entry.directory?
           FileUtils.mkdir_p(destination_path)
@@ -33,6 +35,12 @@ module ImportFilesHelper
         end
       end
     end
+  end
+
+  def ensure_within_directory!(destination_path, base_path)
+    return if destination_path.start_with?("#{base_path}/") || destination_path == base_path
+
+    raise "Refusing to extract outside #{base_path}: #{destination_path}"
   end
 
   def confirm_file_presence(file_name_search_string, unzip_dir)

--- a/app/javascript/controllers/audio_player_controller.js
+++ b/app/javascript/controllers/audio_player_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["audio"]
+
+  play() {
+    if (!this.hasAudioTarget) return
+
+    this.audioTarget.currentTime = 0
+    this.audioTarget.play().catch(() => {})
+  }
+}

--- a/app/jobs/admin/provisioning_job.rb
+++ b/app/jobs/admin/provisioning_job.rb
@@ -8,6 +8,7 @@ module Admin
       "custom_dictionary"  => Admin::CustomDictionaryProvisioningService,
       "frequency_data"     => Admin::FrequencyProvisioningService,
       "makemeahanzi_source" => Admin::MakemeahanziSourceProvisioningService,
+      "audio_pronunciations" => Admin::AudioPronunciationsProvisioningService,
       "wiktionary"         => Admin::WiktionaryProvisioningService,
       "stroke_order"       => Admin::StrokeOrderProvisioningService,
       "unihan"             => Admin::UnihanProvisioningService,

--- a/app/models/admin_task.rb
+++ b/app/models/admin_task.rb
@@ -5,6 +5,7 @@ class AdminTask < ApplicationRecord
     custom_dictionary
     frequency_data
     makemeahanzi_source
+    audio_pronunciations
     wiktionary
     stroke_order
     unihan

--- a/app/models/audio_pronunciation.rb
+++ b/app/models/audio_pronunciation.rb
@@ -1,0 +1,18 @@
+class AudioPronunciation < ApplicationRecord
+  SOURCE_KRMANIK = "krmanik".freeze
+  LOCALE_ZH_CN = "zh-CN".freeze
+
+  belongs_to :dictionary_entry
+  has_one_attached :audio
+
+  validates :source, presence: true
+  validates :locale, presence: true
+  validates :source, uniqueness: { scope: [ :dictionary_entry_id, :locale ] }
+  validate :audio_must_be_attached
+
+  private
+
+  def audio_must_be_attached
+    errors.add(:audio, "must be attached") unless audio.attached?
+  end
+end

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -9,6 +9,7 @@ class DictionaryEntry < ApplicationRecord
   has_many :dictionary_entry_tags, dependent: :destroy
   has_many :tags, through: :dictionary_entry_tags
   has_many :meanings, dependent: :destroy
+  has_many :audio_pronunciations, -> { order(:id) }, dependent: :destroy
   has_many :dictionary_entry_radicals, dependent: :destroy
   has_many :radicals, through: :dictionary_entry_radicals
   has_many :user_learnings, dependent: :destroy
@@ -29,10 +30,16 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def self.find_with_associations(id, user)
-    entry = includes(tags: :parent).find(id)
+    entry = includes(tags: :parent, audio_pronunciations: { audio_attachment: :blob }).find(id)
     meanings = entry.meanings.includes(:source)
     user_learning = entry.user_learning_for(user)
     { entry: entry, meanings: meanings, user_learning: user_learning }
+  end
+
+  def primary_audio_pronunciation
+    return audio_pronunciations.first if association(:audio_pronunciations).loaded?
+
+    audio_pronunciations.includes(audio_attachment: :blob).first
   end
 
   def flashcard_meanings

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -30,7 +30,7 @@ class DictionaryEntry < ApplicationRecord
   end
 
   def self.find_with_associations(id, user)
-    entry = includes(tags: :parent, audio_pronunciations: { audio_attachment: :blob }).find(id)
+    entry = includes(:audio_pronunciations, tags: :parent).find(id)
     meanings = entry.meanings.includes(:source)
     user_learning = entry.user_learning_for(user)
     { entry: entry, meanings: meanings, user_learning: user_learning }
@@ -39,7 +39,7 @@ class DictionaryEntry < ApplicationRecord
   def primary_audio_pronunciation
     return audio_pronunciations.first if association(:audio_pronunciations).loaded?
 
-    audio_pronunciations.includes(audio_attachment: :blob).first
+    audio_pronunciations.first
   end
 
   def flashcard_meanings

--- a/app/services/admin/audio_pronunciations_provisioning_service.rb
+++ b/app/services/admin/audio_pronunciations_provisioning_service.rb
@@ -2,6 +2,7 @@ module Admin
   class AudioPronunciationsProvisioningService
     include ImportFilesHelper
 
+    BATCH_SIZE = 500
     ARCHIVE_URL = "https://codeload.github.com/krmanik/HSK-3.0/zip/refs/heads/main"
     ARCHIVE_PATH = Rails.root.join("tmp", "audio", "krmanik_hsk_3_0.zip")
     EXTRACT_DIR = Rails.root.join("tmp", "audio", "krmanik_hsk_3_0")
@@ -44,6 +45,15 @@ module Admin
     end
 
     def download
+      if source_ready?
+        return {
+          archive_path: @archive_path.to_s,
+          audio_dir: resolved_audio_dir.to_s,
+          downloaded_files: audio_lookup.size,
+          reused_source: true
+        }
+      end
+
       download_file_to_tmp(@archive_url, @archive_path.to_s)
       FileUtils.rm_rf(@extract_dir)
       unzip_file(@archive_path, @extract_dir)
@@ -51,7 +61,8 @@ module Admin
       {
         archive_path: @archive_path.to_s,
         audio_dir: resolved_audio_dir.to_s,
-        downloaded_files: audio_lookup.size
+        downloaded_files: audio_lookup.size,
+        reused_source: false
       }
     end
 
@@ -62,18 +73,23 @@ module Admin
       unmatched_entries = []
       lookup = audio_lookup
 
-      target_entries.find_each do |entry|
-        file_path = lookup[entry.text]
+      target_entry_ids.each_slice(BATCH_SIZE) do |entry_ids|
+        entries = DictionaryEntry.where(id: entry_ids).to_a
+        existing_pronunciations = existing_pronunciations_for(entries)
 
-        unless file_path
-          unmatched_entries << entry
-          next
+        entries.each do |entry|
+          file_path = lookup[entry.text]
+
+          unless file_path
+            unmatched_entries << entry
+            next
+          end
+
+          result = import_file_for(entry, file_path, existing_pronunciations[entry.id])
+          imported += 1 if result == :created
+          updated += 1 if result == :updated
+          unchanged += 1 if result == :unchanged
         end
-
-        result = import_file_for(entry, file_path)
-        imported += 1 if result == :created
-        updated += 1 if result == :updated
-        unchanged += 1 if result == :unchanged
       end
 
       write_unmatched_log(unmatched_entries)
@@ -96,27 +112,45 @@ module Admin
                      .distinct
     end
 
-    def import_file_for(entry, file_path)
-      pronunciation = AudioPronunciation.find_or_initialize_by(
+    def target_entry_ids
+      @target_entry_ids ||= target_entries.pluck(:id)
+    end
+
+    def existing_pronunciations_for(entries)
+      AudioPronunciation
+        .where(
+          dictionary_entry_id: entries.map(&:id),
+          source: @source_key,
+          locale: @locale
+        )
+        .includes(audio_attachment: :blob)
+        .index_by(&:dictionary_entry_id)
+    end
+
+    def import_file_for(entry, file_path, existing_pronunciation = nil)
+      pronunciation = existing_pronunciation || AudioPronunciation.new(
         dictionary_entry: entry,
         source: @source_key,
         locale: @locale
       )
+      existing_attachment = pronunciation.audio_attachment
       status = pronunciation.new_record? ? :created : :updated
 
       if same_attachment?(pronunciation, file_path)
         return :unchanged
       end
 
-      pronunciation.audio.purge if pronunciation.audio.attached?
+      File.open(file_path, "rb") do |audio_file|
+        pronunciation.audio.attach(
+          io: audio_file,
+          filename: File.basename(file_path),
+          content_type: "audio/mpeg"
+        )
 
-      pronunciation.audio.attach(
-        io: StringIO.new(File.binread(file_path)),
-        filename: File.basename(file_path),
-        content_type: "audio/mpeg"
-      )
+        pronunciation.save!
+      end
 
-      pronunciation.save!
+      existing_attachment&.purge_later if existing_attachment && existing_attachment != pronunciation.audio_attachment
       status
     end
 
@@ -143,6 +177,10 @@ module Admin
 
         Pathname(match)
       end
+    end
+
+    def source_ready?
+      @archive_path.exist? && Dir.exist?(@extract_dir) && Dir.glob(@extract_dir.join(AUDIO_DIR_GLOB)).any?
     end
 
     def write_unmatched_log(unmatched_entries)

--- a/app/services/admin/audio_pronunciations_provisioning_service.rb
+++ b/app/services/admin/audio_pronunciations_provisioning_service.rb
@@ -1,0 +1,154 @@
+module Admin
+  class AudioPronunciationsProvisioningService
+    include ImportFilesHelper
+
+    ARCHIVE_URL = "https://codeload.github.com/krmanik/HSK-3.0/zip/refs/heads/main"
+    ARCHIVE_PATH = Rails.root.join("tmp", "audio", "krmanik_hsk_3_0.zip")
+    EXTRACT_DIR = Rails.root.join("tmp", "audio", "krmanik_hsk_3_0")
+    LOG_PATH = Rails.root.join("log", "audio_import_errors.log")
+    AUDIO_DIR_GLOB = "**/New HSK (2025)/Audio".freeze
+    TARGET_LEVELS = [ "HSK 1", "HSK 2", "HSK 3", "HSK 4" ].freeze
+
+    def self.call(**kwargs)
+      new(**kwargs).call
+    end
+
+    def self.download(**kwargs)
+      new(**kwargs).download
+    end
+
+    def self.import(**kwargs)
+      new(**kwargs).import
+    end
+
+    def initialize(
+      archive_url: ARCHIVE_URL,
+      archive_path: ARCHIVE_PATH,
+      extract_dir: EXTRACT_DIR,
+      log_path: LOG_PATH,
+      target_levels: TARGET_LEVELS,
+      source_key: AudioPronunciation::SOURCE_KRMANIK,
+      locale: AudioPronunciation::LOCALE_ZH_CN
+    )
+      @archive_url = archive_url
+      @archive_path = Pathname(archive_path)
+      @extract_dir = Pathname(extract_dir)
+      @log_path = Pathname(log_path)
+      @target_levels = target_levels
+      @source_key = source_key
+      @locale = locale
+    end
+
+    def call
+      download.merge(import)
+    end
+
+    def download
+      download_file_to_tmp(@archive_url, @archive_path.to_s)
+      FileUtils.rm_rf(@extract_dir)
+      unzip_file(@archive_path, @extract_dir)
+
+      {
+        archive_path: @archive_path.to_s,
+        audio_dir: resolved_audio_dir.to_s,
+        downloaded_files: audio_lookup.size
+      }
+    end
+
+    def import
+      imported = 0
+      updated = 0
+      unchanged = 0
+      unmatched_entries = []
+      lookup = audio_lookup
+
+      target_entries.find_each do |entry|
+        file_path = lookup[entry.text]
+
+        unless file_path
+          unmatched_entries << entry
+          next
+        end
+
+        result = import_file_for(entry, file_path)
+        imported += 1 if result == :created
+        updated += 1 if result == :updated
+        unchanged += 1 if result == :unchanged
+      end
+
+      write_unmatched_log(unmatched_entries)
+
+      {
+        imported: imported,
+        updated: updated,
+        unchanged: unchanged,
+        unmatched: unmatched_entries.size,
+        source: @source_key,
+        locale: @locale
+      }
+    end
+
+    private
+
+    def target_entries
+      DictionaryEntry.joins(:tags)
+                     .where(tags: { category: "HSK", name: @target_levels })
+                     .distinct
+    end
+
+    def import_file_for(entry, file_path)
+      pronunciation = AudioPronunciation.find_or_initialize_by(
+        dictionary_entry: entry,
+        source: @source_key,
+        locale: @locale
+      )
+      status = pronunciation.new_record? ? :created : :updated
+
+      if same_attachment?(pronunciation, file_path)
+        return :unchanged
+      end
+
+      pronunciation.audio.purge if pronunciation.audio.attached?
+
+      pronunciation.audio.attach(
+        io: StringIO.new(File.binread(file_path)),
+        filename: File.basename(file_path),
+        content_type: "audio/mpeg"
+      )
+
+      pronunciation.save!
+      status
+    end
+
+    def same_attachment?(pronunciation, file_path)
+      return false unless pronunciation.audio.attached?
+
+      pronunciation.audio.filename.to_s == File.basename(file_path) &&
+        pronunciation.audio.blob.byte_size == File.size(file_path)
+    end
+
+    def audio_lookup
+      @audio_lookup ||= Dir.glob(resolved_audio_dir.join("*.mp3")).each_with_object({}) do |path, lookup|
+        basename = File.basename(path, ".mp3")
+        next unless basename.start_with?("cmn-")
+
+        lookup[basename.delete_prefix("cmn-")] = path
+      end
+    end
+
+    def resolved_audio_dir
+      @resolved_audio_dir ||= begin
+        match = Dir.glob(@extract_dir.join(AUDIO_DIR_GLOB)).first
+        raise "Audio directory not found in #{@extract_dir}" if match.blank?
+
+        Pathname(match)
+      end
+    end
+
+    def write_unmatched_log(unmatched_entries)
+      FileUtils.mkdir_p(@log_path.dirname)
+      lines = unmatched_entries.map { |entry| "#{entry.id}\t#{entry.text}" }
+      File.write(@log_path, lines.join("\n"))
+    end
+  end
+end

--- a/app/views/admin/dashboard/_task_card.html.erb
+++ b/app/views/admin/dashboard/_task_card.html.erb
@@ -1,5 +1,5 @@
 <% locked = task&.pending? || task&.running? %>
-<% requires_dictionary = local_assigns.fetch(:requires_dictionary, false) %>
+<% blocked_reason = local_assigns[:blocked_reason] %>
 
 <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-5 flex flex-col gap-3">
   <div class="flex items-start justify-between gap-2">
@@ -40,9 +40,9 @@
         </svg>
         Running…
       </span>
-    <% elsif requires_dictionary %>
+    <% elsif blocked_reason.present? %>
       <span class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-yellow-50 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-700">
-        Import dictionary first
+        <%= blocked_reason %>
       </span>
     <% else %>
       <%= button_to admin_tasks_path, method: :post,

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -59,7 +59,15 @@
           task:      @tasks_by_type["hsk_tags"],
           db_count:  @db_stats[:hsk_tags],
           unit:      "tags",
-          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+          blocked_reason: (@db_stats[:dictionary_entries].zero? ? "Import dictionary first" : nil) %>
+
+    <%= render "task_card",
+          label:     "Pronunciation audio",
+          task_type: "audio_pronunciations",
+          task:      @tasks_by_type["audio_pronunciations"],
+          db_count:  @db_stats[:audio_pronunciations],
+          unit:      "audio records",
+          blocked_reason: (@db_stats[:hsk_tags].zero? ? "Import HSK tags first" : nil) %>
 
     <%= render "task_card",
           label:     "Frequency data",
@@ -67,7 +75,7 @@
           task:      @tasks_by_type["frequency_data"],
           db_count:  @db_stats[:frequency_entries],
           unit:      "ranked entries",
-          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+          blocked_reason: (@db_stats[:dictionary_entries].zero? ? "Import dictionary first" : nil) %>
 
     <%= render "task_card",
           label:     "Radical breakdowns",
@@ -75,7 +83,7 @@
           task:      @tasks_by_type["radicals"],
           db_count:  @db_stats[:radical_entries],
           unit:      "entries with radicals",
-          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+          blocked_reason: (@db_stats[:dictionary_entries].zero? ? "Import dictionary first" : nil) %>
 
     <%= render "task_card",
           label:     "Stroke order",
@@ -83,7 +91,7 @@
           task:      @tasks_by_type["stroke_order"],
           db_count:  @db_stats[:stroke_order_entries],
           unit:      "entries with stroke data",
-          requires_dictionary: @db_stats[:dictionary_entries].zero? %>
+          blocked_reason: (@db_stats[:dictionary_entries].zero? ? "Import dictionary first" : nil) %>
 
   </div>
 

--- a/app/views/dictionary_entries/show.html.erb
+++ b/app/views/dictionary_entries/show.html.erb
@@ -33,6 +33,8 @@
   </style>
 <% end %>
 
+<% audio_pronunciation = @dictionary_entry.primary_audio_pronunciation %>
+
 <div class="w-full max-w-4xl mx-auto pb-20">
 
   <%# ── Back nav ──────────────────────────────────────────── %>
@@ -66,12 +68,22 @@
     <div class="relative flex items-start justify-between gap-6">
 
       <%# Left: character + pinyin %>
-      <div>
+      <div class="flex items-start gap-3">
+        <div>
         <h1 class="de-char font-hanzi text-[6.5rem] text-gray-50 mb-3" lang="zh">
           <%= @dictionary_entry.text %>
         </h1>
         <% @meanings.map(&:pinyin).uniq.each do |pinyin| %>
           <p class="de-mono text-amber-400 text-lg tracking-[0.25em]"><%= pinyin %></p>
+        <% end %>
+        </div>
+        <% if audio_pronunciation %>
+          <div class="pt-2">
+            <%= render "shared/audio_pronunciation_button",
+                  audio_pronunciation: audio_pronunciation,
+                  button_class: "inline-flex h-10 w-10 items-center justify-center rounded-full border border-amber-300/40 bg-amber-400/10 text-amber-300 transition-colors hover:bg-amber-400/20 hover:text-amber-200",
+                  label: "Play audio for #{@dictionary_entry.text}" %>
+          </div>
         <% end %>
       </div>
 
@@ -307,18 +319,35 @@
       </p>
     </div>
 
-    <div class="de-future rounded-xl p-6">
+    <div class="<%= audio_pronunciation ? "bg-gray-800/40 border border-gray-700/40" : "de-future" %> rounded-xl p-6">
       <div class="flex items-center justify-between mb-3">
-        <h2 class="de-lora text-[10px] text-gray-600 uppercase tracking-[0.2em] font-semibold">
+        <h2 class="de-lora text-[10px] <%= audio_pronunciation ? "text-red-500" : "text-gray-600" %> uppercase tracking-[0.2em] font-semibold">
           Pronunciation
         </h2>
-        <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
-          SOON
-        </span>
+        <% unless audio_pronunciation %>
+          <span class="de-mono text-[9px] text-gray-700 border border-gray-700/60 rounded px-1.5 py-0.5 tracking-widest">
+            SOON
+          </span>
+        <% end %>
       </div>
-      <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
-        Audio recording of native speaker pronunciation.
-      </p>
+
+      <% if audio_pronunciation %>
+        <div class="flex items-center gap-3">
+          <%= render "shared/audio_pronunciation_button",
+                audio_pronunciation: audio_pronunciation,
+                label: "Play audio for #{@dictionary_entry.text}" %>
+          <div>
+            <p class="de-lora text-gray-200 text-sm">Tap to hear the entry pronounced.</p>
+            <p class="de-mono text-[10px] text-gray-500 mt-1 uppercase tracking-[0.15em]">
+              <%= audio_pronunciation.source %> · <%= audio_pronunciation.locale %>
+            </p>
+          </div>
+        </div>
+      <% else %>
+        <p class="de-lora text-gray-600 text-sm italic leading-relaxed">
+          Audio recording of native speaker pronunciation.
+        </p>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/learn/review_show.html.erb
+++ b/app/views/learn/review_show.html.erb
@@ -10,6 +10,7 @@
   primary_group = meaning_groups.first || []
   primary_meaning = primary_group.first
   pinyin = primary_meaning&.pinyin
+  audio_pronunciation = entry.primary_audio_pronunciation
   supplemental_meaning_groups = []
 
   if primary_group.drop(1).any?
@@ -39,7 +40,14 @@
         </div>
 
         <div data-card-flip-target="back" class="hidden h-full overflow-y-auto pr-1">
-          <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
+          <div class="mb-2 flex items-center justify-center gap-3">
+            <p class="text-3xl text-gray-400"><%= pinyin %></p>
+            <% if audio_pronunciation %>
+              <%= render "shared/audio_pronunciation_button",
+                    audio_pronunciation: audio_pronunciation,
+                    label: "Play audio for #{entry.text}" %>
+            <% end %>
+          </div>
           <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
 
           <% if supplemental_meaning_groups.any? %>

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -10,6 +10,7 @@
   primary_group = meaning_groups.first || []
   primary_meaning = primary_group.first
   pinyin = primary_meaning&.pinyin
+  audio_pronunciation = entry.primary_audio_pronunciation
   supplemental_meaning_groups = []
 
   if primary_group.drop(1).any?
@@ -39,7 +40,14 @@
         </div>
 
         <div data-card-flip-target="back" class="hidden h-full overflow-y-auto pr-1">
-          <p class="text-3xl text-gray-400 mb-2"><%= pinyin %></p>
+          <div class="mb-2 flex items-center justify-center gap-3">
+            <p class="text-3xl text-gray-400"><%= pinyin %></p>
+            <% if audio_pronunciation %>
+              <%= render "shared/audio_pronunciation_button",
+                    audio_pronunciation: audio_pronunciation,
+                    label: "Play audio for #{entry.text}" %>
+            <% end %>
+          </div>
           <p data-adaptive-card-text-target="meaning" class="text-xl font-medium text-gray-800 dark:text-gray-200"><%= primary_meaning&.text %></p>
 
           <% if supplemental_meaning_groups.any? %>

--- a/app/views/shared/_audio_pronunciation_button.html.erb
+++ b/app/views/shared/_audio_pronunciation_button.html.erb
@@ -1,0 +1,18 @@
+<% button_class = local_assigns[:button_class] || "inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-300/70 bg-white/80 text-gray-700 shadow-sm transition-colors hover:bg-white hover:text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700" %>
+<% label = local_assigns[:label] || "Play audio" %>
+
+<div data-controller="audio-player" class="inline-flex">
+  <button type="button"
+          data-action="audio-player#play"
+          class="<%= button_class %>"
+          aria-label="<%= label %>">
+    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path d="M6 4.75a.75.75 0 0 1 1.14-.64l8 5.25a.75.75 0 0 1 0 1.28l-8 5.25A.75.75 0 0 1 6 15.25V4.75Z" />
+    </svg>
+  </button>
+
+  <audio preload="none" data-audio-player-target="audio">
+    <source src="<%= rails_blob_path(audio_pronunciation.audio, only_path: true) %>"
+            type="<%= audio_pronunciation.audio.content_type || "audio/mpeg" %>">
+  </audio>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require "rails"
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
-# require "active_storage/engine"
+require "active_storage/engine"
 require "action_controller/railtie"
 # require "action_mailer/railtie" # Disabled — using Pocket ID for authentication
 # require "action_mailbox/engine"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,6 @@ Rails.application.configure do
   # config.action_mailer.delivery_method = :letter_opener
   # config.action_mailer.perform_deliveries = true
   # config.action_mailer.default_url_options = { host: "localhost", port: 3000, from: "dev@example.com" }
+
+  config.active_storage.service = :local
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,8 @@ Rails.application.configure do
   #   from: ENV.fetch("MAILER_FROM", "noreply@example.com")
   # }
 
+  config.active_storage.service = :local
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # Restore this block if mailer is re-enabled in config/application.rb.
   # config.action_mailer.delivery_method = :test
   # config.action_mailer.default_url_options = { host: "localhost", port: 3000, from: "test@example.com" }
+
+  config.active_storage.service = :test
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>

--- a/db/migrate/20260509133000_create_active_storage_tables.rb
+++ b/db/migrate/20260509133000_create_active_storage_tables.rb
@@ -1,0 +1,48 @@
+class CreateActiveStorageTables < ActiveRecord::Migration[8.1]
+  def change
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+      t.datetime :created_at, precision: 6, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+      t.datetime   :created_at, precision: 6, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ],
+              name: :index_active_storage_attachments_uniqueness,
+              unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ],
+              name: :index_active_storage_variant_records_uniqueness,
+              unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    generators = Rails.configuration.generators
+    primary_key_type = generators.options[generators.orm][:primary_key_type]
+    [ primary_key_type || :primary_key, primary_key_type || :bigint ]
+  end
+end

--- a/db/migrate/20260509133100_create_audio_pronunciations.rb
+++ b/db/migrate/20260509133100_create_audio_pronunciations.rb
@@ -1,0 +1,16 @@
+class CreateAudioPronunciations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :audio_pronunciations do |t|
+      t.references :dictionary_entry, null: false, foreign_key: true
+      t.string :source, null: false
+      t.string :locale, null: false
+
+      t.timestamps
+    end
+
+    add_index :audio_pronunciations,
+              [ :dictionary_entry_id, :source, :locale ],
+              unique: true,
+              name: "index_audio_pronunciations_on_entry_source_locale"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_123500) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_09_133100) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "admin_tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -36,6 +64,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_123500) do
     t.integer "user_id", null: false
     t.index ["user_id", "created_at"], name: "index_anki_imports_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_anki_imports_on_user_id"
+  end
+
+  create_table "audio_pronunciations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "dictionary_entry_id", null: false
+    t.string "locale", null: false
+    t.string "source", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dictionary_entry_id", "source", "locale"], name: "index_audio_pronunciations_on_entry_source_locale", unique: true
+    t.index ["dictionary_entry_id"], name: "index_audio_pronunciations_on_dictionary_entry_id"
   end
 
   create_table "dictionary_entries", force: :cascade do |t|
@@ -199,7 +237,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_123500) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "anki_imports", "users"
+  add_foreign_key "audio_pronunciations", "dictionary_entries"
   add_foreign_key "dictionary_entry_radicals", "dictionary_entries"
   add_foreign_key "dictionary_entry_radicals", "radicals"
   add_foreign_key "dictionary_entry_tags", "dictionary_entries"

--- a/lib/tasks/audio.rake
+++ b/lib/tasks/audio.rake
@@ -1,0 +1,19 @@
+namespace :audio do
+  desc "Download and extract pronunciation audio archive"
+  task download: :environment do
+    result = Admin::AudioPronunciationsProvisioningService.download
+    puts "Audio archive ready at #{result[:archive_path]}"
+    puts "Extracted audio directory: #{result[:audio_dir]}"
+    puts "#{result[:downloaded_files]} audio files available"
+  end
+
+  desc "Import pronunciation audio for HSK 1-4 entries"
+  task import: :environment do
+    result = Admin::AudioPronunciationsProvisioningService.import
+    puts "Imported: #{result[:imported]}"
+    puts "Updated: #{result[:updated]}"
+    puts "Unchanged: #{result[:unchanged]}"
+    puts "Unmatched: #{result[:unmatched]}"
+    puts "Logged unmatched entries to log/audio_import_errors.log"
+  end
+end

--- a/spec/factories/audio_pronunciations.rb
+++ b/spec/factories/audio_pronunciations.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :audio_pronunciation do
+    association :dictionary_entry
+    source { AudioPronunciation::SOURCE_KRMANIK }
+    locale { AudioPronunciation::LOCALE_ZH_CN }
+
+    after(:build) do |audio_pronunciation|
+      next if audio_pronunciation.audio.attached?
+
+      audio_pronunciation.audio.attach(
+        io: StringIO.new("fake mp3 data"),
+        filename: "cmn-#{audio_pronunciation.dictionary_entry.text}.mp3",
+        content_type: "audio/mpeg"
+      )
+    end
+  end
+end

--- a/spec/models/admin_task_spec.rb
+++ b/spec/models/admin_task_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe AdminTask, type: :model do
     it "includes radicals for admin provisioning" do
       expect(AdminTask::VALID_TASK_TYPES).to include("radicals")
     end
+
+    it "includes audio_pronunciations for admin provisioning" do
+      expect(AdminTask::VALID_TASK_TYPES).to include("audio_pronunciations")
+    end
   end
 
   describe ".in_progress" do

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Admin::Dashboard", type: :request do
         expect(response.body).to include("CC-CEDICT")
         expect(response.body).to include("HSK")
         expect(response.body).to include("Makemeahanzi source")
+        expect(response.body).to include("Pronunciation audio")
         expect(response.body).to include("Frequency data")
         expect(response.body).to include("Radical breakdowns")
         expect(response.body).to include("Stroke order")
@@ -84,13 +85,13 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
 
       it "enqueues a job for each unlocked task type" do
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(9).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(10).times
         post admin_provision_all_path
       end
 
       it "does not enqueue a job for a locked task type" do
         create(:admin_task, task_type: "cc_cedict", state: "running")
-        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(8).times
+        expect(Admin::ProvisioningJob).to receive(:perform_later).exactly(9).times
         post admin_provision_all_path
       end
 

--- a/spec/requests/dictionary_entries_spec.rb
+++ b/spec/requests/dictionary_entries_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe "DictionaryEntries", type: :request do
         expect(response.body).not_to include("Stroke Order")
       end
 
+      it "shows a play button when pronunciation audio is available" do
+        create(:audio_pronunciation, dictionary_entry: dictionary_entry)
+
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body).to include("Play audio for #{dictionary_entry.text}")
+      end
+
+      it "omits the play button when pronunciation audio is unavailable" do
+        get dictionary_entry_path(dictionary_entry)
+
+        expect(response.body).not_to include("Play audio for #{dictionary_entry.text}")
+      end
+
       it "falls back to constituent characters for multi-character words" do
         dictionary_entry.update!(text: "学习")
         xue = create(:dictionary_entry, text: "学")

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -457,6 +457,14 @@ RSpec.describe "Learn", type: :request do
         expect(response.body).to include("Stroke order:")
         expect(response.body).to include('data-controller="hanzi-writer"')
       end
+
+      it "shows a play button when pronunciation audio is available" do
+        create(:audio_pronunciation, dictionary_entry: new_card.dictionary_entry)
+
+        get learn_review_path
+
+        expect(response.body).to include("Play audio for #{new_card.dictionary_entry.text}")
+      end
     end
 
     context "when authenticated without an active review phase" do

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -333,6 +333,20 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to include("Stroke order:")
         expect(response.body).to include('data-controller="hanzi-writer"')
       end
+
+      it "shows a play button when pronunciation audio is available" do
+        create(:audio_pronunciation, dictionary_entry: user_learning.dictionary_entry)
+
+        get review_card_path
+
+        expect(response.body).to include("Play audio for #{user_learning.dictionary_entry.text}")
+      end
+
+      it "omits the play button when pronunciation audio is unavailable" do
+        get review_card_path
+
+        expect(response.body).not_to include("Play audio for #{user_learning.dictionary_entry.text}")
+      end
     end
   end
 

--- a/spec/services/admin/audio_pronunciations_provisioning_service_spec.rb
+++ b/spec/services/admin/audio_pronunciations_provisioning_service_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Admin::AudioPronunciationsProvisioningService, type: :service do
+  describe "#call" do
+    let!(:hsk_tag) { create(:tag, name: "HSK 1", category: "HSK") }
+    let!(:matched_entry) { create(:dictionary_entry, text: "苹果").tap { |entry| entry.tags << hsk_tag } }
+    let!(:unmatched_entry) { create(:dictionary_entry, text: "香蕉").tap { |entry| entry.tags << hsk_tag } }
+    let!(:out_of_scope_entry) { create(:dictionary_entry, text: "西瓜") }
+
+    it "imports matching audio and logs unmatched HSK 1-4 entries" do
+      Dir.mktmpdir do |tmpdir|
+        source_archive = File.join(tmpdir, "source.zip")
+        build_archive(source_archive, {
+          "HSK-3.0-main/New HSK (2025)/Audio/cmn-苹果.mp3" => "audio data"
+        })
+
+        archive_path = File.join(tmpdir, "download.zip")
+        extract_dir = File.join(tmpdir, "extract")
+        log_path = File.join(tmpdir, "audio_import_errors.log")
+        service = described_class.new(
+          archive_path: archive_path,
+          extract_dir: extract_dir,
+          log_path: log_path
+        )
+
+        allow(service).to receive(:download_file_to_tmp) do |_url, destination|
+          FileUtils.cp(source_archive, destination)
+        end
+
+        result = service.call
+
+        expect(result[:imported]).to eq(1)
+        expect(result[:unmatched]).to eq(1)
+        expect(AudioPronunciation.count).to eq(1)
+
+        pronunciation = AudioPronunciation.first
+        expect(pronunciation.dictionary_entry).to eq(matched_entry)
+        expect(pronunciation.source).to eq(AudioPronunciation::SOURCE_KRMANIK)
+        expect(pronunciation.locale).to eq(AudioPronunciation::LOCALE_ZH_CN)
+        expect(pronunciation.audio).to be_attached
+
+        log_contents = File.read(log_path)
+        expect(log_contents).to include(unmatched_entry.text)
+        expect(log_contents).not_to include(out_of_scope_entry.text)
+      end
+    end
+  end
+
+  def build_archive(path, entries)
+    Zip::File.open(path, create: true) do |zip_file|
+      entries.each do |entry_path, contents|
+        zip_file.get_output_stream(entry_path) { |stream| stream.write(contents) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Active Storage-backed pronunciation audio records and import tasks for HSK 1-4 entries
- wire audio download/import into the admin provisioning dashboard for production setup
- expose a lightweight play control on dictionary entries and review card backs when audio exists

## Testing
- `bin/rails db:migrate`
- `bin/rails db:migrate RAILS_ENV=test`
- `bundle exec rspec spec/models/admin_task_spec.rb spec/requests/admin/dashboard_spec.rb spec/requests/dictionary_entries_spec.rb spec/requests/review_spec.rb spec/requests/learn_spec.rb spec/services/admin/audio_pronunciations_provisioning_service_spec.rb`

## Notes
- partial RSpec runs still trip the existing SimpleCov minimum, even though the targeted examples pass
- source licensing/provenance for the krmanik audio files still needs confirmation before treating them as fully cleared content