### PR TITLE
chore: enable full Sentry instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,9 @@ gem "solid_queue"
 gem "mission_control-jobs"
 gem "rubyzip", "~> 3.3"
 
-# Observability
+# Observability — stackprof must load before sentry-ruby for profiling support
+gem "stackprof"
+gem "sentry-ruby"
 gem "sentry-rails"
 gem "lograge"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,6 +562,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    stackprof (0.2.28)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -671,11 +672,13 @@ DEPENDENCIES
   rubyzip (~> 3.3)
   selenium-webdriver
   sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 7.0)
   simplecov
   solid_cache
   solid_queue
   sqlite3 (>= 2.1)
+  stackprof
   stimulus-rails
   tailwindcss-rails
   thruster

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,11 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
-  config.traces_sample_rate = 0.2
-  config.send_default_pii = false
+  config.send_default_pii = true
+
+  config.enable_logs = true
+  config.enabled_patches = [ :logger ]
+
+  config.traces_sample_rate = 1.0
+  config.profiles_sample_rate = 1.0
 end


### PR DESCRIPTION
## Summary

- Adds `stackprof` gem (must load before `sentry-ruby` for Ruby profiling beta support) and explicit `sentry-ruby` dependency
- Enables log forwarding (`enable_logs`, `enabled_patches: [:logger]`)
- Sets `send_default_pii = true` to capture request headers/IPs
- Raises `traces_sample_rate` to 1.0 and adds `profiles_sample_rate = 1.0`

DSN stays in `ENV["SENTRY_DSN"]` — not hardcoded.

## Test plan

- [ ] Deploy and verify errors/transactions appear in Sentry dashboard
- [ ] Confirm Ruby profiles appear in Sentry Profiling tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)