### PR TITLE
perf: raise SolidQueue worker polling_interval to 2s

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -6,7 +6,7 @@ default: &default
     - queues: "*"
       threads: <%= ENV.fetch("JOB_THREADS", 3) %>
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: 2
 
 development:
   <<: *default


### PR DESCRIPTION
## Summary

- Raises the SolidQueue worker `polling_interval` from `0.1` to `2` seconds in `config/queue.yml`
- Eliminates ~95% of `solid_queue_ready_executions` queries (10 req/s → 0.5 req/s)
- Relieves SQLite write contention that was inflating the `SolidQueue::Process` heartbeat query to 200ms p95 during study sessions

## Context

Closes #333. During a study session on 2026-05-25, the SolidQueue worker was polling SQLite 10 times/second with an empty queue, saturating the write lock. This caused the otherwise-simple `Process` heartbeat query to reach 205ms p95 — well above the 20ms acceptance criterion.

Both job types in this app (`AnkiImportJob`, `ProvisioningJob`) are admin-triggered batch tasks with no real-time latency requirement. A 2s job pickup delay is imperceptible.

## Test plan

- [x] Full RSpec suite passes (865 examples, 0 failures)
- [x] Rubocop passes (249 files, no offences)
- [ ] Deploy to production and verify `SolidQueue::Process query` p95 drops below 20ms at the same ~0.05 req/s call rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)