### PR TITLE
fix: read CF-Access-Jwt-Assertion header for MCP auth

### DIFF
--- a/app/controllers/concerns/cf_access_authentication.rb
+++ b/app/controllers/concerns/cf_access_authentication.rb
@@ -16,7 +16,7 @@ module CfAccessAuthentication
   attr_reader :current_mcp_user
 
   def cf_access_authenticate!
-    token = extract_bearer_token
+    token = extract_cf_assertion_token
     return render_unauthorized unless token
 
     payload = decode_cf_token(token)
@@ -31,7 +31,7 @@ module CfAccessAuthentication
     @current_mcp_user = user
   end
 
-  def extract_bearer_token
+  def extract_cf_assertion_token
     request.headers["CF-Access-Jwt-Assertion"].presence
   end
 

--- a/app/controllers/concerns/cf_access_authentication.rb
+++ b/app/controllers/concerns/cf_access_authentication.rb
@@ -32,8 +32,7 @@ module CfAccessAuthentication
   end
 
   def extract_bearer_token
-    auth = request.headers["Authorization"]
-    auth&.start_with?("Bearer ") ? auth.delete_prefix("Bearer ") : nil
+    request.headers["CF-Access-Jwt-Assertion"].presence
   end
 
   def decode_cf_token(token)

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -22,37 +22,37 @@ RSpec.describe "MCP", type: :request do
       end
 
       it "returns 401 with a malformed token" do
-        post "/mcp", headers: bearer("not.a.jwt"), as: :json
+        post "/mcp", headers: cf_assertion_header("not.a.jwt"), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 with an expired token" do
         token = cf_access_token(email: user.email_address, exp: 1.hour.ago.to_i)
-        post "/mcp", headers: bearer(token), as: :json
+        post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 with the wrong issuer" do
         token = cf_access_token(email: user.email_address, iss: "https://evil.example.com")
-        post "/mcp", headers: bearer(token), as: :json
+        post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 with the wrong audience" do
         token = cf_access_token(email: user.email_address, aud: "wrong-aud")
-        post "/mcp", headers: bearer(token), as: :json
+        post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 when the email claim is absent" do
         token = cf_access_token(email: user.email_address, omit_email: true)
-        post "/mcp", headers: bearer(token), as: :json
+        post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 when the email does not match any user" do
         token = cf_access_token(email: "nobody@example.com")
-        post "/mcp", headers: bearer(token), as: :json
+        post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe "MCP", type: :request do
 
       it "does not expose internal error detail on auth failure" do
         bad_token = cf_access_token(email: "nobody@example.com")
-        post "/mcp", headers: bearer(bad_token), as: :json
+        post "/mcp", headers: cf_assertion_header(bad_token), as: :json
         expect(response.body).not_to include("ActiveRecord")
         expect(response.body).not_to include("exception")
       end
@@ -82,32 +82,32 @@ RSpec.describe "MCP", type: :request do
         end
 
         it "returns a JSON-RPC 2.0 envelope with the request id" do
-          post "/mcp", params: init_params, headers: bearer(token), as: :json
+          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
           body = JSON.parse(response.body)
           expect(body["jsonrpc"]).to eq("2.0")
           expect(body["id"]).to eq(1)
         end
 
         it "returns the negotiated protocol version" do
-          post "/mcp", params: init_params, headers: bearer(token), as: :json
+          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
           body = JSON.parse(response.body)
           expect(body["result"]["protocolVersion"]).to eq("2025-03-26")
         end
 
         it "advertises resource capabilities" do
-          post "/mcp", params: init_params, headers: bearer(token), as: :json
+          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
           body = JSON.parse(response.body)
           expect(body["result"]["capabilities"]["resources"]).to be_present
         end
 
         it "returns server info" do
-          post "/mcp", params: init_params, headers: bearer(token), as: :json
+          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
           body = JSON.parse(response.body)
           expect(body["result"]["serverInfo"]["name"]).to eq("learn-hanzi")
         end
 
         it "issues a session ID in the response header" do
-          post "/mcp", params: init_params, headers: bearer(token), as: :json
+          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
           expect(response.headers["Mcp-Session-Id"]).to be_present
         end
       end
@@ -117,7 +117,7 @@ RSpec.describe "MCP", type: :request do
           session_id = establish_mcp_session(token)
           post "/mcp",
             params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           expect(response).to have_http_status(:ok)
         end
@@ -125,7 +125,7 @@ RSpec.describe "MCP", type: :request do
         it "returns 404 with no session ID" do
           post "/mcp",
             params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: bearer(token),
+            headers: cf_assertion_header(token),
             as: :json
           expect(response).to have_http_status(:not_found)
         end
@@ -133,7 +133,7 @@ RSpec.describe "MCP", type: :request do
         it "returns 404 with an unknown session ID" do
           post "/mcp",
             params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: bearer(token).merge("Mcp-Session-Id" => "bogus-session-id"),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => "bogus-session-id"),
             as: :json
           expect(response).to have_http_status(:not_found)
         end
