### PR TITLE
perf: instrument flashcard request timings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,31 @@ class ApplicationController < ActionController::Base
 
   before_action :set_sentry_user
 
+  def append_info_to_payload(payload)
+    super
+
+    performance_timings.each do |name, duration_ms|
+      payload[:"perf_#{name}_ms"] = duration_ms.round(1)
+    end
+  end
+
   private
+
+   def measure_performance(name)
+     started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+     result = yield
+     elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000.0
+     performance_timings[name] = elapsed_ms
+     result
+   end
+
+   def measure_action_performance
+     measure_performance("#{controller_name}_#{action_name}_total") { yield }
+   end
+
+   def performance_timings
+     request.env["learn_hanzi.performance_timings"] ||= {}
+   end
 
   def set_sentry_user
     return unless Current.user&.telemetry_enabled?

--- a/app/controllers/learn_controller.rb
+++ b/app/controllers/learn_controller.rb
@@ -2,6 +2,7 @@ class LearnController < ApplicationController
   before_action :require_learn_session, only: [ :show, :submit ]
   before_action :require_review_phase,  only: [ :review_show, :review_submit ]
   before_action :require_started_session, only: [ :summary ]
+  around_action :measure_action_performance, only: [ :show, :submit, :review_show, :review_submit ]
 
   def start
     queue_size = Current.user.new_cards_per_session
@@ -25,29 +26,37 @@ class LearnController < ApplicationController
   end
 
   def show
-    @user_learning = current_card
+    @user_learning = measure_performance("learn_show_user_learning_lookup") { current_card }
     @position      = session[:learn_index] + 1
     @total         = session[:learn_queue].size
-    @related_anchors = RelatedAnchorBuilder.call(
-      user: Current.user,
-      target_learning: @user_learning,
-      limit: 5
-    )
-    @radical_breakdown = RadicalBreakdownBuilder.call(
-      user: Current.user,
-      dictionary_entry: @user_learning.dictionary_entry
-    )
-    @stroke_order_diagrams = StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    @related_anchors = measure_performance("learn_show_related_anchors") do
+      RelatedAnchorBuilder.call(
+        user: Current.user,
+        target_learning: @user_learning,
+        limit: 5
+      )
+    end
+    @radical_breakdown = measure_performance("learn_show_radical_breakdown") do
+      RadicalBreakdownBuilder.call(
+        user: Current.user,
+        dictionary_entry: @user_learning.dictionary_entry
+      )
+    end
+    @stroke_order_diagrams = measure_performance("learn_show_stroke_order_diagrams") do
+      StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    end
   end
 
   def submit
     know_it = params[:know_it] == "true"
-    ul      = current_card
+    ul      = measure_performance("learn_submit_user_learning_lookup") { current_card }
 
-    if know_it
-      ul.update!(state: "learning", last_interval: 1, factor: 2500, next_due: 1.day.from_now)
-    else
-      ul.update!(state: "learning", last_interval: 0, factor: 2500, next_due: Time.current)
+    measure_performance("learn_submit_update_user_learning") do
+      if know_it
+        ul.update!(state: "learning", last_interval: 1, factor: 2500, next_due: 1.day.from_now)
+      else
+        ul.update!(state: "learning", last_interval: 0, factor: 2500, next_due: Time.current)
+      end
     end
 
     session[:learn_introduced] = (session[:learn_introduced] || []) + [ ul.id ]
@@ -62,42 +71,52 @@ class LearnController < ApplicationController
   end
 
   def review_show
-    @user_learning = current_review_card
+    @user_learning = measure_performance("learn_review_show_user_learning_lookup") { current_review_card }
     @position      = session[:learn_review_index] + 1
     @total         = session[:learn_introduced].size
