### PR TITLE
fix: order new cards by HSK level then frequency rank

### DIFF
--- a/app/services/learning_session/composer.rb
+++ b/app/services/learning_session/composer.rb
@@ -2,6 +2,8 @@ class LearningSession::Composer
     DEFAULT_SIZE = 20
     DEFAULT_NEW_CAP = 5
 
+    HSK_LEVEL_NAMES = [ "HSK 1", "HSK 2", "HSK 3", "HSK 4", "HSK 5", "HSK 6", "HSK 7-9" ].freeze
+
     def self.call(user:, size: DEFAULT_SIZE, new_cap: DEFAULT_NEW_CAP, include_new: false, tag: nil)
       new(user, size, new_cap, include_new, tag).call
     end
@@ -43,7 +45,37 @@ class LearningSession::Composer
     end
 
     def new_cards(limit)
-      scoped_learnings.new_learnings.order(:created_at).limit(limit).to_a
+      ul      = UserLearning.arel_table
+      hsk_de  = Arel::Table.new("dictionary_entries", as: "hsk_de")
+      hsk_det = Arel::Table.new("dictionary_entry_tags", as: "hsk_det")
+      hsk_t   = Arel::Table.new("tags", as: "hsk_t")
+
+      hsk_joins = [
+        ul.join(hsk_de, Arel::Nodes::OuterJoin)
+          .on(hsk_de[:id].eq(ul[:dictionary_entry_id]))
+          .join_sources,
+        ul.join(hsk_det, Arel::Nodes::OuterJoin)
+          .on(hsk_det[:dictionary_entry_id].eq(hsk_de[:id]))
+          .join_sources,
+        ul.join(hsk_t, Arel::Nodes::OuterJoin)
+          .on(
+            hsk_t[:id].eq(hsk_det[:tag_id])
+              .and(hsk_t[:category].eq("HSK"))
+              .and(hsk_t[:name].in(HSK_LEVEL_NAMES))
+          )
+          .join_sources
+      ].flatten
+
+      scoped_learnings
+        .new_learnings
+        .joins(hsk_joins)
+        .group("user_learnings.id")
+        .order(Arel.sql("CASE WHEN MIN(hsk_t.id) IS NULL THEN 1 ELSE 0 END"))
+        .order(Arel.sql("MIN(CAST(SUBSTR(hsk_t.name, 5) AS INTEGER))"))
+        .order(Arel.sql("CASE WHEN hsk_de.frequency_rank IS NULL THEN 1 ELSE 0 END"))
+        .order(Arel.sql("hsk_de.frequency_rank ASC"))
+        .limit(limit)
+        .to_a
     end
 
     def due_mastered_cards
@@ -52,10 +84,11 @@ class LearningSession::Composer
 
     def scoped_learnings
       @scoped_learnings ||= if @tag
-        @user.user_learnings
-             .joins(dictionary_entry: :dictionary_entry_tags)
-             .where(dictionary_entry_tags: { tag_id: @tag.subtree_ids })
-             .distinct
+        entry_ids = DictionaryEntry
+          .joins(:dictionary_entry_tags)
+          .where(dictionary_entry_tags: { tag_id: @tag.subtree_ids })
+          .select(:id)
+        @user.user_learnings.where(dictionary_entry_id: entry_ids)
       else
         @user.user_learnings
       end

--- a/spec/services/learning_session/composer_spec.rb
+++ b/spec/services/learning_session/composer_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe LearningSession::Composer do
       it "returns UserLearning records" do
         expect(queue).to all(be_a(UserLearning))
       end
-
-      it "returns UserLearning records in some order" do
-        expect(queue).to all(be_a(UserLearning))
-      end
     end
 
     context "when the user has more new cards than new_cap" do

--- a/spec/services/learning_session/composer_spec.rb
+++ b/spec/services/learning_session/composer_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe LearningSession::Composer do
         expect(queue).to all(be_a(UserLearning))
       end
 
-      it "orders new cards by created_at ascending (oldest first)" do
-        expect(queue.map(&:created_at)).to eq(queue.map(&:created_at).sort)
+      it "returns UserLearning records in some order" do
+        expect(queue).to all(be_a(UserLearning))
       end
     end
 
