### PR TITLE
chore: switch error tracking from GlitchTip to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = ENV["GLITCHTIP_DSN"]
+  config.dsn = ENV["SENTRY_DSN"]
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
   config.traces_sample_rate = 0.2
   config.send_default_pii = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:?OIDC_CLIENT_ID must be set}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?OIDC_CLIENT_SECRET must be set}
       OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:?OIDC_REDIRECT_URI must be set}
-      GLITCHTIP_DSN: ${GLITCHTIP_DSN}
+      SENTRY_DSN: ${SENTRY_DSN}
     volumes:
       - ${STORAGE_PATH:?STORAGE_PATH is required}:/rails/storage
     healthcheck:


### PR DESCRIPTION
## Summary

- Replaces `GLITCHTIP_DSN` with `SENTRY_DSN` in the Sentry initializer and `docker-compose.yml`
- No gem changes needed — `sentry-ruby` already speaks the Sentry protocol; GlitchTip was just consuming it

## Motivation

Self-hosted GlitchTip (postgres + valkey + web) was too resource-heavy to run locally. Switching to hosted Sentry.io removes the operational burden. The companion PR in `composer` removes the GlitchTip stack and firewall rules.

## Test plan

- [ ] Deploy with `SENTRY_DSN` set in server `.env` and confirm errors appear in Sentry
- [ ] Confirm app starts cleanly without `SENTRY_DSN` set (SDK is a no-op when DSN is blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)