### PR TITLE
test: fix misleading auth descriptions in MCP specs

### DIFF
--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -11,13 +11,8 @@ RSpec.describe "MCP", type: :request do
 
   describe "POST /mcp" do
     context "when unauthenticated" do
-      it "returns 401 with no Authorization header" do
+      it "returns 401 when CF-Access-Jwt-Assertion header is absent" do
         post "/mcp", as: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
-
-      it "returns 401 with a non-Bearer Authorization scheme" do
-        post "/mcp", headers: { "Authorization" => "Basic dXNlcjpwYXNz" }, as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 


### PR DESCRIPTION
## Summary

Copilot caught that two examples in the unauthenticated context still described `Authorization` header behaviour after the switch to `CF-Access-Jwt-Assertion`:

- `"returns 401 with no Authorization header"` → renamed to `"returns 401 when CF-Access-Jwt-Assertion header is absent"`
- `"returns 401 with a non-Bearer Authorization scheme"` → removed; it was sending an irrelevant `Authorization: Basic` header and the 401 fired because `CF-Access-Jwt-Assertion` was absent, not because of that header's value. The absence case above already covers this scenario.

56 examples, 0 failures.

Closes the Copilot comment on #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)