@@ -196,6 +196,56 @@ RSpec.describe LearningSession::Composer do
         it "does not include the card more than once" do
           expect(queue.count { |ul| ul.id == multi_tagged.id }).to eq(1)
         end
+      end
+    end
+
+    context "new card ordering: HSK level then frequency rank" do
+      subject(:queue) { described_class.call(user: user, size: 20, new_cap: 20, include_new: true) }
+
+      let(:hsk1_tag) { create(:tag, name: "HSK 1", category: "HSK") }
+      let(:hsk2_tag) { create(:tag, name: "HSK 2", category: "HSK") }
+
+      # Created in reverse order so that created_at ordering would give the wrong result
+      let!(:ul_untagged) do
+        entry = create(:dictionary_entry, frequency_rank: 1)
+        create(:user_learning, user: user, dictionary_entry: entry, state: "new")
+      end
+      let!(:ul_hsk2) do
+        entry = create(:dictionary_entry, frequency_rank: 20)
+        entry.tags << hsk2_tag
+        create(:user_learning, user: user, dictionary_entry: entry, state: "new")
+      end
+      let!(:ul_hsk1_uncommon) do
+        entry = create(:dictionary_entry, frequency_rank: 50)
+        entry.tags << hsk1_tag
+        create(:user_learning, user: user, dictionary_entry: entry, state: "new")
+      end
+      let!(:ul_hsk1_common) do
+        entry = create(:dictionary_entry, frequency_rank: 5)
+        entry.tags << hsk1_tag
+        create(:user_learning, user: user, dictionary_entry: entry, state: "new")
+      end
+      let!(:ul_no_frequency) do
+        entry = create(:dictionary_entry, frequency_rank: nil)
+        entry.tags << hsk1_tag
+        create(:user_learning, user: user, dictionary_entry: entry, state: "new")
+      end
+
+      it "places HSK 1 entries before HSK 2" do
+        expect(queue.index(ul_hsk1_common)).to be < queue.index(ul_hsk2)
+        expect(queue.index(ul_hsk1_uncommon)).to be < queue.index(ul_hsk2)
+      end
+
+      it "orders by frequency rank within the same HSK level, lowest rank first" do
+        expect(queue.index(ul_hsk1_common)).to be < queue.index(ul_hsk1_uncommon)
+      end
+
+      it "places entries with no frequency rank after those with a rank, within the same level" do
+        expect(queue.index(ul_hsk1_uncommon)).to be < queue.index(ul_no_frequency)
+      end
+
+      it "places untagged entries after all HSK-levelled entries" do
+        expect(queue.index(ul_untagged)).to be > queue.index(ul_hsk2)
       end
     end
 


### PR DESCRIPTION
## Summary

- New vocabulary was surfaced in `created_at` order (import order), causing higher HSK-level words to appear before lower-level ones
- Fixes by ordering new cards: HSK level ascending (1 → 7-9), then `frequency_rank` ascending (most common first), with untagged and unranked entries last
- Uses LEFT JOINs with table aliases so the ordering join is independent of any tag-filter join already present in `scoped_learnings`

Closes #353

## How it works

The `new_cards` method in `LearningSession::Composer` now joins through `dictionary_entry_tags → tags` (filtered to names `HSK 1`–`HSK 7-9`) and orders by:

1. `CASE WHEN MIN(hsk_t.id) IS NULL THEN 1 ELSE 0 END` — entries with no HSK level tag sort last
2. `MIN(CAST(SUBSTR(hsk_t.name, 5) AS INTEGER))` — extracts the numeric level; `HSK 7-9` casts to `7` correctly
3. `CASE WHEN hsk_de.frequency_rank IS NULL THEN 1 ELSE 0 END` — unranked entries sort last within their level
4. `hsk_de.frequency_rank ASC` — most common word first within a level

`GROUP BY user_learnings.id` replaces `DISTINCT` for deduplication, so entries tagged at multiple HSK levels still appear once at their lowest level.

## Test plan

- [x] New specs added for each ordering rule (level before level, frequency within level, unranked last, untagged last)
- [x] Entries created in reverse order in the spec to rule out accidental `created_at` pass
- [x] Full suite: 830 examples, 0 failures
- [x] Rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)