### PR TITLE
fix: split Solid Queue from web

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: <%= ENV.fetch("JOB_THREADS", 3) %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,11 @@ services:
     user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
     restart: unless-stopped
     ports:
-      - "${PORT:-80}:${HTTP_PORT:-3000}"
+      - "${PORT:-80}:${HTTP_PORT:-8080}"
     environment:
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:?RAILS_MASTER_KEY must be set}
       RAILS_LOG_LEVEL: ${RAILS_LOG_LEVEL:-info}
-      SOLID_QUEUE_IN_PUMA: "true"
-      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
-      HTTP_PORT: ${HTTP_PORT:-3000}
+      HTTP_PORT: ${HTTP_PORT:-8080}
       BUNDLE_USER_HOME: /tmp/bundler
       OIDC_ISSUER: ${OIDC_ISSUER:?OIDC_ISSUER must be set}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:?OIDC_CLIENT_ID must be set}
@@ -27,9 +25,28 @@ services:
           "-f",
           "-H",
           "X-Forwarded-Proto: https",
-          "http://localhost:${HTTP_PORT:-3000}/up",
+          "http://localhost:${HTTP_PORT:-8080}/up",
         ]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  jobs:
+    image: 127.0.0.1:5000/learn_hanzi:${IMAGE_TAG:-latest}
+    command: ./bin/jobs
+    user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
+    restart: unless-stopped
+    environment:
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:?RAILS_MASTER_KEY must be set}
+      RAILS_LOG_LEVEL: ${RAILS_LOG_LEVEL:-info}
+      JOB_CONCURRENCY: ${JOB_CONCURRENCY:-1}
+      JOB_THREADS: ${JOB_THREADS:-1}
+      BUNDLE_USER_HOME: /tmp/bundler
+      OIDC_ISSUER: ${OIDC_ISSUER:?OIDC_ISSUER must be set}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:?OIDC_CLIENT_ID must be set}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?OIDC_CLIENT_SECRET must be set}
+      OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:?OIDC_REDIRECT_URI must be set}
+      GLITCHTIP_DSN: ${GLITCHTIP_DSN}
+    volumes:
+      - ${STORAGE_PATH:?STORAGE_PATH is required}:/rails/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
     command: ./bin/jobs
     user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
     restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
     environment:
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:?RAILS_MASTER_KEY must be set}
       RAILS_LOG_LEVEL: ${RAILS_LOG_LEVEL:-info}


### PR DESCRIPTION
## Summary
- move Solid Queue out of the web container into a separate `jobs` service
- stop configuring the web container to run in-process queue workers
- make job worker thread count configurable so SQLite-backed queue traffic can be tuned conservatively

## Why
Production is booting successfully, but user traffic and Solid Queue are contending on SQLite and causing `database is locked` errors, long requests, and intermittent `/up` failures.

## Verification
- reviewed production logs showing successful boot followed by SQLite lock contention in Solid Queue and `/review`
- confirmed Rails is already using SQLite WAL, so the issue is concurrency shape rather than missing pragmas
- verified the compose and queue config changes match the intended split between web and job processes