### PR TITLE
fix(ci): increase Portainer stack redeploy timeout to 300s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
               headers=headers,
               method="PUT",
           )
-          with urllib.request.urlopen(req, timeout=120) as resp:
+          with urllib.request.urlopen(req, timeout=300) as resp:
               result = json.load(resp)
               print(f"Redeployed learn_hanzi stack (status={result['Status']})")
           PYEOF


### PR DESCRIPTION
## Summary

- Every `publish` job failure in recent history is the same `TimeoutError` on the Portainer stack redeploy PUT
- The call to `PUT /api/stacks/{id}` was set to `timeout=120` — Portainer holds the connection open while docker-compose recreates containers
- Worst-case healthcheck cycle (`start_period: 30s`, `interval: 30s`, `retries: 3`) can hit 120s on its own, putting us right at the edge
- Bumps the timeout to 300s (5 min) to give headroom without being unreasonably long

## Test plan

- [ ] Merge and watch the next push to main — publish job should complete rather than time out

🤖 Generated with [Claude Code](https://claude.com/claude-code)