### PR TITLE
feat: associate CF Access service token with user account

### DIFF
--- a/app/controllers/concerns/cf_access_authentication.rb
+++ b/app/controllers/concerns/cf_access_authentication.rb
@@ -30,7 +30,10 @@ module CfAccessAuthentication
 
   def resolve_user(payload)
     if payload["type"] == "app"
-      token_id = payload["common_name"]&.delete_suffix(".access")
+      common_name = payload["common_name"]
+      return nil unless common_name&.end_with?(".access")
+      token_id = common_name.delete_suffix(".access")
+      return nil if token_id.blank?
       User.find_by(mcp_service_token_id: token_id)
     else
       email = payload["email"].presence

--- a/app/controllers/concerns/cf_access_authentication.rb
+++ b/app/controllers/concerns/cf_access_authentication.rb
@@ -22,13 +22,20 @@ module CfAccessAuthentication
     payload = decode_cf_token(token)
     return render_unauthorized unless payload
 
-    email = payload["email"].presence
-    return render_unauthorized unless email
-
-    user = User.find_by(email_address: email)
+    user = resolve_user(payload)
     return render_unauthorized unless user
 
     @current_mcp_user = user
+  end
+
+  def resolve_user(payload)
+    if payload["type"] == "app"
+      token_id = payload["common_name"]&.delete_suffix(".access")
+      User.find_by(mcp_service_token_id: token_id)
+    else
+      email = payload["email"].presence
+      User.find_by(email_address: email) if email
+    end
   end
 
   def extract_cf_assertion_token

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -17,6 +17,6 @@ class SettingsController < ApplicationController
   private
 
   def settings_params
-    params.require(:user).permit(:session_size, :new_cards_per_session, :telemetry_enabled)
+    params.require(:user).permit(:session_size, :new_cards_per_session, :telemetry_enabled, :mcp_service_token_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
 
   validates :email_address, presence: true, uniqueness: true
   validates :mcp_service_token_id, uniqueness: true, allow_nil: true
-  normalizes :mcp_service_token_id, with: ->(v) { v.presence }
+  normalizes :mcp_service_token_id, with: ->(v) { v&.strip.presence }
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
   normalizes :email_address, with: ->(e) { e.strip.downcase }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   has_many :learning_sessions, dependent: :destroy
 
   validates :email_address, presence: true, uniqueness: true
+  validates :mcp_service_token_id, uniqueness: true, allow_nil: true
+  normalizes :mcp_service_token_id, with: ->(v) { v.presence }
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
   normalizes :email_address, with: ->(e) { e.strip.downcase }

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -94,6 +94,32 @@
   </div>
 
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-6">API access (MCP)</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      Link a Cloudflare Access service token so AI tools (e.g. Claude) can access your learning data via the MCP server.
+      Enter your service token's <strong>Client ID</strong> from the Cloudflare Zero Trust dashboard.
+    </p>
+
+    <%= form_with model: @user, url: settings_path, method: :patch do |f| %>
+      <div>
+        <%= f.label :mcp_service_token_id, "Cloudflare Access Client ID",
+              class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" %>
+        <%= f.text_field :mcp_service_token_id,
+              placeholder: "e.g. 19a513a5fef05e1f9e6b6b0375be7cbf",
+              class: "w-full max-w-lg rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700
+                      text-gray-900 dark:text-gray-100 px-3 py-2 text-sm font-mono
+                      focus:outline-none focus:ring-2 focus:ring-indigo-500" %>
+      </div>
+
+      <div class="mt-6">
+        <%= f.submit "Save API settings",
+              class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-6 py-3
+                      transition-colors cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
     <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Your data</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
       Export all your learning progress as a JSON file, or restore from a previous export.

--- a/db/migrate/20260705211906_add_mcp_service_token_id_to_users.rb
+++ b/db/migrate/20260705211906_add_mcp_service_token_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddMcpServiceTokenIdToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :mcp_service_token_id, :string
+    add_index :users, :mcp_service_token_id, unique: true, where: "mcp_service_token_id IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_30_225142) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_211906) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -229,6 +229,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_225142) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false
+    t.string "mcp_service_token_id"
     t.integer "new_cards_per_session", default: 5, null: false
     t.string "provider", default: "", null: false
     t.integer "session_size", default: 20, null: false
@@ -236,6 +237,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_225142) do
     t.string "uid", default: "", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["mcp_service_token_id"], name: "index_users_on_mcp_service_token_id", unique: true, where: "mcp_service_token_id IS NOT NULL"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "mcp_service_token_id" do
+    it "is optional" do
+      expect(build(:user, mcp_service_token_id: nil)).to be_valid
+    end
+
+    it "must be unique when present" do
+      create(:user, mcp_service_token_id: "abc123")
+      expect(build(:user, mcp_service_token_id: "abc123")).not_to be_valid
+    end
+
+    it "allows multiple users with nil" do
+      create(:user, mcp_service_token_id: nil)
+      expect(build(:user, mcp_service_token_id: nil)).to be_valid
+    end
+  end
+
   describe "admin flag" do
     it "defaults to false" do
       expect(create(:user).admin).to be false

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "MCP", type: :request do
           headers: cf_assertion_header(token),
           params: { jsonrpc: "2.0", id: 1, method: "initialize",
                     params: { protocolVersion: "2025-03-26", capabilities: {},
-                              clientInfo: { name: "test", version: "1" } } }.to_json,
+                              clientInfo: { name: "test", version: "1" } } },
           as: :json
         expect(response).to have_http_status(:ok)
         expect(response.headers["Mcp-Session-Id"]).to be_present

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -52,6 +52,36 @@ RSpec.describe "MCP", type: :request do
       end
     end
 