-    @related_anchors = RelatedAnchorBuilder.call(
-      user: Current.user,
-      target_learning: @user_learning,
-      limit: 5
-    )
-    @radical_breakdown = RadicalBreakdownBuilder.call(
-      user: Current.user,
-      dictionary_entry: @user_learning.dictionary_entry
-    )
-    @stroke_order_diagrams = StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    @related_anchors = measure_performance("learn_review_show_related_anchors") do
+      RelatedAnchorBuilder.call(
+        user: Current.user,
+        target_learning: @user_learning,
+        limit: 5
+      )
+    end
+    @radical_breakdown = measure_performance("learn_review_show_radical_breakdown") do
+      RadicalBreakdownBuilder.call(
+        user: Current.user,
+        dictionary_entry: @user_learning.dictionary_entry
+      )
+    end
+    @stroke_order_diagrams = measure_performance("learn_review_show_stroke_order_diagrams") do
+      StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    end
   end
 
   def review_submit
     ease = params[:ease].to_i
     return head :unprocessable_content unless (1..4).include?(ease)
 
-    ul     = current_review_card
-    result = SpacedRepetition::SM2.call(user_learning: ul, ease: ease)
+    ul     = measure_performance("learn_review_submit_user_learning_lookup") { current_review_card }
+    result = measure_performance("learn_review_submit_sm2") do
+      SpacedRepetition::SM2.call(user_learning: ul, ease: ease)
+    end
 
-    ApplicationRecord.transaction do
-      ul.update!(
-        state:         result.new_state,
-        last_interval: result.interval,
-        factor:        result.factor,
-        next_due:      result.next_due
-      )
-      ReviewLog.create!(
-        user_learning: ul,
-        ease:          ease,
-        interval:      result.interval,
-        factor:        result.factor,
-        log_type:      0
-      )
+    measure_performance("learn_review_submit_transaction") do
+      ApplicationRecord.transaction do
+        ul.update!(
+          state:         result.new_state,
+          last_interval: result.interval,
+          factor:        result.factor,
+          next_due:      result.next_due
+        )
+        ReviewLog.create!(
+          user_learning: ul,
+          ease:          ease,
+          interval:      result.interval,
+          factor:        result.factor,
+          log_type:      0
+        )
+      end
     end
 
     session[:learn_review_index] += 1

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -1,6 +1,7 @@
 class ReviewController < ApplicationController
   before_action :require_active_session, only: [ :show, :submit ]
   before_action :require_completed_session, only: [ :summary ]
+  around_action :measure_action_performance, only: [ :show, :submit ]
 
   def start
     Current.user.learning_sessions.in_progress.update_all(state: "abandoned")
@@ -24,51 +25,67 @@ class ReviewController < ApplicationController
   end
 
   def show
-    @learning_session = active_learning_session
-    @session_card     = @learning_session.current_card(current_position)
-    @user_learning    = UserLearning
-                          .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent }, :audio_pronunciations ])
-                          .find(@session_card.user_learning_id)
+    @learning_session = measure_performance("review_show_session_lookup") { active_learning_session }
+    @session_card     = measure_performance("review_show_session_card_lookup") do
+      @learning_session.current_card(current_position)
+    end
+    @user_learning    = measure_performance("review_show_user_learning_lookup") do
+      UserLearning
+        .includes(dictionary_entry: [ { meanings: :source }, { tags: :parent }, :audio_pronunciations ])
+        .find(@session_card.user_learning_id)
+    end
     @position         = current_position + 1
     @total            = @learning_session.card_count
-    @related_anchors  = RelatedAnchorBuilder.call(
-      user: Current.user,
-      target_learning: @user_learning,
-      limit: 5
-    )
-    @radical_breakdown = RadicalBreakdownBuilder.call(
-      user: Current.user,
-      dictionary_entry: @user_learning.dictionary_entry
-    )
-    @stroke_order_diagrams = StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    @related_anchors  = measure_performance("review_show_related_anchors") do
+      RelatedAnchorBuilder.call(
+        user: Current.user,
+        target_learning: @user_learning,
+        limit: 5
+      )
+    end
+    @radical_breakdown = measure_performance("review_show_radical_breakdown") do
+      RadicalBreakdownBuilder.call(
+        user: Current.user,
+        dictionary_entry: @user_learning.dictionary_entry
+      )
+    end
+    @stroke_order_diagrams = measure_performance("review_show_stroke_order_diagrams") do
+      StrokeOrderDiagramBuilder.call(dictionary_entry: @user_learning.dictionary_entry)
+    end
   end
 
   def submit
     ease = params[:ease].to_i
     return head :unprocessable_content unless (1..4).include?(ease)
 
