### PR TITLE
fix: content missing at end of keyboard-driven review session

### DIFF
--- a/app/javascript/controllers/card_flip_controller.js
+++ b/app/javascript/controllers/card_flip_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
 
     if (revealed && ["1", "2", "3", "4"].includes(event.key)) {
       const btn = this.element.querySelector(`button[data-ease="${event.key}"]`)
-      btn?.closest("form")?.requestSubmit()
+      btn?.closest("form")?.requestSubmit(btn)
     }
   }
 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ require_relative 'support/authentication_helpers'
 require_relative 'support/anki_helper'
 require_relative 'support/cf_access_helpers'
 require_relative 'support/query_counter'
+require_relative 'support/capybara'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -41,6 +42,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include AuthenticationHelpers, type: :request
+  config.include AuthenticationHelpers, type: :system
   config.include CfAccessHelpers, type: :request
   config.include QueryCounter
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -12,4 +12,21 @@ module AuthenticationHelpers
     OmniAuth.config.mock_auth.delete(:oidc)
     OmniAuth.config.test_mode = false
   end
+
+  # For system specs: drives the real sign-in form in a JS-capable browser
+  # rather than posting directly, since there is no shared Rack session to
+  # forge a request against.
+  def sign_in_via_browser(user)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new(
+      provider: user.provider,
+      uid: user.uid,
+      info: { email: user.email_address }
+    )
+    visit sign_in_path
+    click_button "Sign in with PocketID"
+  ensure
+    OmniAuth.config.mock_auth.delete(:oidc)
+    OmniAuth.config.test_mode = false
+  end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,36 @@
+require "capybara/rspec"
+require "json"
+
+# Selenium Manager's default resolution prefers a chromedriver already on
+# PATH over downloading one that matches the installed Chrome version. Dev
+# machines can have a stale one there (e.g. from an old nvm-installed npm
+# package), so ask Selenium Manager to ignore PATH and fetch/cache a driver
+# that actually matches the local Chrome build.
+def system_matched_chromedriver_path
+  selenium_manager = Dir.glob(
+    File.join(Gem.loaded_specs["selenium-webdriver"].full_gem_path, "bin/*/selenium-manager")
+  ).first
+  Selenium::WebDriver::Platform.assert_executable(selenium_manager)
+
+  output = `#{selenium_manager} --browser chrome --skip-driver-in-path --output json`
+  JSON.parse(output).dig("result", "driver_path")
+end
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless=new")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--window-size=1400,1400")
+
+  service = Selenium::WebDriver::Service.chrome(path: system_matched_chromedriver_path)
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, service: service)
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    WebMock.disable_net_connect!(allow_localhost: true)
+    driven_by :selenium_chrome_headless
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,6 @@
 require "capybara/rspec"
 require "json"
+require "open3"
 
 # Selenium Manager's default resolution prefers a chromedriver already on
 # PATH over downloading one that matches the installed Chrome version. Dev
@@ -7,13 +8,22 @@ require "json"
 # package), so ask Selenium Manager to ignore PATH and fetch/cache a driver
 # that actually matches the local Chrome build.
 def system_matched_chromedriver_path
-  selenium_manager = Dir.glob(
-    File.join(Gem.loaded_specs["selenium-webdriver"].full_gem_path, "bin/*/selenium-manager")
-  ).first
-  Selenium::WebDriver::Platform.assert_executable(selenium_manager)
+  @system_matched_chromedriver_path ||= begin
+    selenium_manager = Dir.glob(
+      File.join(Gem.loaded_specs["selenium-webdriver"].full_gem_path, "bin/*/selenium-manager")
+    ).first
+    Selenium::WebDriver::Platform.assert_executable(selenium_manager)
 
-  output = `#{selenium_manager} --browser chrome --skip-driver-in-path --output json`
-  JSON.parse(output).dig("result", "driver_path")
+    stdout, stderr, status = Open3.capture3(
+      selenium_manager, "--browser", "chrome", "--skip-driver-in-path", "--output", "json"
+    )
+    raise "Selenium Manager failed to resolve a chromedriver: #{stderr}" unless status.success?
+
+    driver_path = JSON.parse(stdout).dig("result", "driver_path")
+    raise "Selenium Manager did not return a chromedriver path: #{stdout}" if driver_path.blank?
+
+    driver_path
+  end
 end
 
 Capybara.register_driver :selenium_chrome_headless do |app|

--- a/spec/system/review_keyboard_spec.rb
+++ b/spec/system/review_keyboard_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Reviewing via keyboard shortcuts", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    create(:user_learning, user: user, state: "learning",
+           next_due: 1.day.ago, last_interval: 3)
+    sign_in_via_browser(user)
+  end
+
+  it "renders the summary page after rating the final card with a keyboard shortcut" do
+    visit review_path
+
+    expect(page).to have_css("[data-controller~='card-flip']")
+
+    find("body").send_keys(" ")
+    expect(page).to have_css("[data-card-flip-target='back']:not(.hidden)")
+
+    find("body").send_keys("3")
+
+    expect(page).to have_content("Session complete")
+    expect(page).to have_content("1")
+    expect(page).to have_content("cards reviewed")
+  end
+end


### PR DESCRIPTION
## Summary

- Rating the final card of a review session via keyboard (1-4) left the summary page blank ("Content missing"), because `requestSubmit()` was called with no submitter argument, dropping the button's `data-turbo-frame="_top"` override and leaving the submission scoped to the `#card` Turbo frame — which doesn't exist on the summary page.
- Adds Capybara + headless Chrome system spec infrastructure (gems were present but unconfigured) and a system spec that completes a one-card session entirely via keyboard, reproducing the bug and guarding against regression.

## Test plan

- [x] `bundle exec rspec spec/system/review_keyboard_spec.rb` fails against the pre-fix controller code (confirmed by temporarily reverting the fix) and passes with it applied
- [x] `bundle exec rspec` — 896 examples, 0 failures, 96.07% coverage
- [x] `bin/rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDi7gRJxFNnYYP6bjmA9su