+    context "when authenticated via service token" do
+      let(:common_name) { "abc123def456.access" }
+      let(:token) { cf_service_token(common_name: common_name) }
+
+      before { user.update!(mcp_service_token_id: "abc123def456") }
+
+      it "authenticates and returns an MCP session" do
+        post "/mcp",
+          headers: cf_assertion_header(token),
+          params: { jsonrpc: "2.0", id: 1, method: "initialize",
+                    params: { protocolVersion: "2025-03-26", capabilities: {},
+                              clientInfo: { name: "test", version: "1" } } }.to_json,
+          as: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Mcp-Session-Id"]).to be_present
+      end
+
+      it "returns 401 when no user has a matching mcp_service_token_id" do
+        user.update!(mcp_service_token_id: nil)
+        post "/mcp", headers: cf_assertion_header(token), as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "returns 401 when the service token is expired" do
+        expired = cf_service_token(common_name: common_name, exp: 1.hour.ago.to_i)
+        post "/mcp", headers: cf_assertion_header(expired), as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
     context "when authenticated" do
       let(:token) { cf_access_token(email: user.email_address) }
 

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe "MCP", type: :request do
         post "/mcp", headers: cf_assertion_header(expired), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "returns 401 when common_name is absent" do
+        token_without_common_name = cf_service_token(common_name: nil)
+        post "/mcp", headers: cf_assertion_header(token_without_common_name), as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "returns 401 when common_name lacks the .access suffix" do
+        token_bad_format = cf_service_token(common_name: "abc123def456")
+        post "/mcp", headers: cf_assertion_header(token_bad_format), as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context "when authenticated" do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe "Settings", type: :request do
           expect(response).to redirect_to(settings_path)
         end
 
+        it "saves mcp_service_token_id and redirects back to settings" do
+          patch settings_path, params: { user: { mcp_service_token_id: "abc123def456" } }
+          expect(user.reload.mcp_service_token_id).to eq("abc123def456")
+          expect(response).to redirect_to(settings_path)
+        end
+
+        it "clears mcp_service_token_id when blank" do
+          user.update!(mcp_service_token_id: "abc123def456")
+          patch settings_path, params: { user: { mcp_service_token_id: "" } }
+          expect(user.reload.mcp_service_token_id).to be_nil
+        end
+
         it "disables telemetry_enabled" do
           user.update!(telemetry_enabled: true)
           patch settings_path, params: { user: { telemetry_enabled: false } }

--- a/spec/support/cf_access_helpers.rb
+++ b/spec/support/cf_access_helpers.rb
@@ -29,6 +29,11 @@ module CfAccessHelpers
     JWT.encode(payload, CfAccessHelpers.private_key, "RS256", { kid: "test-kid-1" })
   end
 
+  def cf_service_token(common_name:, aud: CfAccessHelpers::AUD, iss: CfAccessHelpers::ISSUER, exp: 1.hour.from_now.to_i)
+    payload = { type: "app", iss: iss, sub: "", aud: [ aud ], exp: exp, iat: Time.current.to_i, common_name: common_name }
+    JWT.encode(payload, CfAccessHelpers.private_key, "RS256", { kid: "test-kid-1" })
+  end
+
   def cf_assertion_header(token)
     { "CF-Access-Jwt-Assertion" => token }
   end

--- a/spec/support/cf_access_helpers.rb
+++ b/spec/support/cf_access_helpers.rb
@@ -30,7 +30,8 @@ module CfAccessHelpers
   end
 
   def cf_service_token(common_name:, aud: CfAccessHelpers::AUD, iss: CfAccessHelpers::ISSUER, exp: 1.hour.from_now.to_i)
-    payload = { type: "app", iss: iss, sub: "", aud: [ aud ], exp: exp, iat: Time.current.to_i, common_name: common_name }
+    payload = { type: "app", iss: iss, sub: "", aud: [ aud ], exp: exp, iat: Time.current.to_i }
+    payload[:common_name] = common_name unless common_name.nil?
     JWT.encode(payload, CfAccessHelpers.private_key, "RS256", { kid: "test-kid-1" })
   end
 


### PR DESCRIPTION
## Summary

- Adds `mcp_service_token_id` to `User` (nullable, unique-indexed)
- When the MCP server receives a service token JWT (`type=app`), it matches `common_name` (minus the `.access` suffix) to `User#mcp_service_token_id` instead of relying on an `email` claim (which service tokens don't carry)
- Settings page gains an **API access (MCP)** section where users paste their Cloudflare Access Client ID
- `normalizes` coerces blank strings to `nil` so clearing the field works cleanly

## Test plan

- [ ] All 893 specs pass
- [ ] After merge and deploy: enter Client ID in Settings, then run the test curl — should get a 200 with a session ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)