### PR TITLE
fix: resolve 138s /learn/card response time

### DIFF
--- a/app/services/related_anchor_builder.rb
+++ b/app/services/related_anchor_builder.rb
@@ -31,17 +31,12 @@ class RelatedAnchorBuilder
     target = target_text
     return [] if target.blank?
 
-    ordered_mastered_scope
+    ids = ordered_mastered_scope
       .where("dictionary_entries.text LIKE ?", "%#{escape_like(target)}%")
       .limit(limit)
-      .to_a
-      .map do |learning|
-        Result.new(
-          user_learning: learning,
-          full_token_match: true,
-          matched_characters: matching_characters_for(learning, target_characters)
-        )
-      end
+      .pluck(:id)
+
+    load_with_includes(ids, target_characters, full_token_match: true)
   end
 
   def per_character_results(excluding_ids:, limit:)
@@ -51,20 +46,32 @@ class RelatedAnchorBuilder
     pattern = chars.map { "dictionary_entries.text LIKE ?" }.join(" OR ")
     values = chars.map { |char| "%#{escape_like(char)}%" }
 
-    scope = ordered_mastered_scope
-      .where(pattern, *values)
+    scope = ordered_mastered_scope.where(pattern, *values)
     scope = scope.where.not(id: excluding_ids) if excluding_ids.any?
 
-    scope
-      .limit(limit)
-      .to_a
-      .map do |learning|
-        Result.new(
-          user_learning: learning,
-          full_token_match: false,
-          matched_characters: matching_characters_for(learning, chars)
-        )
-      end
+    ids = scope.limit(limit).pluck(:id)
+    load_with_includes(ids, chars, full_token_match: false)
+  end
+
+  # Loads user_learnings by ID with full associations, preserving the given ID order.
+  # Separated from the filtering query so that LIKE + ORDER BY + LIMIT work on a
+  # simple join without Rails switching to eager_load mode (which would apply LIMIT
+  # to joined rows rather than to user_learnings).
+  def load_with_includes(ids, chars, full_token_match:)
+    return [] if ids.empty?
+
+    by_id = UserLearning.where(id: ids)
+                        .includes(dictionary_entry: { meanings: :source })
+                        .index_by(&:id)
+    ids.filter_map do |id|
+      learning = by_id[id]
+      next unless learning
+      Result.new(
+        user_learning: learning,
+        full_token_match: full_token_match,
+        matched_characters: matching_characters_for(learning, chars)
+      )
+    end
   end
 
   def matching_characters_for(learning, chars)
@@ -88,7 +95,6 @@ class RelatedAnchorBuilder
         .order(Arel.sql("CASE WHEN dictionary_entries.frequency_rank IS NULL THEN 1 ELSE 0 END"))
         .order("dictionary_entries.frequency_rank ASC")
         .order("dictionary_entries.text ASC")
-        .includes(dictionary_entry: { meanings: :source })
   end
 
   def escape_like(value)

--- a/db/migrate/20260510230000_add_user_state_index_to_user_learnings.rb
+++ b/db/migrate/20260510230000_add_user_state_index_to_user_learnings.rb
@@ -1,0 +1,5 @@
+class AddUserStateIndexToUserLearnings < ActiveRecord::Migration[8.1]
+  def change
+    add_index :user_learnings, [ :user_id, :state ], name: "index_user_learnings_on_user_and_state"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_09_133100) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_230000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -220,6 +220,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_09_133100) do
     t.integer "user_id", null: false
     t.index ["dictionary_entry_id"], name: "index_user_learnings_on_dictionary_entry_id"
     t.index ["user_id", "dictionary_entry_id"], name: "index_user_learnings_on_user_and_entry", unique: true
+    t.index ["user_id", "state"], name: "index_user_learnings_on_user_and_state"
     t.index ["user_id"], name: "index_user_learnings_on_user_id"
   end
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes two performance issues identified from production logs showing
`duration=138686ms db=59634ms view=18118ms` on `/learn/card`. A Firefox
Android user received a 502 after 126 seconds; the server continued
processing for another ~12 seconds after that.

- Fixes #304 — `RelatedAnchorBuilder` eager_load trap caused catastrophic
  LEFT JOIN query for every card load
- Fixes #305 — missing `(user_id, state)` index on `user_learnings` forced
  full user-partition scans on every state-based scope

## What changed

### `app/services/related_anchor_builder.rb`

`ordered_mastered_scope` combined `.joins(:dictionary_entry)` with
`.includes(dictionary_entry: { meanings: :source })`. When callers then
added `.where("dictionary_entries.text LIKE ?", …)`, Rails switched from
efficient two-query preload to eager_load (LEFT OUTER JOIN across four
tables). Consequences:

1. `LIKE '%token%'` with a leading wildcard = full table scan of 120k
   dictionary entries on every card load
2. `LIMIT 5` applied to joined rows (not to `user_learnings`), so Rails
   returned at most 1–2 anchors while still evaluating every candidate row

Fix: `.includes` removed from the filtering scope. A new `load_with_includes`
method first calls `.pluck(:id)` (LIMIT now applies correctly, no JOIN
explosion) and then loads only those IDs with a proper `.includes` query.

### `db/migrate/20260510230000_add_user_state_index_to_user_learnings.rb`

Adds `(user_id, state)` index so `.mastered`, `.in_progress`, and
`.due_mastered` scopes skip directly to the relevant subset instead of
scanning every row belonging to a user.

## Test plan

- [ ] Existing `spec/services/related_anchor_builder_spec.rb` passes
  (ordering, deduplication, and character matching behaviour unchanged)
- [ ] `bundle exec rspec spec/controllers/learn_controller_spec.rb` (if
  present) passes
- [ ] `bin/rails db:migrate` applies cleanly
- [ ] Manual smoke test: `/learn/card` returns in under 2 s with a user who
  has hundreds of mastered entries

https://claude.ai/code/session_01M1xc2tSNKwwtSXjyY9yMH5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1xc2tSNKwwtSXjyY9yMH5)_