### PR TITLE
fix: replace real Client ID with dummy placeholder in settings view

### DIFF
--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -105,7 +105,7 @@
         <%= f.label :mcp_service_token_id, "Cloudflare Access Client ID",
               class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" %>
         <%= f.text_field :mcp_service_token_id,
-              placeholder: "e.g. 19a513a5fef05e1f9e6b6b0375be7cbf",
+              placeholder: "e.g. a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
               class: "w-full max-w-lg rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700
                       text-gray-900 dark:text-gray-100 px-3 py-2 text-sm font-mono
                       focus:outline-none focus:ring-2 focus:ring-indigo-500" %>


### PR DESCRIPTION
The settings view placeholder accidentally used a real CF Access Client ID. Replaced with a generic dummy value.