### PR TITLE
build: skip InvalidDefaultArgInFrom Dockerfile lint rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# check=error=true
+# check=error=true,skip=InvalidDefaultArgInFrom
 
 # This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
 # docker build -t learn_hanzi .


### PR DESCRIPTION
## Summary

- `ARG RUBY_VERSION` in the Dockerfile intentionally has no default — it must be passed via `--build-arg` so the version is always sourced from `.ruby-version`
- BuildKit's `InvalidDefaultArgInFrom` lint rule (enforced as an error via `# check=error=true`) requires ARGs used in `FROM` to have defaults, which conflicts with this intent
- Skips that specific rule while keeping all other Dockerfile lint checks as errors

## Test plan

- [ ] CI passes and the `publish` job builds the Docker image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)