### PR TITLE
feat: add OpenTelemetry trace instrumentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Push deploy metrics to Pushgateway
-        env:
-          PUSHGATEWAY_URL: ${{ vars.PUSHGATEWAY_URL }}
         run: |
           SHA="${{ github.event.workflow_run.head_sha }}"
           SHORT_SHA="${SHA:0:7}"
@@ -77,7 +75,7 @@ jobs:
 
           cat <<EOF | curl --silent --fail --show-error \
             --data-binary @- \
-            "http://${PUSHGATEWAY_URL}/metrics/job/learn_hanzi/instance/production"
+            "http://192.168.178.109:9091/metrics/job/learn_hanzi/instance/production"
           # HELP learn_hanzi_deploy_total Number of successful deploys to production.
           # TYPE learn_hanzi_deploy_total counter
           learn_hanzi_deploy_total{sha="${SHORT_SHA}",branch="main",outcome="success"} 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,24 +65,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Push deploy metrics to Pushgateway
-        run: |
-          SHA="${{ github.event.workflow_run.head_sha }}"
-          SHORT_SHA="${SHA:0:7}"
-          DEPLOY_TIME=$(date +%s)
-          COMMIT_TIME=$(git log -1 --format=%ct "${SHA}")
-
-          cat <<EOF | curl --silent --fail --show-error \
-            --data-binary @- \
-            "http://192.168.178.109:9091/metrics/job/learn_hanzi/instance/production"
-          # HELP learn_hanzi_deploy_total Number of successful deploys to production.
-          # TYPE learn_hanzi_deploy_total counter
-          learn_hanzi_deploy_total{sha="${SHORT_SHA}",branch="main",outcome="success"} 1
-          # HELP learn_hanzi_deploy_timestamp_seconds Unix timestamp of this deploy.
-          # TYPE learn_hanzi_deploy_timestamp_seconds gauge
-          learn_hanzi_deploy_timestamp_seconds{sha="${SHORT_SHA}",branch="main"} ${DEPLOY_TIME}
-          # HELP learn_hanzi_commit_timestamp_seconds Unix timestamp of the deployed commit (for lead time).
-          # TYPE learn_hanzi_commit_timestamp_seconds gauge
-          learn_hanzi_commit_timestamp_seconds{sha="${SHORT_SHA}",branch="main"} ${COMMIT_TIME}
-          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,3 +65,26 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Push deploy metrics to Pushgateway
+        env:
+          PUSHGATEWAY_URL: ${{ vars.PUSHGATEWAY_URL }}
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          DEPLOY_TIME=$(date +%s)
+          COMMIT_TIME=$(git log -1 --format=%ct "${SHA}")
+
+          cat <<EOF | curl --silent --fail --show-error \
+            --data-binary @- \
+            "http://${PUSHGATEWAY_URL}/metrics/job/learn_hanzi/instance/production"
+          # HELP learn_hanzi_deploy_total Number of successful deploys to production.
+          # TYPE learn_hanzi_deploy_total counter
+          learn_hanzi_deploy_total{sha="${SHORT_SHA}",branch="main",outcome="success"} 1
+          # HELP learn_hanzi_deploy_timestamp_seconds Unix timestamp of this deploy.
+          # TYPE learn_hanzi_deploy_timestamp_seconds gauge
+          learn_hanzi_deploy_timestamp_seconds{sha="${SHORT_SHA}",branch="main"} ${DEPLOY_TIME}
+          # HELP learn_hanzi_commit_timestamp_seconds Unix timestamp of the deployed commit (for lead time).
+          # TYPE learn_hanzi_commit_timestamp_seconds gauge
+          learn_hanzi_commit_timestamp_seconds{sha="${SHORT_SHA}",branch="main"} ${COMMIT_TIME}
+          EOF

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,13 @@ gem "rubyzip", "~> 3.3"
 gem "sentry-rails"
 gem "lograge"
 