-    ls           = active_learning_session
-    session_card = ls.current_card(current_position)
+    ls           = measure_performance("review_submit_session_lookup") { active_learning_session }
+    session_card = measure_performance("review_submit_session_card_lookup") do
+      ls.current_card(current_position)
+    end
     user_learning = session_card.user_learning
-    result = SpacedRepetition::SM2.call(user_learning: user_learning, ease: ease)
+    result = measure_performance("review_submit_sm2") do
+      SpacedRepetition::SM2.call(user_learning: user_learning, ease: ease)
+    end
 
-    ApplicationRecord.transaction do
-      user_learning.update!(
-        state:         result.new_state,
-        last_interval: result.interval,
-        factor:        result.factor,
-        next_due:      result.next_due
-      )
+    measure_performance("review_submit_transaction") do
+      ApplicationRecord.transaction do
+        user_learning.update!(
+          state:         result.new_state,
+          last_interval: result.interval,
+          factor:        result.factor,
+          next_due:      result.next_due
+        )
 
-      ReviewLog.create!(
-        user_learning: user_learning,
-        ease:          ease,
-        interval:      result.interval,
-        factor:        result.factor,
-        log_type:      0
-      )
+        ReviewLog.create!(
+          user_learning: user_learning,
+          ease:          ease,
+          interval:      result.interval,
+          factor:        result.factor,
+          log_type:      0
+        )
 
-      session_card.update!(ease: ease, reviewed_at: Time.current)
+        session_card.update!(ease: ease, reviewed_at: Time.current)
+      end
     end
 
     next_position = current_position + 1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,12 @@ Rails.application.configure do
 
   # Single-line structured request logs (replaces Rails' multi-line default).
   config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    event.payload.each_with_object({}) do |(key, value), custom|
+      key = key.to_s
+      custom[key] = value if key.start_with?("perf_")
+    end
+  end
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"

--- a/spec/requests/learn_spec.rb
+++ b/spec/requests/learn_spec.rb
@@ -346,6 +346,25 @@ RSpec.describe "Learn", type: :request do
 
         expect(response.body).to include("Mastered")
       end
+
+      it "adds learn show performance timings to the request payload" do
+        payload = nil
+        callback = lambda do |_name, _start, _finish, _id, data|
+          payload = data if data[:controller] == "LearnController" && data[:action] == "show"
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+          get learn_card_path
+        end
+
+        expect(payload).to include(
+          :perf_learn_show_total_ms,
+          :perf_learn_show_user_learning_lookup_ms,
+          :perf_learn_show_related_anchors_ms,
+          :perf_learn_show_radical_breakdown_ms,
+          :perf_learn_show_stroke_order_diagrams_ms
+        )
+      end
     end
 
     context "when authenticated without an active learn session" do
@@ -377,6 +396,23 @@ RSpec.describe "Learn", type: :request do
         it "adds the card to learn_introduced" do
           post learn_card_path, params: { know_it: "true" }
           expect(request.session[:learn_introduced]).to include(new_card.id)
+        end
+
+        it "adds learn submit performance timings to the request payload" do
+          payload = nil
+          callback = lambda do |_name, _start, _finish, _id, data|
+            payload = data if data[:controller] == "LearnController" && data[:action] == "submit"
+          end
+
+          ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+            post learn_card_path, params: { know_it: "true" }
+          end
+
+          expect(payload).to include(
+            :perf_learn_submit_total_ms,
+            :perf_learn_submit_user_learning_lookup_ms,
+            :perf_learn_submit_update_user_learning_ms
+          )
         end
       end
 
@@ -465,6 +501,25 @@ RSpec.describe "Learn", type: :request do
 
         expect(response.body).to include("Play audio for #{new_card.dictionary_entry.text}")
       end
