### PR TITLE
build: fix Dockerfile check directive syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# check=error=true,skip=InvalidDefaultArgInFrom
+# check=error=true;skip=InvalidDefaultArgInFrom
 
 # This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
 # docker build -t learn_hanzi .


### PR DESCRIPTION
## Summary

Fixes the `# check=` directive syntax introduced in the previous PR.

Comma is not a valid separator between check options — BuildKit's parser treats it as part of the `error` value, causing:
```
failed to parse check option "error=true,skip=InvalidDefaultArgInFrom": strconv.ParseBool: parsing "true,skip=InvalidDefaultArgInFrom": invalid syntax
```

Semicolons are the correct delimiter for multiple options within a single `# check=` directive.

## Test plan

- [ ] `publish` job builds the Docker image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)