### PR TITLE
fix: add turbo-frame=_top to rating buttons to escape card frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,3 +246,26 @@ Authentication helpers for request specs are in `spec/support/authentication_hel
 ### Authentication
 
 Rails 8's built-in authentication generator was used (`bin/rails generate authentication`). Session management is in `app/controllers/concerns/authentication.rb`.
+
+## Deployment
+
+Production runs as a Docker container on a Synology NAS ("gismo") managed by Portainer.
+
+**Automated pipeline** (CI on push to `main`):
+1. GitHub Actions builds a Docker image and pushes it to a private registry at `gismo:5000` (reachable via Tailscale), tagged `latest` and with a CalVer tag.
+2. CI then calls the Portainer API to pull the new image and redeploy the stack.
+
+**Stack definition**: `../composer/stacks/learn-hanzi/docker-compose.yml` — this file is the source of truth for the container configuration (port mappings, env vars, volume mounts, network). The companion project lives at `~/Projects/Personal/composer`.
+
+**Manual deploy**: from the composer project, run:
+```bash
+rake provision:learn_hanzi
+```
+
+**Required environment variables** (set in Portainer stack env, not committed):
+- `RAILS_MASTER_KEY`
+- `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`
+- `STORAGE_PATH` — host path mounted to `/rails/storage` (holds the SQLite databases)
+- `SENTRY_DSN` (optional)
+
+The app runs on port 8037 externally, 3037 internally, with SolidQueue embedded in Puma (`SOLID_QUEUE_IN_PUMA=true`).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ bin/rubocop              # lint
 bin/brakeman --no-pager  # security scan
 ```
 
+## Deployment
+
+Production runs as a Docker container on a Synology NAS via Portainer.
+
+Pushing to `main` triggers a GitHub Actions pipeline that builds a Docker image, pushes it to a private registry at `gismo:5000` (Tailscale-accessible), and redeploys the Portainer stack automatically.
+
+The compose stack definition and deployment tooling live in the companion [`composer`](../composer) project (`stacks/learn-hanzi/docker-compose.yml`). To redeploy manually:
+
+```bash
+cd ../composer
+rake provision:learn_hanzi
+```
+
 ## Contributing
 
 Issues and pull requests welcome. See `CLAUDE.md` for development conventions (commit format, branching, TDD workflow) and `docs/DEVELOPMENT.md` for the project's early development history.

--- a/app/views/review/show.html.erb
+++ b/app/views/review/show.html.erb
@@ -103,22 +103,22 @@
     <%# ---- BACK: rating buttons (hidden until revealed) ---- %>
     <div data-card-flip-target="back" class="hidden">
       <div class="mt-6 flex justify-between">
-        <%= button_to review_card_path, params: { ease: 1 }, data: { ease: "1" },
+        <%= button_to review_card_path, params: { ease: 1 }, data: { ease: "1", turbo_frame: "_top" },
               class: "relative p-5 bg-red-50 dark:bg-red-900/40 text-red-600 dark:text-red-400 font-medium rounded-xl hover:bg-red-100 dark:hover:bg-red-900/60 transition-colors" do %>
           <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">1</span>
           Again
         <% end %>
-        <%= button_to review_card_path, params: { ease: 2 }, data: { ease: "2" },
+        <%= button_to review_card_path, params: { ease: 2 }, data: { ease: "2", turbo_frame: "_top" },
               class: "relative p-5 bg-orange-50 dark:bg-orange-900/40 text-orange-600 dark:text-orange-400 font-medium rounded-xl hover:bg-orange-100 dark:hover:bg-orange-900/60 transition-colors" do %>
           <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">2</span>
           Hard
         <% end %>
-        <%= button_to review_card_path, params: { ease: 3 }, data: { ease: "3" },
+        <%= button_to review_card_path, params: { ease: 3 }, data: { ease: "3", turbo_frame: "_top" },
               class: "relative p-5 bg-green-50 dark:bg-green-900/40 text-green-600 dark:text-green-400 font-medium rounded-xl hover:bg-green-100 dark:hover:bg-green-900/60 transition-colors" do %>
           <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">3</span>
           Good
         <% end %>
-        <%= button_to review_card_path, params: { ease: 4 }, data: { ease: "4" },
+        <%= button_to review_card_path, params: { ease: 4 }, data: { ease: "4", turbo_frame: "_top" },
               class: "relative p-5 bg-blue-50 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 font-medium rounded-xl hover:bg-blue-100 dark:hover:bg-blue-900/60 transition-colors" do %>
           <span class="absolute top-1.5 right-1.5 text-xs font-mono border border-current rounded px-1 leading-none opacity-40">4</span>
           Easy

--- a/spec/requests/review_spec.rb
+++ b/spec/requests/review_spec.rb
@@ -196,6 +196,11 @@ RSpec.describe "Review", type: :request do
         expect(response.body).to match(/<turbo-frame[^>]*id="card"/)
       end
 
+      it "rating buttons target _top to escape the card frame on submit" do
+        get review_card_path
+        expect(response.body).to include('data-turbo-frame="_top"').at_least(4).times
+      end
+
       it "shows position and total" do
         get review_card_path
         expect(response.body).to include("1 / 1")


### PR DESCRIPTION
## Summary

- Adds `data-turbo-frame="_top"` to the four ease rating buttons (Again/Hard/Good/Easy) in `app/views/review/show.html.erb`
- Fixes the "Content missing" Turbo error when submitting the final card in a review session

## Root cause

The rating buttons sit inside `<turbo-frame id="card">`. Turbo was scoping their form submissions to that frame, so the redirect to `/review/summary` after the last card prompted Turbo to look for `<turbo-frame id="card">` in the summary page — which doesn't exist — producing "Content missing".

Setting `data-turbo-frame="_top"` on each button tells Turbo to target the top-level frame at activation time, making the redirect a full-page navigation regardless of the button's position in the DOM.

## Test plan

- [ ] New request spec asserts all four buttons carry `data-turbo-frame="_top"`
- [ ] Full review spec suite passes (63 examples, 0 failures)
- [ ] Manual: complete a review session and confirm summary page loads correctly

Closes #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)