+
+      it "adds learn review show performance timings to the request payload" do
+        payload = nil
+        callback = lambda do |_name, _start, _finish, _id, data|
+          payload = data if data[:controller] == "LearnController" && data[:action] == "review_show"
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+          get learn_review_path
+        end
+
+        expect(payload).to include(
+          :perf_learn_review_show_total_ms,
+          :perf_learn_review_show_user_learning_lookup_ms,
+          :perf_learn_review_show_related_anchors_ms,
+          :perf_learn_review_show_radical_breakdown_ms,
+          :perf_learn_review_show_stroke_order_diagrams_ms
+        )
+      end
     end
 
     context "when authenticated without an active review phase" do
@@ -499,6 +554,24 @@ RSpec.describe "Learn", type: :request do
           post learn_review_path, params: { ease: 3 }
           expect(response).to redirect_to(learn_summary_path)
         end
+      end
+
+      it "adds learn review submit performance timings to the request payload" do
+        payload = nil
+        callback = lambda do |_name, _start, _finish, _id, data|
+          payload = data if data[:controller] == "LearnController" && data[:action] == "review_submit"
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+          post learn_review_path, params: { ease: 3 }
+        end
+
+        expect(payload).to include(
+          :perf_learn_review_submit_total_ms,
+          :perf_learn_review_submit_user_learning_lookup_ms,
+          :perf_learn_review_submit_sm2_ms,
+          :perf_learn_review_submit_transaction_ms
+        )
       end
     end
 

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -347,6 +347,27 @@ RSpec.describe "Review", type: :request do
 
         expect(response.body).not_to include("Play audio for #{user_learning.dictionary_entry.text}")
       end
+
+      it "adds performance timings to the request payload" do
+        payload = nil
+        callback = lambda do |_name, _start, _finish, _id, data|
+          payload = data if data[:controller] == "ReviewController" && data[:action] == "show"
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+          get review_card_path
+        end
+
+        expect(payload).to include(
+          :perf_review_show_total_ms,
+          :perf_review_show_session_lookup_ms,
+          :perf_review_show_session_card_lookup_ms,
+          :perf_review_show_user_learning_lookup_ms,
+          :perf_review_show_related_anchors_ms,
+          :perf_review_show_radical_breakdown_ms,
+          :perf_review_show_stroke_order_diagrams_ms
+        )
+      end
     end
   end
 
@@ -401,6 +422,25 @@ RSpec.describe "Review", type: :request do
           expect {
             post review_card_path, params: { ease: 3 }
           }.to change { user_learning.reload.last_interval }
+        end
+
+        it "adds submit performance timings to the request payload" do
+          payload = nil
+          callback = lambda do |_name, _start, _finish, _id, data|
+            payload = data if data[:controller] == "ReviewController" && data[:action] == "submit"
+          end
+
+          ActiveSupport::Notifications.subscribed(callback, "process_action.action_controller") do
+            post review_card_path, params: { ease: 3 }
+          end
+
+          expect(payload).to include(
+            :perf_review_submit_total_ms,
+            :perf_review_submit_session_lookup_ms,
+            :perf_review_submit_session_card_lookup_ms,
+            :perf_review_submit_sm2_ms,
+            :perf_review_submit_transaction_ms
+          )
         end
       end
 


### PR DESCRIPTION
## Summary
- add lightweight timing instrumentation around learn and review flashcard actions
- include per-step timings for card lookup, related anchors, radical breakdown, stroke order, SM-2, and submit transactions
- forward `perf_*` payload fields into production Lograge output and cover the instrumentation with request specs

## Why
Production card transitions are slow, but the current logs do not show where request time is being spent. This adds enough visibility to tell whether the delay is in lookup queries, builder work, or write transactions before changing behaviour.

## Testing
- `bundle exec rspec spec/requests/review_spec.rb spec/requests/learn_spec.rb` (examples passed; repo SimpleCov minimum still fails on partial runs)
- `bundle exec ruby -c app/controllers/application_controller.rb`
- `bundle exec ruby -c app/controllers/review_controller.rb`
- `bundle exec ruby -c app/controllers/learn_controller.rb`
- `bundle exec ruby -c config/environments/production.rb`