### PR TITLE
fix: guard user_learnings state index

### DIFF
--- a/db/migrate/20260510230000_add_user_state_index_to_user_learnings.rb
+++ b/db/migrate/20260510230000_add_user_state_index_to_user_learnings.rb
@@ -1,5 +1,7 @@
 class AddUserStateIndexToUserLearnings < ActiveRecord::Migration[8.1]
   def change
-    add_index :user_learnings, [ :user_id, :state ], name: "index_user_learnings_on_user_and_state"
+    add_index :user_learnings, [ :user_id, :state ],
+      name: "index_user_learnings_on_user_and_state",
+      if_not_exists: true
   end
 end


### PR DESCRIPTION
## Summary
- make the `AddUserStateIndexToUserLearnings` migration idempotent with `if_not_exists: true`
- prevent `db:prepare` and `bin/dev` from failing when SQLite already has `index_user_learnings_on_user_and_state`
- clean up the local stray `schema_migrations` version `0` entry while verifying the fix

## Verification
- `bin/rails db:migrate`
- `bin/rails db:prepare`
- `bin/rails db:migrate:status`