@@ -145,7 +145,7 @@ RSpec.describe "MCP", type: :request do
         it "returns a JSON-RPC 2.0 envelope" do
           post "/mcp",
             params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           body = JSON.parse(response.body)
           expect(body["jsonrpc"]).to eq("2.0")
@@ -155,7 +155,7 @@ RSpec.describe "MCP", type: :request do
         it "returns all five resources" do
           post "/mcp",
             params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           resources = JSON.parse(response.body).dig("result", "resources")
           expect(resources.length).to eq(5)
@@ -164,7 +164,7 @@ RSpec.describe "MCP", type: :request do
         it "includes all expected resource URIs" do
           post "/mcp",
             params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           uris = JSON.parse(response.body).dig("result", "resources").map { |r| r["uri"] }
           expect(uris).to contain_exactly(
@@ -179,7 +179,7 @@ RSpec.describe "MCP", type: :request do
         it "includes a name and mimeType for each resource" do
           post "/mcp",
             params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           resources = JSON.parse(response.body).dig("result", "resources")
           resources.each do |resource|
@@ -195,7 +195,7 @@ RSpec.describe "MCP", type: :request do
         def read_resource(uri)
           post "/mcp",
             params: { jsonrpc: "2.0", id: 3, method: "resources/read", params: { uri: uri } },
-            headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
             as: :json
           JSON.parse(response.body)
         end
@@ -488,7 +488,7 @@ RSpec.describe "MCP", type: :request do
           it "returns a JSON-RPC parse error (-32700) for invalid JSON" do
             post "/mcp",
               params: "not: valid json{{",
-              headers: bearer(token).merge("Content-Type" => "application/json")
+              headers: cf_assertion_header(token).merge("Content-Type" => "application/json")
             body = JSON.parse(response.body)
             expect(body["error"]["code"]).to eq(-32700)
           end
@@ -496,14 +496,14 @@ RSpec.describe "MCP", type: :request do
           it "returns a JSON-RPC invalid request error (-32600) for a JSON array body" do
             post "/mcp",
               params: "[1, 2, 3]",
-              headers: bearer(token).merge("Content-Type" => "application/json")
+              headers: cf_assertion_header(token).merge("Content-Type" => "application/json")
             body = JSON.parse(response.body)
             expect(body["error"]["code"]).to eq(-32600)
           end
 
           it "returns 401 when JWKS fetch raises an unexpected error" do
             stub_request(:get, CfAccessHelpers::JWKS_URI).to_raise(Net::OpenTimeout)
-            post "/mcp", headers: bearer(cf_access_token(email: user.email_address)), as: :json
+            post "/mcp", headers: cf_assertion_header(cf_access_token(email: user.email_address)), as: :json
             expect(response).to have_http_status(:unauthorized)
           end
 
@@ -511,7 +511,7 @@ RSpec.describe "MCP", type: :request do
             session_id = establish_mcp_session(token)
             post "/mcp",
               params: { jsonrpc: "2.0", id: 2, method: "unknown/method" },
-              headers: bearer(token).merge("Mcp-Session-Id" => session_id),
+              headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
               as: :json
             body = JSON.parse(response.body)
             expect(body["error"]["code"]).to eq(-32601)
@@ -529,7 +529,7 @@ RSpec.describe "MCP", type: :request do
         method: "initialize",
         params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "Test", version: "1.0" } }
       },
-      headers: bearer(token),
+      headers: cf_assertion_header(token),
       as: :json
     response.headers["Mcp-Session-Id"]
   end

--- a/spec/support/cf_access_helpers.rb
+++ b/spec/support/cf_access_helpers.rb
@@ -29,7 +29,7 @@ module CfAccessHelpers
     JWT.encode(payload, CfAccessHelpers.private_key, "RS256", { kid: "test-kid-1" })
   end
 
-  def bearer(token)
+  def cf_assertion_header(token)
     { "CF-Access-Jwt-Assertion" => token }
   end
 end

--- a/spec/support/cf_access_helpers.rb
+++ b/spec/support/cf_access_helpers.rb
@@ -30,6 +30,6 @@ module CfAccessHelpers
   end
 
   def bearer(token)
-    { "Authorization" => "Bearer #{token}" }
+    { "CF-Access-Jwt-Assertion" => token }
   end
 end


### PR DESCRIPTION
## Summary

- CF Access validates service token credentials (`CF-Access-Client-Id` / `CF-Access-Client-Secret`) at the proxy level and injects the resulting JWT as `CF-Access-Jwt-Assertion` on the forwarded request to the origin
- The previous `Authorization: Bearer` approach was intercepted by CF Access before reaching Rails, causing a 302 redirect to the login page
- Switching to `CF-Access-Jwt-Assertion` means MCP clients only need static service token headers — no token rotation required

## Test plan

- [ ] All 57 MCP specs pass (test helper updated to send `CF-Access-Jwt-Assertion`)
- [ ] After merge and deploy, test with service token headers:
  ```bash
  curl -X POST https://xue.huwdiprose.co.uk/mcp \
    -H "CF-Access-Client-Id: <client-id>" \
    -H "CF-Access-Client-Secret: <client-secret>" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)