### PR TITLE
Remove jobs container, run SolidQueue via Puma plugin

### DIFF
--- a/bin/jobs
+++ b/bin/jobs
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative "../config/environment"
-require "solid_queue/cli"
-
-SolidQueue::Cli.start(ARGV)

--- a/config/initializers/deploy_metric.rb
+++ b/config/initializers/deploy_metric.rb
@@ -2,10 +2,8 @@ require "net/http"
 require "uri"
 
 # Push deploy metrics to the Pushgateway when the web container boots in production.
-# Only fires on the web container (CONTAINER_ROLE=web) to avoid double-counting
-# when the jobs container also starts. PUSHGATEWAY_URL is provisioned to the
-# Portainer stack via rake provision:learn_hanzi and points to the observability
-# stack's pushgateway over monitoring_net.
+# PUSHGATEWAY_URL is provisioned to the Portainer stack via rake provision:learn_hanzi
+# and points to the observability stack's pushgateway over monitoring_net.
 if Rails.env.production? &&
     ENV["CONTAINER_ROLE"] == "web" &&
     ENV["PUSHGATEWAY_URL"].present?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,25 +31,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-
-  jobs:
-    image: 127.0.0.1:5000/learn_hanzi:${IMAGE_TAG:-latest}
-    command: ./bin/jobs
-    user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
-    restart: unless-stopped
-    depends_on:
-      app:
-        condition: service_healthy
-    environment:
-      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:?RAILS_MASTER_KEY must be set}
-      RAILS_LOG_LEVEL: ${RAILS_LOG_LEVEL:-info}
-      JOB_CONCURRENCY: ${JOB_CONCURRENCY:-1}
-      JOB_THREADS: ${JOB_THREADS:-1}
-      BUNDLE_USER_HOME: /tmp/bundler
-      OIDC_ISSUER: ${OIDC_ISSUER:?OIDC_ISSUER must be set}
-      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:?OIDC_CLIENT_ID must be set}
-      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?OIDC_CLIENT_SECRET must be set}
-      OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:?OIDC_REDIRECT_URI must be set}
-      GLITCHTIP_DSN: ${GLITCHTIP_DSN}
-    volumes:
-      - ${STORAGE_PATH:?STORAGE_PATH is required}:/rails/storage


### PR DESCRIPTION
## Summary

- Removes the separate `jobs` container in favour of Rails 8's `SOLID_QUEUE_IN_PUMA` mode, which runs the SolidQueue supervisor inside the Puma web process
- Deletes `bin/jobs` (no longer invoked by anything)
- Removes the `jobs` service from `docker-compose.yml`
- Updates a stale comment in `deploy_metric.rb` that referenced the now-gone jobs container

The Kamal `config/deploy.yml` already had `SOLID_QUEUE_IN_PUMA: true` — this aligns the Portainer stack to the same approach. A companion PR in [composer](https://github.com/huwd/composer) updates the Portainer stack definition.

## Motivation

`gismo` (the NAS) is under sustained I/O and memory pressure. The jobs container (a second Ruby/Rails process) adds ~90 MB RSS and competes for the same SQLite queue database. Moving to the Puma plugin eliminates the second container entirely.

## Test plan

- [ ] CI passes
- [ ] Deploy to production via Portainer (after merging companion composer PR) and confirm jobs still process (provisioning and Anki import)
- [ ] Check MissionControl at `/admin/jobs` to confirm SolidQueue is running inside the web process

🤖 Generated with [Claude Code](https://claude.com/claude-code)