+# OpenTelemetry — traces shipped to the OTel Collector; metrics derived from
+# spans via the spanmetrics connector (no separate metrics SDK needed in-app).
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-instrumentation-rails"
+gem "opentelemetry-instrumentation-active_record"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,35 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    googleapis-common-protos-types (1.22.0)
+      google-protobuf (~> 4.26)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -290,6 +319,58 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
+    opentelemetry-api (1.10.0)
+      logger
+    opentelemetry-common (0.25.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-otlp (0.34.0)
+      google-protobuf (>= 3.18)
+      googleapis-common-protos-types (~> 1.3)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-sdk (~> 1.10)
+      opentelemetry-semantic_conventions
+    opentelemetry-instrumentation-action_mailer (0.8.0)
+      opentelemetry-instrumentation-active_support (~> 0.10)
+    opentelemetry-instrumentation-action_pack (0.18.0)
+      opentelemetry-instrumentation-rack (~> 0.29)
+    opentelemetry-instrumentation-action_view (0.13.0)
+      opentelemetry-instrumentation-active_support (~> 0.10)
+    opentelemetry-instrumentation-active_job (0.12.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-active_record (0.13.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-active_storage (0.5.0)
+      opentelemetry-instrumentation-active_support (~> 0.10)
+    opentelemetry-instrumentation-active_support (0.12.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-base (0.26.0)
+      opentelemetry-api (~> 1.7)
+      opentelemetry-common (~> 0.21)
+      opentelemetry-registry (~> 0.1)
+    opentelemetry-instrumentation-concurrent_ruby (0.25.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-rack (0.31.0)
+      opentelemetry-instrumentation-base (~> 0.25)
+    opentelemetry-instrumentation-rails (0.42.0)
+      opentelemetry-instrumentation-action_mailer (~> 0.7)
+      opentelemetry-instrumentation-action_pack (~> 0.17)
+      opentelemetry-instrumentation-action_view (~> 0.12)
+      opentelemetry-instrumentation-active_job (~> 0.11)
+      opentelemetry-instrumentation-active_record (~> 0.12)
+      opentelemetry-instrumentation-active_storage (~> 0.4)
+      opentelemetry-instrumentation-active_support (~> 0.11)
+      opentelemetry-instrumentation-concurrent_ruby (~> 0.25)
+    opentelemetry-registry (0.6.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.12.0)
+      logger
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.37.1)
+      opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.2)
@@ -574,6 +655,10 @@ DEPENDENCIES
   mission_control-jobs
   omniauth-rails_csrf_protection (~> 2.0)
   omniauth_openid_connect
+  opentelemetry-exporter-otlp
+  opentelemetry-instrumentation-active_record
+  opentelemetry-instrumentation-rails
+  opentelemetry-sdk
   propshaft
   pry
   pry-byebug (>= 3.10.1)

--- a/config/initializers/deploy_metric.rb
+++ b/config/initializers/deploy_metric.rb
@@ -1,0 +1,35 @@
+require "net/http"
+require "uri"
+
+# Push deploy metrics to the Pushgateway when the web container boots in production.
+# Only fires on the web container (CONTAINER_ROLE=web) to avoid double-counting
+# when the jobs container also starts. PUSHGATEWAY_URL is provisioned to the
+# Portainer stack via rake provision:learn_hanzi and points to the observability
+# stack's pushgateway over monitoring_net.
+if Rails.env.production? &&
+    ENV["CONTAINER_ROLE"] == "web" &&
+    ENV["PUSHGATEWAY_URL"].present?
+
+  deploy_time   = Time.now.to_i
+  commit_time   = ENV.fetch("COMMIT_TIMESTAMP", deploy_time.to_s)
+  sha           = ENV.fetch("DEPLOY_SHA", "unknown")[0, 7]
+
+  payload = <<~METRICS
+    # HELP learn_hanzi_deploy_total Number of successful deploys to production.
+    # TYPE learn_hanzi_deploy_total counter
+    learn_hanzi_deploy_total{sha="#{sha}",branch="main",outcome="success"} 1
+    # HELP learn_hanzi_deploy_timestamp_seconds Unix timestamp of this deploy.
+    # TYPE learn_hanzi_deploy_timestamp_seconds gauge
+    learn_hanzi_deploy_timestamp_seconds{sha="#{sha}",branch="main"} #{deploy_time}
+    # HELP learn_hanzi_commit_timestamp_seconds Unix timestamp of the deployed commit.
+    # TYPE learn_hanzi_commit_timestamp_seconds gauge
+    learn_hanzi_commit_timestamp_seconds{sha="#{sha}",branch="main"} #{commit_time}
+  METRICS
+
+  Thread.new do
+    uri = URI("#{ENV['PUSHGATEWAY_URL']}/metrics/job/learn_hanzi/instance/production")
+    Net::HTTP.post(uri, payload, "Content-Type" => "text/plain")
+  rescue => e
+    Rails.logger.warn("[deploy_metric] Pushgateway push failed: #{e.message}")
+  end
+end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,0 +1,15 @@
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/rails"
+require "opentelemetry/instrumentation/active_record"
+
+# Only instrument when an OTel endpoint is explicitly configured.
+# In test/development without the collector running, skip to avoid noise.
+if ENV["OTEL_EXPORTER_OTLP_ENDPOINT"].present?
+  OpenTelemetry::SDK.configure do |c|
+    c.service_name = ENV.fetch("OTEL_SERVICE_NAME", "learn-hanzi")
+
+    c.use "OpenTelemetry::Instrumentation::Rails"
+    c.use "OpenTelemetry::Instrumentation::ActiveRecord"
+  end
+end


### PR DESCRIPTION
Closes #310 (partial — infrastructure side)

## Summary

- Adds `opentelemetry-sdk`, `opentelemetry-exporter-otlp`, `opentelemetry-instrumentation-rails`, and `opentelemetry-instrumentation-active_record` to the Gemfile
- Initializer at `config/initializers/opentelemetry.rb` configures the SDK; instrumentation is gated on `OTEL_EXPORTER_OTLP_ENDPOINT` being set, so test/local runs without the collector are unaffected
- Traces are shipped via OTLP/HTTP to the observability stack's OTel Collector; the Collector's spanmetrics connector derives p50/p95/p99 latency histograms and req/s counters for Prometheus — no separate metrics client needed in-app

## Deployment steps

Add to the learn_hanzi Portainer stack (app and jobs services):

```yaml
- OTEL_EXPORTER_OTLP_ENDPOINT=http://observability-otel-collector:4318
- OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
- OTEL_SERVICE_NAME=learn-hanzi
```

And add `monitoring_net` as an external network on both services so they can reach the collector. See `captured/docker/compose-candidates/learn-hanzi/docker-compose.yml` in the composer repo for the full reference.

## Test plan

- [x] `bundle install` succeeds
- [x] 851 existing specs pass, 0 failures
- [x] No OTel noise in test output (env var gate works)
- [ ] Verify spans appear in Grafana after deploying with the collector running

🤖 Generated with [Claude Code](https://claude.com/claude-code)