### PR TITLE
feat: MCP OAuth 2.1 authorization server (Doorkeeper + CIMD)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,12 @@ gem "omniauth-rails_csrf_protection", "~> 2.0"
 # JWT validation for MCP server (CF Access bearer tokens)
 gem "jwt", "~> 3.2"
 
+# OAuth 2.1 authorization server for MCP clients (auth code + PKCE + refresh)
+gem "doorkeeper", "~> 5.9"
+
+# Rate limiting for OAuth authorize/token endpoints
+gem "rack-attack"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,12 @@ gem "jwt", "~> 3.2"
 # OAuth 2.1 authorization server for MCP clients (auth code + PKCE + refresh)
 gem "doorkeeper", "~> 5.9"
 
+# SSRF-safe HTTP fetch for CIMD client metadata documents (arbitrary
+# client-supplied URLs) — pins connections to the resolved IP it validated,
+# closing the DNS-rebinding TOCTOU gap a hand-rolled resolve-then-connect
+# check would have.
+gem "ssrf_filter", "~> 1.5"
+
 # Rate limiting for OAuth authorize/token endpoints
 gem "rack-attack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    doorkeeper (5.9.3)
+      railties (>= 5)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -401,6 +403,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-oauth2 (2.3.0)
@@ -650,6 +654,7 @@ DEPENDENCIES
   bullet
   capybara
   debug
+  doorkeeper (~> 5.9)
   dotenv-rails
   factory_bot_rails (~> 6.5)
   importmap-rails
@@ -669,6 +674,7 @@ DEPENDENCIES
   pry-byebug (>= 3.10.1)
   pry-rails
   puma (>= 5.0)
+  rack-attack
   rack-mini-profiler
   rails (~> 8.1.3)
   rspec-rails (~> 8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    ssrf_filter (1.5.0)
     stackprof (0.2.28)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
@@ -688,6 +689,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   sqlite3 (>= 2.1)
+  ssrf_filter (~> 1.5)
   stackprof
   stimulus-rails
   tailwindcss-rails

--- a/app/controllers/concerns/cf_access_authentication.rb
+++ b/app/controllers/concerns/cf_access_authentication.rb
@@ -1,44 +1,25 @@
 require "net/http"
 require "uri"
 
+# JWT-mechanics for the transitional Cloudflare Access service-token fallback
+# on /mcp. Deliberately has no before_action of its own — McpAuthentication
+# calls these methods explicitly as one of two auth strategies it tries.
 module CfAccessAuthentication
   extend ActiveSupport::Concern
 
   ISSUER   = "https://susurrant.cloudflareaccess.com"
   JWKS_URI = "#{ISSUER}/cdn-cgi/access/certs"
 
-  included do
-    before_action :cf_access_authenticate!
-  end
-
   private
 
-  attr_reader :current_mcp_user
+  def resolve_user_via_cf_service_token(payload)
+    return nil unless payload["type"] == "app"
 
-  def cf_access_authenticate!
-    token = extract_cf_assertion_token
-    return render_unauthorized unless token
-
-    payload = decode_cf_token(token)
-    return render_unauthorized unless payload
-
-    user = resolve_user(payload)
-    return render_unauthorized unless user
-
-    @current_mcp_user = user
-  end
-
-  def resolve_user(payload)
-    if payload["type"] == "app"
-      common_name = payload["common_name"]
-      return nil unless common_name&.end_with?(".access")
-      token_id = common_name.delete_suffix(".access")
-      return nil if token_id.blank?
-      User.find_by(mcp_service_token_id: token_id)
-    else
-      email = payload["email"].presence
-      User.find_by(email_address: email) if email
-    end
+    common_name = payload["common_name"]
+    return nil unless common_name&.end_with?(".access")
+    token_id = common_name.delete_suffix(".access")
+    return nil if token_id.blank?
+    User.find_by(mcp_service_token_id: token_id)
   end
 
   def extract_cf_assertion_token
@@ -70,9 +51,5 @@ module CfAccessAuthentication
       raise "JWKS fetch failed (#{response.code})" unless response.is_a?(Net::HTTPSuccess)
       JSON.parse(response.body)
     end
-  end
-
-  def render_unauthorized
-    render json: { error: "Unauthorized" }, status: :unauthorized
   end
 end

--- a/app/controllers/concerns/mcp_authentication.rb
+++ b/app/controllers/concerns/mcp_authentication.rb
@@ -1,0 +1,41 @@
+# Dispatches /mcp authentication across two strategies: a Doorkeeper OAuth
+# bearer token (the long-term path) or a Cloudflare Access service token (a
+# transitional fallback while existing clients migrate — see
+# CfAccessAuthentication). Trying Doorkeeper first means well-formed bearer
+# tokens never touch the CF JWT/JWKS code path at all.
+module McpAuthentication
+  extend ActiveSupport::Concern
+  include CfAccessAuthentication
+
+  included do
+    before_action :authenticate_mcp_request!
+  end
+
+  private
+
+  attr_reader :current_mcp_user
+
+  def authenticate_mcp_request!
+    @current_mcp_user = user_from_doorkeeper_token || user_from_cf_service_token
+    render_unauthorized unless @current_mcp_user
+  end
+
+  def user_from_doorkeeper_token
+    return nil unless doorkeeper_token&.acceptable?(%w[mcp])
+    User.find_by(id: doorkeeper_token.resource_owner_id)
+  end
+
+  def user_from_cf_service_token
+    token = extract_cf_assertion_token
+    return nil unless token
+
+    payload = decode_cf_token(token)
+    return nil unless payload
+
+    resolve_user_via_cf_service_token(payload)
+  end
+
+  def render_unauthorized
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+end

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -1,5 +1,5 @@
 class McpController < ActionController::API
-  include CfAccessAuthentication
+  include McpAuthentication
 
   PROTOCOL_VERSION = "2025-03-26"
   SESSION_TTL = 24.hours

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -32,7 +32,7 @@ module Oauth
 
       Oauth::CimdClientResolver.new(client_id).resolve!
     rescue Oauth::CimdClientResolver::InvalidMetadata, Oauth::CimdClientResolver::FetchError => e
-      Rails.logger.warn("CIMD resolution failed for #{client_id}: #{e.message}")
+      Rails.logger.warn("CIMD resolution failed for #{client_id.truncate(200).inspect}: #{e.message}")
     end
   end
 end

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -1,0 +1,25 @@
+module Oauth
+  # Resolves CIMD clients (client_id as an https:// metadata URL) before
+  # Doorkeeper's own pre_auth/client lookup runs. If resolution fails, no
+  # Doorkeeper::Application row exists for that client_id, so Doorkeeper's
+  # normal pre_auth.authorizable? check fails on its own and renders its
+  # standard invalid_client error — no separate error path needed here.
+  class AuthorizationsController < Doorkeeper::AuthorizationsController
+    # Deliberately a plain before_action (runs after the inherited
+    # authenticate_resource_owner!), not prepend_before_action — an
+    # unauthenticated visitor is redirected to sign in before this ever
+    # triggers an outbound fetch, not after.
+    before_action :resolve_cimd_client!
+
+    private
+
+    def resolve_cimd_client!
+      client_id = params[:client_id].to_s
+      return unless client_id.start_with?("https://")
+
+      Oauth::CimdClientResolver.new(client_id).resolve!
+    rescue Oauth::CimdClientResolver::InvalidMetadata, Oauth::CimdClientResolver::FetchError => e
+      Rails.logger.warn("CIMD resolution failed for #{client_id}: #{e.message}")
+    end
+  end
+end

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -5,6 +5,15 @@ module Oauth
   # normal pre_auth.authorizable? check fails on its own and renders its
   # standard invalid_client error — no separate error path needed here.
   class AuthorizationsController < Doorkeeper::AuthorizationsController
+    # Reuses the app's shared layout (Tailwind, nav, dark mode) rather than
+    # Doorkeeper's own bare layout. This controller doesn't inherit from
+    # ApplicationController (Doorkeeper's own hierarchy doesn't either, by
+    # design — TokensController etc. must stay session-agnostic for
+    # machine-to-machine calls), so the layout's `authenticated?` check needs
+    # a matching helper method defined here instead.
+    layout "application"
+    helper_method :authenticated?
+
     # Deliberately a plain before_action (runs after the inherited
     # authenticate_resource_owner!), not prepend_before_action — an
     # unauthenticated visitor is redirected to sign in before this ever
@@ -12,6 +21,10 @@ module Oauth
     before_action :resolve_cimd_client!
 
     private
+
+    def authenticated?
+      Current.user.present?
+    end
 
     def resolve_cimd_client!
       client_id = params[:client_id].to_s

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -2,6 +2,7 @@ class SettingsController < ApplicationController
   def show
     @user   = Current.user
     @advice = LearningAdvisor.classify(user: Current.user)
+    @connected_apps = connected_apps
   end
 
   def update
@@ -10,13 +11,27 @@ class SettingsController < ApplicationController
       redirect_to settings_path, notice: "Settings saved."
     else
       @advice = LearningAdvisor.classify(user: Current.user)
+      @connected_apps = connected_apps
       render :show, status: :unprocessable_content
     end
+  end
+
+  def revoke_connected_app
+    Doorkeeper::AccessToken.revoke_all_for(params[:id], Current.user)
+    redirect_to settings_path, notice: "Access revoked."
   end
 
   private
 
   def settings_params
     params.require(:user).permit(:session_size, :new_cards_per_session, :telemetry_enabled, :mcp_service_token_id)
+  end
+
+  def connected_apps
+    Doorkeeper::AccessToken
+      .by_resource_owner(Current.user)
+      .where(revoked_at: nil)
+      .includes(:application)
+      .group_by(&:application)
   end
 end

--- a/app/controllers/well_known_controller.rb
+++ b/app/controllers/well_known_controller.rb
@@ -1,0 +1,29 @@
+# OAuth discovery metadata for MCP clients (RFC 9728 / RFC 8414), advertising
+# this app as its own MCP clients' authorization server. No registration_endpoint
+# is advertised — clients self-identify via CIMD instead (see
+# Oauth::CimdClientResolver), which its absence signals per spec.
+class WellKnownController < ActionController::API
+  def oauth_protected_resource
+    render json: {
+      resource: mcp_url,
+      authorization_servers: [ root_url.chomp("/") ],
+      bearer_methods_supported: [ "header" ],
+      scopes_supported: [ "mcp" ]
+    }
+  end
+
+  def oauth_authorization_server
+    render json: {
+      issuer: root_url.chomp("/"),
+      authorization_endpoint: oauth_authorization_url,
+      token_endpoint: oauth_token_url,
+      revocation_endpoint: oauth_revoke_url,
+      response_types_supported: [ "code" ],
+      grant_types_supported: [ "authorization_code", "refresh_token" ],
+      code_challenge_methods_supported: [ "S256" ],
+      token_endpoint_auth_methods_supported: [ "none" ],
+      client_id_metadata_document_supported: true,
+      scopes_supported: [ "mcp" ]
+    }
+  end
+end

--- a/app/services/oauth/cimd_client_resolver.rb
+++ b/app/services/oauth/cimd_client_resolver.rb
@@ -1,0 +1,119 @@
+module Oauth
+  # Resolves an OAuth Client ID Metadata Document (CIMD) — client_id is an
+  # https:// URL pointing at a JSON document describing the client, fetched
+  # and validated on demand rather than a stateful registration call. This is
+  # the MCP authorization spec's recommended self-registration mechanism
+  # (SHOULD, as of the November 2025 revision), chosen over classic RFC 7591
+  # Dynamic Client Registration specifically because there's no public,
+  # unauthenticated "create a row" endpoint to spam — the tradeoff is that
+  # this resolver performs a server-side fetch of an attacker-reachable URL,
+  # so the SSRF hardening below is the security-critical part of this class.
+  class CimdClientResolver
+    class InvalidMetadata < StandardError; end
+    class FetchError < StandardError; end
+
+    CACHE_TTL = 1.hour
+    MAX_BODY_BYTES = 10.kilobytes
+    OPEN_TIMEOUT = 3
+    READ_TIMEOUT = 3
+
+    def initialize(client_id_url)
+      @client_id_url = client_id_url
+    end
+
+    def resolve!
+      validate_url_shape!
+      # A failed fetch/validation raises out of this block, so nothing is
+      # ever cached for a bad client_id — only a successfully validated
+      # document is memoized.
+      metadata = Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { fetch_and_validate_metadata }
+      upsert_application(metadata)
+    end
+
+    private
+
+    attr_reader :client_id_url
+
+    def cache_key
+      "cimd_client_metadata:#{client_id_url}"
+    end
+
+    def validate_url_shape!
+      uri = URI.parse(client_id_url)
+      raise InvalidMetadata, "client_id must be an https:// URL" unless uri.is_a?(URI::HTTPS)
+      raise InvalidMetadata, "client_id must have a path" if uri.path.blank?
+      raise InvalidMetadata, "client_id must not include a fragment" if uri.fragment.present?
+      raise InvalidMetadata, "client_id must not include userinfo" if uri.userinfo.present?
+    rescue URI::InvalidURIError
+      raise InvalidMetadata, "client_id is not a valid URL"
+    end
+
+    def fetch_and_validate_metadata
+      metadata = JSON.parse(fetch_body)
+      raise InvalidMetadata, "metadata document must be a JSON object" unless metadata.is_a?(Hash)
+
+      unless metadata["client_id"] == client_id_url
+        raise InvalidMetadata, "metadata client_id does not match the fetched URL"
+      end
+
+      redirect_uris = metadata["redirect_uris"]
+      unless redirect_uris.is_a?(Array) && redirect_uris.any?
+        raise InvalidMetadata, "redirect_uris is required"
+      end
+
+      auth_method = metadata["token_endpoint_auth_method"]
+      unless auth_method.nil? || auth_method == "none"
+        raise InvalidMetadata, "CIMD clients must be public (token_endpoint_auth_method must be absent or 'none')"
+      end
+
+      if metadata.key?("client_secret")
+        raise InvalidMetadata, "client_secret is not permitted in a CIMD document"
+      end
+
+      metadata
+    rescue JSON::ParserError
+      raise InvalidMetadata, "metadata document is not valid JSON"
+    end
+
+    def fetch_body
+      body = +""
+
+      response = SsrfFilter.get(
+        client_id_url,
+        max_redirects: 0, # fail closed rather than follow a client_id to somewhere else
+        http_options: { open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT }
+      ) do |res|
+        res.read_body do |chunk|
+          body << chunk
+          raise FetchError, "metadata document exceeded #{MAX_BODY_BYTES} bytes" if body.bytesize > MAX_BODY_BYTES
+        end
+      end
+
+      raise FetchError, "metadata fetch failed with status #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      body
+    rescue FetchError
+      raise
+    rescue SsrfFilter::Error => e
+      raise FetchError, "metadata fetch blocked: #{e.message}"
+    rescue StandardError => e
+      raise FetchError, "metadata fetch failed: #{e.class}: #{e.message}"
+    end
+
+    def upsert_application(metadata)
+      application = Doorkeeper::Application.find_or_initialize_by(metadata_url: client_id_url)
+      application.assign_attributes(
+        uid: client_id_url,
+        name: metadata["client_name"].presence || "Unnamed MCP client",
+        redirect_uri: Array(metadata["redirect_uris"]).join("\n"),
+        confidential: false,
+        scopes: "mcp",
+        metadata_fetched_at: Time.current
+      )
+      application.save!
+      application
+    rescue ActiveRecord::RecordInvalid => e
+      raise InvalidMetadata, e.message
+    end
+  end
+end

--- a/app/services/oauth/cimd_client_resolver.rb
+++ b/app/services/oauth/cimd_client_resolver.rb
@@ -44,6 +44,12 @@ module Oauth
       raise InvalidMetadata, "client_id must have a path" if uri.path.blank?
       raise InvalidMetadata, "client_id must not include a fragment" if uri.fragment.present?
       raise InvalidMetadata, "client_id must not include userinfo" if uri.userinfo.present?
+      # uri.port is normalized to 443 whether or not it was written explicitly,
+      # so check the literal string — an explicit `:443` is a second, spurious
+      # representation of the same origin the spec asks us to reject.
+      if client_id_url.match?(%r{\Ahttps://[^/]*:443(/|\z)})
+        raise InvalidMetadata, "client_id must not specify the default port explicitly"
+      end
     rescue URI::InvalidURIError
       raise InvalidMetadata, "client_id is not a valid URL"
     end

--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Authorization error" %>
+
+<div class="max-w-md mx-auto w-full py-16">
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-4">
+      <%= t("doorkeeper.authorizations.error.title") %>
+    </h2>
+    <p class="text-sm text-red-600 dark:text-red-400">
+      <%= (local_assigns[:error_response] ? error_response : @pre_auth.error_response).body[:error_description] %>
+    </p>
+  </div>
+</div>

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -1,0 +1,15 @@
+<header class="page-header">
+  <h1><%= t('.title') %></h1>
+</header>
+
+<%= form_tag @pre_auth.redirect_uri, method: :post, name: :redirect_form, authenticity_token: false do %>
+  <% auth.body.compact.each do |key, value| %>
+    <%= hidden_field_tag key, value %>
+  <% end %>
+<% end %>
+
+<script>
+  window.onload = function () {
+    document.forms['redirect_form'].submit();
+  };
+</script>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -1,0 +1,49 @@
+<% content_for :title, "Authorize application" %>
+
+<div class="max-w-md mx-auto w-full py-16">
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Authorize application</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
+      <strong class="text-gray-700 dark:text-gray-300"><%= @pre_auth.client.name %></strong>
+      is requesting access to your learn-hanzi data.
+    </p>
+
+    <% if @pre_auth.scopes.count > 0 %>
+      <div class="mb-6">
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">This will allow it to:</p>
+        <ul class="list-disc list-inside space-y-1 text-sm text-gray-600 dark:text-gray-400">
+          <% @pre_auth.scopes.each do |scope| %>
+            <li><%= t scope, scope: [ :doorkeeper, :scopes ] %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="flex gap-4">
+      <%= form_tag oauth_authorization_path, method: :post, class: "flex-1" do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri, id: nil %>
+        <%= hidden_field_tag :state, @pre_auth.state, id: nil %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type, id: nil %>
+        <%= hidden_field_tag :response_mode, @pre_auth.response_mode, id: nil %>
+        <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
+        <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
+        <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+        <%= submit_tag t("doorkeeper.authorizations.buttons.authorize"),
+              class: "w-full px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-500 transition-colors cursor-pointer" %>
+      <% end %>
+      <%= form_tag oauth_authorization_path, method: :delete, class: "flex-1" do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri, id: nil %>
+        <%= hidden_field_tag :state, @pre_auth.state, id: nil %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type, id: nil %>
+        <%= hidden_field_tag :response_mode, @pre_auth.response_mode, id: nil %>
+        <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
+        <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
+        <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+        <%= submit_tag t("doorkeeper.authorizations.buttons.deny"),
+              class: "w-full px-6 py-3 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 font-semibold rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors cursor-pointer" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Authorization code" %>
+
+<div class="max-w-md mx-auto w-full py-16">
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-4"><%= t(".title") %></h2>
+    <code id="authorization_code" class="block break-all text-sm bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg p-4"><%= params[:code] %></code>
+  </div>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -120,6 +120,32 @@
   </div>
 
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
+    <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-6">Connected apps</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      AI tools that have completed OAuth sign-in and can access your learning data via the MCP server.
+    </p>
+
+    <% if @connected_apps.any? %>
+      <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+        <% @connected_apps.each do |application, tokens| %>
+          <li class="py-4 flex items-center justify-between gap-4">
+            <div>
+              <p class="font-medium text-gray-800 dark:text-gray-200"><%= application.name %></p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                Connected <%= tokens.map(&:created_at).min.to_date %>
+              </p>
+            </div>
+            <%= button_to "Revoke", revoke_connected_app_path(application.id), method: :delete,
+                  class: "text-sm font-semibold text-red-600 dark:text-red-400 hover:text-red-500 bg-transparent border-0 p-0 cursor-pointer" %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-gray-500 dark:text-gray-400">No AI tools are currently connected.</p>
+    <% end %>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-8 mt-8">
     <h2 class="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">Your data</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
       Export all your learning progress as a JSON file, or restore from a previous export.

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,8 @@ module LearnHanzi
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Throttles OAuth authorize/token endpoints (see config/initializers/rack_attack.rb).
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -26,7 +26,7 @@ Doorkeeper.configure do
   # sign-in flow and lands back here afterwards.
   resource_owner_authenticator do
     Current.session ||= Session.find_by(id: cookies.signed[:session_id])
-    Current.user || (session[:return_to_after_authenticating] = request.url
+    Current.user || (session[:return_to_after_authenticating] = request.url if request.get? || request.head?
                       redirect_to(sign_in_path))
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -296,7 +296,12 @@ Doorkeeper.configure do
   # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
   # for more information on customization
   #
-  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+  # Header only — never accept a bearer token via a query/body param (avoids
+  # tokens leaking into logs/referrers) and avoids Rails eagerly parsing the
+  # request body as params just to check for one, which would otherwise blow
+  # up on malformed JSON before McpController's own parser gets a chance to
+  # render a proper JSON-RPC error for it.
+  access_token_methods :from_bearer_authorization
 
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,558 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # Enable support for multiple database configurations with read replicas.
+  # When enabled, Doorkeeper will wrap database write operations to ensure they
+  # use the primary (writable) database when automatic role switching is enabled.
+  #
+  # For ActiveRecord (Rails 6.1+), this uses `ActiveRecord::Base.connected_to(role: :writing)`.
+  # Other ORM extensions can implement their own primary database targeting logic.
+  #
+  # enable_multiple_database_roles
+  #
+  # This prevents `ActiveRecord::ReadOnlyError` when using read replicas with Rails
+  # automatic role switching. Enable this if your application uses multiple databases
+  # with automatic role switching for read replicas.
+  #
+  # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching
+
+  # Reuse the exact same session resolution the rest of the app uses (see
+  # Authentication#resume_session) rather than a second identity system —
+  # an unauthenticated visitor is bounced through the existing PocketID-backed
+  # sign-in flow and lands back here afterwards.
+  resource_owner_authenticator do
+    Current.session ||= Session.find_by(id: cookies.signed[:session_id])
+    Current.user || (session[:return_to_after_authenticating] = request.url
+                      redirect_to(sign_in_path))
+  end
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #
+  #   if current_user
+  #     head :forbidden unless current_user.admin?
+  #   else
+  #     redirect_to sign_in_url
+  #   end
+  # end
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # By default Doorkeeper ActiveRecord ORM uses its own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you set this to `nil` Doorkeeper will not expire the token and omit expires_in in response.
+  # It is RECOMMENDED to set expiration time explicitly.
+  # Prefer access_token_expires_in 100.years or similar,
+  # which would be functionally equivalent and avoid the risk of unexpected behavior by callers.
+  #
+  access_token_expires_in 2.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
+  #
+  # base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Only allow one valid access token obtained via authorization code
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # revoke_previous_authorization_code_token
+
+  # Require non-confidential clients to use PKCE when using an authorization code
+  # to obtain an access_token (disabled by default)
+  #
+  # Every application this server creates is a public client (CIMD-resolved MCP
+  # clients are always confidential: false), so PKCE is mandatory, not optional.
+  force_pkce
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without adding 'fallback: :plain'.
+  #
+  hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # This can be done by adding 'fallback: plain', e.g. :
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt', fallback: :plain
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  # enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  # The server is read-only, so there's exactly one scope — no write/admin
+  # scopes exist yet.
+  default_scopes :mcp
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  # enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+  #
+  # Mirrors the same dev/test-vs-everything-else split used for the OIDC
+  # redirect_uri (see config/initializers/omniauth.rb).
+  force_ssl_in_redirect_uri { !Rails.env.local? }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is allowed by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+  #
+  # If you want to redirect back to the client application in accordance with
+  # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can set
+  # +handle_auth_errors+ to :redirect
+  #
+  # handle_auth_errors :redirect
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
+  #
+  # Only the authorization code grant is needed for MCP clients — no implicit,
+  # password, or client_credentials flows.
+  grant_flows %w[authorization_code]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # By default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
+  # end
+
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_attributes [:tenant_id]
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # No third-party resource servers consume these tokens — only this app's own
+  # MCP endpoint, which validates tokens directly via doorkeeper_token — so the
+  # introspection endpoint is disabled rather than left exposed unused.
+  allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -25,7 +25,7 @@ Doorkeeper.configure do
   # an unauthenticated visitor is bounced through the existing PocketID-backed
   # sign-in flow and lands back here afterwards.
   resource_owner_authenticator do
-    Current.session ||= Session.find_by(id: cookies.signed[:session_id])
+    Current.session ||= (Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id])
     Current.user || (session[:return_to_after_authenticating] = request.url if request.get? || request.head?
                       redirect_to(sign_in_path))
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,16 @@
+class Rack::Attack
+  # Share the throttle counters across Puma workers via solid_cache rather
+  # than each worker's own in-memory store.
+  Rack::Attack.cache.store = Rails.cache
+
+  # /oauth/authorize also triggers a CIMD metadata fetch for unrecognized
+  # client_id URLs (see Oauth::CimdClientResolver), so throttling it bounds
+  # outbound fetch volume from a single IP as well as authorization attempts.
+  throttle("oauth/authorize", limit: 30, period: 1.minute) do |req|
+    req.ip if req.path == "/oauth/authorize"
+  end
+
+  throttle("oauth/token", limit: 20, period: 1.minute) do |req|
+    req.ip if req.path == "/oauth/token" && req.post?
+  end
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,155 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match those configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require a redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID:'
+        secret: 'Secret:'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes:'
+        confidential: 'Confidential:'
+        callback_urls: 'Callback URLs:'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to:'
+      show:
+        title: 'Authorization code:'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request needs to be authorized. Required parameter for authorizing the request is missing or invalid.'
+          invalid_code_challenge: 'Code challenge is required.'
+        invalid_redirect_uri: "The requested redirect URI is malformed or doesn't match the client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method:
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,15 @@ Rails.application.routes.draw do
   # Returns 200 when the primary DB is reachable, 503 when the connection fails.
   get "up" => "health#show", as: :rails_health_check
 
-  # MCP server — AI agent access to learning state (OAuth 2.1 via CF Access)
+  # OAuth 2.1 authorization server for MCP clients. No self-service application
+  # management UI is exposed — CIMD clients are resolved automatically, so
+  # :applications/:authorized_applications are skipped rather than left open.
+  use_doorkeeper do
+    skip_controllers :applications, :authorized_applications
+  end
+
+  # MCP server — Doorkeeper OAuth 2.1 bearer tokens, with a transitional CF
+  # Access service-token fallback while existing clients migrate.
   post "mcp", to: "mcp#handle"
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   # :applications/:authorized_applications are skipped rather than left open.
   use_doorkeeper do
     skip_controllers :applications, :authorized_applications
+    # Resolves CIMD clients (client_id as an https:// metadata URL) before
+    # Doorkeeper's own client lookup runs.
+    controllers authorizations: "oauth/authorizations"
   end
 
   # MCP server — Doorkeeper OAuth 2.1 bearer tokens, with a transitional CF

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     controllers authorizations: "oauth/authorizations"
   end
 
+  get "/.well-known/oauth-protected-resource",   to: "well_known#oauth_protected_resource"
+  get "/.well-known/oauth-authorization-server", to: "well_known#oauth_authorization_server"
+
   # MCP server — Doorkeeper OAuth 2.1 bearer tokens, with a transitional CF
   # Access service-token fallback while existing clients migrate.
   post "mcp", to: "mcp#handle"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   get  "auth/failure",       to: "omniauth_callbacks#failure",                as: :auth_failure
 
   resource :settings, only: %i[show update]
+  delete "settings/connected_apps/:id", to: "settings#revoke_connected_app", as: :revoke_connected_app
   get "sign_in", to: "sessions#new", as: :sign_in
   resource :session, only: %i[destroy]
   resources :tags, only: [ :index, :show ]

--- a/db/migrate/20260706071214_create_doorkeeper_tables.rb
+++ b/db/migrate/20260706071214_create_doorkeeper_tables.rb
@@ -22,7 +22,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
 
     create_table :oauth_access_grants do |t|
       t.references :resource_owner,  null: false
-      t.references :application,     null: false
+      t.references :application,     null: false, foreign_key: { to_table: :oauth_applications }
       t.string   :token,             null: false
       t.integer  :expires_in,        null: false
       t.text     :redirect_uri,      null: false
@@ -32,18 +32,13 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
     end
 
     add_index :oauth_access_grants, :token, unique: true
-    add_foreign_key(
-      :oauth_access_grants,
-      :oauth_applications,
-      column: :application_id
-    )
 
     create_table :oauth_access_tokens do |t|
       t.references :resource_owner, index: true
 
       # Remove `null: false` if you are planning to use Password
       # Credentials Grant flow that doesn't require an application.
-      t.references :application,    null: false
+      t.references :application,    null: false, foreign_key: { to_table: :oauth_applications }
 
       # If you use a custom token generator you may need to change this column
       # from string to text, so that it accepts tokens larger than 255
@@ -86,15 +81,5 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
     else
       add_index :oauth_access_tokens, :refresh_token, unique: true
     end
-
-    add_foreign_key(
-      :oauth_access_tokens,
-      :oauth_applications,
-      column: :application_id
-    )
-
-    # Uncomment below to ensure a valid reference to the resource owner's table
-    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
-    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
   end
 end

--- a/db/migrate/20260706071214_create_doorkeeper_tables.rb
+++ b/db/migrate/20260706071214_create_doorkeeper_tables.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      # Nullable: every application this server creates is a public client
+      # (CIMD-resolved MCP clients are always confidential: false, no secret).
+      t.string  :secret
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
+  end
+end

--- a/db/migrate/20260706071215_enable_pkce.rb
+++ b/db/migrate/20260706071215_enable_pkce.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EnablePkce < ActiveRecord::Migration[8.1]
+  def change
+    add_column :oauth_access_grants, :code_challenge, :string, null: true
+    add_column :oauth_access_grants, :code_challenge_method, :string, null: true
+  end
+end

--- a/db/migrate/20260706071255_add_cimd_metadata_to_oauth_applications.rb
+++ b/db/migrate/20260706071255_add_cimd_metadata_to_oauth_applications.rb
@@ -1,0 +1,7 @@
+class AddCimdMetadataToOauthApplications < ActiveRecord::Migration[8.1]
+  def change
+    add_column :oauth_applications, :metadata_url, :string
+    add_index :oauth_applications, :metadata_url, unique: true
+    add_column :oauth_applications, :metadata_fetched_at, :datetime
+  end
+end

--- a/db/migrate/20260707105039_add_resource_owner_foreign_keys_to_oauth_tables.rb
+++ b/db/migrate/20260707105039_add_resource_owner_foreign_keys_to_oauth_tables.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddResourceOwnerForeignKeysToOauthTables < ActiveRecord::Migration[8.1]
+  def change
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id
+    add_foreign_key :oauth_access_tokens, :users, column: :resource_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_211906) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_071255) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -144,6 +144,53 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_211906) do
     t.index ["source_id"], name: "index_meanings_on_source_id"
   end
 
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.integer "application_id", null: false
+    t.string "code_challenge"
+    t.string "code_challenge_method"
+    t.datetime "created_at", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.integer "resource_owner_id", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.integer "application_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "expires_in"
+    t.string "previous_refresh_token", default: "", null: false
+    t.string "refresh_token"
+    t.integer "resource_owner_id"
+    t.datetime "revoked_at"
+    t.string "scopes"
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "metadata_fetched_at"
+    t.string "metadata_url"
+    t.string "name", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.string "secret"
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
+    t.index ["metadata_url"], name: "index_oauth_applications_on_metadata_url", unique: true
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
   create_table "radicals", force: :cascade do |t|
     t.string "character", null: false
     t.datetime "created_at", null: false
@@ -254,6 +301,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_211906) do
   add_foreign_key "learning_sessions", "users"
   add_foreign_key "meanings", "dictionary_entries"
   add_foreign_key "meanings", "sources"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "review_logs", "user_learnings"
   add_foreign_key "sessions", "users"
   add_foreign_key "stroke_order_data", "dictionary_entries"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_06_071255) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_105039) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -302,7 +302,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_06_071255) do
   add_foreign_key "meanings", "dictionary_entries"
   add_foreign_key "meanings", "sources"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "review_logs", "user_learnings"
   add_foreign_key "sessions", "users"
   add_foreign_key "stroke_order_data", "dictionary_entries"

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -34,6 +34,25 @@ In the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/):
 
 Go to **Settings → API access (MCP)** in the app and paste your **Client ID**. This associates the service token with your user account so the MCP server knows whose data to return.
 
+**4. Configure your client**
+
+The OAuth-based config shown in "Connecting Claude Desktop" below doesn't apply to this path — a legacy client needs the service token's headers instead:
+
+```json
+{
+  "mcpServers": {
+    "learn-hanzi": {
+      "type": "http",
+      "url": "https://xue.huwdiprose.co.uk/mcp",
+      "headers": {
+        "CF-Access-Client-Id": "<your-client-id>",
+        "CF-Access-Client-Secret": "<your-client-secret>"
+      }
+    }
+  }
+}
+```
+
 ---
 
 ## Connecting Claude Desktop

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,9 +4,15 @@ learn-hanzi exposes a read-only [Model Context Protocol](https://modelcontextpro
 
 ## Authentication
 
-The `/mcp` endpoint sits behind Cloudflare Access. Authentication uses a **Cloudflare Access service token** — a static client ID + secret pair that you create once and embed in your AI client's config.
+The `/mcp` endpoint is an OAuth 2.1 resource server: `learn-hanzi` is its own authorization server for MCP clients (Doorkeeper), with self-service client identification via [OAuth Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) rather than a manual registration step. A compliant MCP client discovers everything it needs from `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` and drives a normal browser-based authorization-code + PKCE flow — there's nothing to create or paste in ahead of time.
 
-### One-time setup
+Signing in during that flow uses your existing learn-hanzi account (PocketID), and you'll see a consent screen naming the client before access is granted. Revoke access at any time from **Settings → Connected apps**.
+
+See `docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md` for the design rationale and threat model.
+
+### Legacy: Cloudflare Access service token
+
+A transitional fallback still exists for clients that only support a static bearer credential. This path is being phased out — see the threat assessment for the sunset plan — and requires the `/mcp` endpoint to still sit behind a Cloudflare Access policy that has vetted the caller:
 
 **1. Create a service token**
 
@@ -39,42 +45,25 @@ Add the following to your Claude Desktop config (`~/Library/Application Support/
   "mcpServers": {
     "learn-hanzi": {
       "type": "http",
-      "url": "https://xue.huwdiprose.co.uk/mcp",
-      "headers": {
-        "CF-Access-Client-Id": "<your-client-id>",
-        "CF-Access-Client-Secret": "<your-client-secret>"
-      }
+      "url": "https://xue.huwdiprose.co.uk/mcp"
     }
   }
 }
 ```
 
-Restart Claude Desktop after saving.
+Restart Claude Desktop after saving — it will open a browser window to complete sign-in and consent on first connection.
 
 ---
 
 ## Smoke test
 
-Verify the server is reachable and your credentials work:
+Verify the discovery endpoints are reachable:
 
 ```bash
-curl -sS -i -X POST https://xue.huwdiprose.co.uk/mcp \
-  -H "CF-Access-Client-Id: <your-client-id>" \
-  -H "CF-Access-Client-Secret: <your-client-secret>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-      "protocolVersion": "2025-03-26",
-      "capabilities": {},
-      "clientInfo": { "name": "test", "version": "1" }
-    }
-  }'
+curl -sS https://xue.huwdiprose.co.uk/.well-known/oauth-authorization-server
 ```
 
-A successful response returns HTTP 200 with a `Mcp-Session-Id` header and a JSON body describing the server's capabilities.
+A successful response is a JSON document listing `authorization_endpoint`, `token_endpoint`, and `client_id_metadata_document_supported: true`.
 
 ---
 

--- a/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
+++ b/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
@@ -1,0 +1,286 @@
+# Threat Assessment: MCP OAuth 2.1 Authorization Server (Doorkeeper + CIMD)
+
+## Status
+
+Accepted — implementation may proceed. A live pentest against this flow is
+planned before Cloudflare Access is opened to "allow anyone" and the CF
+service-token fallback is fully removed (see "Outstanding configuration").
+
+## Context
+
+The existing MCP auth model (`docs/threat_assessments/MCP_OAUTH_AUTH.md`) relies
+on Cloudflare Access to gate `/mcp`: a service token is minted in the Cloudflare
+Zero Trust dashboard and linked to a `User` via `mcp_service_token_id`. Only
+whoever holds that dashboard can mint a token, which rules out ever letting
+other people self-serve access to their own data through this server.
+
+This change makes the Rails app itself an OAuth 2.1 authorization server for
+MCP clients:
+
+- **Doorkeeper** (`config/initializers/doorkeeper.rb`) provides the
+  authorization-code + PKCE + token/refresh lifecycle. Every application this
+  server ever creates is a public client (`confidential: false`) — there is no
+  path that issues a `client_secret`.
+- **`Oauth::CimdClientResolver`** (`app/services/oauth/cimd_client_resolver.rb`)
+  resolves clients via OAuth Client ID Metadata Documents (CIMD,
+  draft-ietf-oauth-client-id-metadata-document) instead of classic RFC 7591
+  Dynamic Client Registration. A client's `client_id` is an `https://` URL
+  pointing at a JSON document describing it; the server fetches and validates
+  it on demand rather than exposing a stateful, unauthenticated `POST
+  /register` endpoint. This is deliberate: the MCP authorization spec's
+  November 2025 revision made CIMD the recommended (SHOULD) mechanism and
+  downgraded DCR to optional (MAY), specifically because CIMD has no
+  registration call to spam.
+- The resource-owner login step (`resource_owner_authenticator` in the
+  Doorkeeper initializer) reuses the app's existing session (the same
+  PocketID-backed login every other page uses) — there is no second identity
+  system.
+- `McpController` (via `McpAuthentication`) accepts a Doorkeeper bearer token
+  **or** the pre-existing CF Access service-token branch, as a transitional
+  fallback while existing clients migrate. The CF Access **email-match**
+  branch has already been deleted (see commit history on this branch) — it
+  relied on Cloudflare Access's own policy having vetted who could get a JWT
+  in the first place, and that assumption breaks the moment the Access policy
+  is loosened to "allow anyone" (planned, see Outstanding configuration).
+
+## What the specs say
+
+### MCP Authorization spec (2025-11-25 revision) — Client ID Metadata Documents
+
+> Authorization servers SHOULD support the OAuth Client ID Metadata Document
+> mechanism... MCP clients and authorization servers MAY additionally support
+> the OAuth 2.0 Dynamic Client Registration Protocol.
+
+This is why DCR is out of scope for this work — CIMD is the primary,
+spec-preferred mechanism for clients with no prior relationship to the server,
+and building both would mean auditing two client-onboarding code paths instead
+of one.
+
+### draft-ietf-oauth-client-id-metadata-document — validation requirements
+
+The draft requires: `client_id` must be an `https://` URL with no fragment,
+userinfo, or default port ambiguity; the document's own `client_id` field must
+string-match the URL it was fetched from; `token_endpoint_auth_method` must
+not indicate a confidential/symmetric method (CIMD clients are inherently
+public — there's no channel to deliver a secret through). All of these are
+validated in `Oauth::CimdClientResolver#validate_url_shape!` and
+`#fetch_and_validate_metadata`.
+
+### OAuth 2.1 (draft) — PKCE is mandatory for public clients
+
+Every application this server registers is public, so PKCE must not be
+optional. Enforced via `force_pkce` in the Doorkeeper initializer, which
+rejects any authorization request from a non-confidential client that omits
+`code_challenge`.
+
+### RFC 6819 §4.4 / general SSRF guidance — server-side requests to
+user-supplied URLs
+
+Fetching a CIMD document means making a server-side HTTP request to a URL an
+unauthenticated (well, authenticated-but-untrusted) party controls. This is
+the single highest-risk piece of this design, addressed in Threat vector 1
+below.
+
+## Threat vectors
+
+### 1. SSRF via CIMD metadata fetch
+
+**Description:** An attacker sets `client_id` to a URL that resolves to an
+internal address (loopback, RFC 1918 private ranges, link-local/cloud-metadata
+addresses like `169.254.169.254`), attempting to make the Rails server issue
+requests against internal infrastructure on their behalf.
+
+**Preconditions:** The attacker can reach `/oauth/authorize` (it requires an
+authenticated session — see Threat vector 6 — but any logged-in user can
+trigger a fetch to an arbitrary URL).
+
+**Mitigation:** `Oauth::CimdClientResolver#fetch_body` uses the `ssrf_filter`
+gem rather than a hand-rolled resolve-then-connect check. `ssrf_filter`
+resolves the hostname, rejects any result in the standard reserved/private/
+loopback/link-local/multicast ranges (IPv4 and IPv6, including IPv4-mapped and
+NAT64-encoded IPv6 forms), and — critically — connects to the *validated* IP
+address directly (`Net::HTTP.start(hostname, port, ipaddr: validated_ip)`),
+not by re-resolving the hostname a second time. This closes the DNS-rebinding
+TOCTOU gap a naive "check then connect" implementation would leave open.
+HTTPS-only, 3-second open/read timeouts, no redirects followed (`max_redirects:
+0` — a redirect is treated as a failure, not silently followed to a different,
+unvalidated URL).
+
+**Verdict: Mitigated.** This is the one piece of this design most worth an
+independent second look before the planned pentest — see Outstanding
+configuration.
+
+### 2. Oversized or slow response (resource exhaustion)
+
+**Description:** A malicious or compromised client host serves an extremely
+large or slow-draining response to tie up a Puma worker or exhaust memory.
+
+**Mitigation:** `MAX_BODY_BYTES` (10KB) enforced by aborting the streamed
+`read_body` block the instant the accumulated size is exceeded, rather than
+buffering the full response first. `OPEN_TIMEOUT`/`READ_TIMEOUT` (3s each)
+bound worst-case latency per fetch.
+
+**Verdict: Mitigated.**
+
+### 3. Redirect-based bypass
+
+**Description:** A CIMD URL that passes validation redirects to a second,
+unvalidated URL (potentially resolving to a private address, or serving
+different content than what was validated).
+
+**Mitigation:** `max_redirects: 0` — any redirect response is treated as a
+fetch failure rather than followed. Fail closed.
+
+**Verdict: Mitigated.**
+
+### 4. Cache staleness and negative-result caching
+
+**Description:** A successfully fetched document is cached for
+`Oauth::CimdClientResolver::CACHE_TTL` (1 hour) to avoid refetching on every
+authorization request. If a *failed* fetch or validation were cached, a
+transient failure could incorrectly deny a legitimate client for the TTL
+window; conversely, if a since-revoked/compromised document's old redirect_uri
+were trusted indefinitely, a compromised client host could take longer than
+expected to lose access.
+
+**Mitigation:** Only a successful `fetch_and_validate_metadata` result is
+passed into `Rails.cache.fetch` — a raised exception propagates out of the
+block without writing anything to the cache, confirmed by spec
+(`"does not cache the failure"` in `cimd_client_resolver_spec.rb`). The 1-hour
+TTL bounds how long a compromised or since-changed document's old data is
+trusted.
+
+**Verdict: Accepted.** An hour is a deliberate balance between "don't refetch
+on every single authorize request" and "don't trust stale client metadata
+indefinitely." Revisit if real-world usage shows this needs to be shorter.
+
+### 5. Confused deputy across users
+
+**Description:** An access token issued to one user's consent could, through
+an implementation error, be usable to read a different user's data.
+
+**Mitigation:** `resource_owner_authenticator` binds the grant to whatever
+`Current.user` resolves to via the existing session at consent time — not a
+client-asserted identity. `McpAuthentication#user_from_doorkeeper_token` looks
+up `User.find_by(id: doorkeeper_token.resource_owner_id)`, and every MCP
+resource read is already scoped to that resolved user (unchanged from the
+pre-existing CF Access implementation). `spec/requests/mcp_spec.rb` has an
+explicit regression test ("cannot read another user's resources") proving a
+token minted for one user returns empty results when used to read a resource
+scoped to a different user's data.
+
+**Verdict: Mitigated,** with explicit regression coverage.
+
+### 6. Anonymous-triggered fetches / rate limiting
+
+**Description:** `/oauth/authorize` triggers a CIMD fetch as a side effect of
+resolving an unrecognized `client_id`. An unauthenticated party spamming this
+endpoint with many distinct fake `client_id` URLs could generate significant
+outbound request volume or `Doorkeeper::Application` rows.
+
+**Mitigation:** Two layers. First, `Oauth::AuthorizationsController` runs CIMD
+resolution in a plain `before_action` (not `prepend_before_action`), which
+Rails runs *after* the inherited `authenticate_resource_owner!` — an
+unauthenticated visitor is redirected to sign in before any fetch is
+attempted, not after. Second, `config/initializers/rack_attack.rb` throttles
+`/oauth/authorize` to 30 requests/minute/IP and `/oauth/token` to 20/minute/IP,
+sharing counters across Puma workers via the existing `solid_cache` store.
+
+**Verdict: Mitigated.** No TTL-based garbage collection of unused
+CIMD-sourced `Doorkeeper::Application` rows exists yet — see Outstanding
+configuration.
+
+### 7. PKCE downgrade
+
+**Description:** A client attempts the authorization-code flow without PKCE,
+or with a mismatched verifier, to obtain a token without proving possession of
+the original authorization request.
+
+**Mitigation:** `force_pkce` in the Doorkeeper initializer. Verified end-to-end
+in `spec/requests/oauth/authorization_code_flow_spec.rb`: the token exchange
+is rejected both when `code_verifier` is missing entirely and when it doesn't
+match the `code_challenge` presented at authorize time.
+
+**Verdict: Mitigated.**
+
+### 8. CF Access transitional exposure
+
+**Description:** The service-token fallback in `McpAuthentication` remains
+active. Huw intends to loosen the Cloudflare Access edge policy to "allow
+anyone" once this ships, at which point Access provides no identity gating at
+all for anything it fronts — it becomes pass-through infrastructure, same as
+Cloudflare Tunnel already is for ingress.
+
+**Analysis:** The service-token branch's security does **not** depend on the
+Access policy — a service token is a possession-based secret Cloudflare merely
+passes through as a header, unrelated to who Access lets past its own login
+challenge. It remains as safe after the policy change as before. This is
+exactly why the *email-match* branch (which did depend on the policy) was
+deleted outright rather than kept as part of this same transition.
+
+**Verdict: Accepted as a deliberate, time-boxed transition.** No forced
+expiry exists yet on the CF fallback — see Outstanding configuration for the
+plan to close this out.
+
+## What we are not doing, and why
+
+| Measure | Reason not adopted |
+|---|---|
+| Classic RFC 7591 Dynamic Client Registration | Spec marks it optional (MAY) now that CIMD covers self-registration for MCP clients with no prior relationship to the server; adding both means auditing two onboarding paths for one problem |
+| `client_credentials`, `password`, or `implicit` grants | `grant_flows %w[authorization_code]` only — no MCP client needs them, and each additional grant type is additional surface to secure and test |
+| Public token introspection endpoint | `allow_token_introspection false` — no third-party resource server consumes these tokens, only this app's own `/mcp`, which validates via `doorkeeper_token` directly |
+| Confidential (secret-bearing) clients | Every application this server creates is public (`confidential: false`); `force_pkce` covers the resulting need for proof-of-possession |
+| Doorkeeper's own `/oauth/applications` admin UI | Skipped in routing (`skip_controllers :applications, :authorized_applications`) — replaced by the CIMD resolver (automatic) and the settings "Connected apps" panel (user-facing, revoke-only) |
+| TTL/garbage-collection job for unused CIMD-sourced applications | Deferred — CIMD rows are cheap (one per distinct client metadata URL) and the security-critical work was the fetch-time hardening, not row cleanup. Track as a follow-up. |
+| mTLS / DPoP (RFC 9449) | Disproportionate to the threat level for this app's scale, consistent with the posture already accepted in `MCP_OAUTH_AUTH.md` |
+
+## Approved posture
+
+1. `Oauth::CimdClientResolver` validates client_id URL shape, fetches via
+   `ssrf_filter` (validated-IP pinning, HTTPS-only, no redirects, 3s
+   timeouts, 10KB cap), and validates document shape (matching client_id,
+   non-empty `redirect_uris`, no `client_secret`, no confidential auth
+   method) before ever persisting a `Doorkeeper::Application`.
+2. Failed fetches/validation are never cached; successful ones are cached for
+   1 hour.
+3. `force_pkce` is enabled; every application is `confidential: false`.
+4. `resource_owner_authenticator` reuses the existing session — no new
+   identity system, no credentials this app doesn't already manage.
+5. `/oauth/authorize` and `/oauth/token` are throttled via `rack-attack`,
+   sharing state across workers via `solid_cache`.
+6. `McpController` accepts a Doorkeeper bearer token or the CF Access
+   service-token fallback; the email-match branch is deleted.
+7. Every MCP resource read is scoped to the resolved token's resource owner,
+   with an explicit cross-user regression test.
+
+## Outstanding configuration
+
+- **Live pentest before broad release.** This document and the accompanying
+  code review are the static/design-level review; a dynamic pentest against a
+  running instance is planned before Cloudflare Access is opened to "allow
+  anyone" and self-service registration is advertised publicly. The SSRF
+  hardening in `Oauth::CimdClientResolver` is the top priority for that
+  exercise.
+- **CF Access policy change is out-of-band.** Loosening the Cloudflare Access
+  policy to "allow anyone" happens in the Cloudflare dashboard, not this
+  repo, and should happen only after the Doorkeeper flow is confirmed working
+  end-to-end against a real MCP client (Claude Desktop or equivalent).
+- **CF service-token fallback sunset.** No forced expiry exists yet. Once the
+  Doorkeeper flow is proven in production, open a dated follow-up issue to
+  delete `user_from_cf_service_token` and the `include CfAccessAuthentication`
+  line in `McpAuthentication` — by design a one-line-deletion blast radius.
+- **CIMD garbage collection.** Not built in this change; track as a follow-up
+  if `oauth_applications` grows unexpectedly large in practice.
+
+## References
+
+- MCP Authorization spec (2025-11-25 revision): https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+- OAuth Client ID Metadata Document (draft): https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document
+- OAuth 2.1 Authorization Framework (draft): https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1
+- RFC 7636 (PKCE): https://www.rfc-editor.org/rfc/rfc7636
+- RFC 9728 (OAuth Protected Resource Metadata): https://www.rfc-editor.org/rfc/rfc9728
+- RFC 8414 (OAuth Authorization Server Metadata): https://www.rfc-editor.org/rfc/rfc8414
+- Doorkeeper gem: https://github.com/doorkeeper-gem/doorkeeper
+- ssrf_filter gem: https://github.com/arkadiyt/ssrf_filter
+- Prior assessment this supersedes for MCP identity resolution:
+  `docs/threat_assessments/MCP_OAUTH_AUTH.md`

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ require_relative 'support/anki_helper'
 require_relative 'support/cf_access_helpers'
 require_relative 'support/query_counter'
 require_relative 'support/capybara'
+require_relative 'support/doorkeeper_helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -44,6 +45,7 @@ RSpec.configure do |config|
   config.include AuthenticationHelpers, type: :request
   config.include AuthenticationHelpers, type: :system
   config.include CfAccessHelpers, type: :request
+  config.include DoorkeeperHelpers, type: :request
   config.include QueryCounter
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -1,5 +1,459 @@
 require "rails_helper"
 
+RSpec.shared_examples "an authenticated MCP session" do
+  it "does not expose internal error detail on auth failure" do
+    post "/mcp", headers: { "Authorization" => "Bearer not-a-real-token" }, as: :json
+    expect(response.body).not_to include("ActiveRecord")
+    expect(response.body).not_to include("exception")
+  end
+
+  describe "initialize" do
+    let(:init_params) do
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0" }
+        }
+      }
+    end
+
+    it "returns a JSON-RPC 2.0 envelope with the request id" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      body = JSON.parse(response.body)
+      expect(body["jsonrpc"]).to eq("2.0")
+      expect(body["id"]).to eq(1)
+    end
+
+    it "returns the negotiated protocol version" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      body = JSON.parse(response.body)
+      expect(body["result"]["protocolVersion"]).to eq("2025-03-26")
+    end
+
+    it "advertises resource capabilities" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      body = JSON.parse(response.body)
+      expect(body["result"]["capabilities"]["resources"]).to be_present
+    end
+
+    it "returns server info" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      body = JSON.parse(response.body)
+      expect(body["result"]["serverInfo"]["name"]).to eq("learn-hanzi")
+    end
+
+    it "issues a session ID in the response header" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      expect(response.headers["Mcp-Session-Id"]).to be_present
+    end
+  end
+
+  describe "notifications/initialized" do
+    it "returns 200 with a valid session" do
+      session_id = establish_mcp_session(auth_headers)
+      post "/mcp",
+        params: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 404 with no session ID" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: auth_headers,
+        as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 with an unknown session ID" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", method: "notifications/initialized" },
+        headers: auth_headers.merge("Mcp-Session-Id" => "bogus-session-id"),
+        as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "resources/list" do
+    let(:session_id) { establish_mcp_session(auth_headers) }
+
+    it "returns a JSON-RPC 2.0 envelope" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      body = JSON.parse(response.body)
+      expect(body["jsonrpc"]).to eq("2.0")
+      expect(body["id"]).to eq(2)
+    end
+
+    it "returns all five resources" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      resources = JSON.parse(response.body).dig("result", "resources")
+      expect(resources.length).to eq(5)
+    end
+
+    it "includes all expected resource URIs" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      uris = JSON.parse(response.body).dig("result", "resources").map { |r| r["uri"] }
+      expect(uris).to contain_exactly(
+        "learn-hanzi://profile",
+        "learn-hanzi://vocabulary/mastered",
+        "learn-hanzi://vocabulary/struggling",
+        "learn-hanzi://vocabulary/recent",
+        "learn-hanzi://vocabulary/active"
+      )
+    end
+
+    it "includes a name and mimeType for each resource" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      resources = JSON.parse(response.body).dig("result", "resources")
+      resources.each do |resource|
+        expect(resource["name"]).to be_present
+        expect(resource["mimeType"]).to eq("application/json")
+      end
+    end
+  end
+
+  describe "resources/read" do
+    let(:session_id) { establish_mcp_session(auth_headers) }
+
+    def read_resource(uri)
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 3, method: "resources/read", params: { uri: uri } },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      JSON.parse(response.body)
+    end
+
+    it "returns -32602 for an unknown resource URI" do
+      body = read_resource("learn-hanzi://does-not-exist")
+      expect(body["error"]["code"]).to eq(-32602)
+    end
+
+    describe "learn-hanzi://profile" do
+      it "returns a JSON-RPC 2.0 envelope with contents" do
+        body = read_resource("learn-hanzi://profile")
+        expect(body["jsonrpc"]).to eq("2.0")
+        expect(body["id"]).to eq(3)
+        contents = body.dig("result", "contents")
+        expect(contents).to be_an(Array)
+        expect(contents.first["uri"]).to eq("learn-hanzi://profile")
+        expect(contents.first["mimeType"]).to eq("application/json")
+      end
+
+      it "returns a parseable JSON text payload" do
+        body = read_resource("learn-hanzi://profile")
+        text = body.dig("result", "contents", 0, "text")
+        expect { JSON.parse(text) }.not_to raise_error
+      end
+
+      it "includes state counts for the authenticated user only" do
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: user, state: "learning")
+        other = create(:user)
+        create(:user_learning, user: other, state: "mastered")
+
+        body   = read_resource("learn-hanzi://profile")
+        summary = JSON.parse(body.dig("result", "contents", 0, "text"))["summary"]
+        expect(summary["mastered"]).to eq(2)
+        expect(summary["learning"]).to eq(1)
+        expect(summary["total"]).to eq(3)
+      end
+
+      it "includes new and suspended counts" do
+        create(:user_learning, user: user, state: "new")
+        create(:user_learning, user: user, state: "suspended")
+
+        body    = read_resource("learn-hanzi://profile")
+        summary = JSON.parse(body.dig("result", "contents", 0, "text"))["summary"]
+        expect(summary["new"]).to eq(1)
+        expect(summary["suspended"]).to eq(1)
+      end
+
+      it "includes an hsk_breakdown key" do
+        body    = read_resource("learn-hanzi://profile")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload).to have_key("hsk_breakdown")
+      end
+
+      it "returns an empty hsk_breakdown array when no HSK tags exist" do
+        body    = read_resource("learn-hanzi://profile")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["hsk_breakdown"]).to eq([])
+      end
+
+      context "with an HSK tag hierarchy" do
+        let!(:hsk_root)  { create(:tag, name: "HSK", parent: nil) }
+        let!(:hsk3)      { create(:tag, name: "HSK 3.0", parent: hsk_root) }
+        let!(:hsk1)      { create(:tag, name: "HSK 1", parent: hsk3) }
+        let!(:entry)     { create(:dictionary_entry).tap { |e| e.tags << hsk1 } }
+        let!(:learning)  { create(:user_learning, user: user, dictionary_entry: entry, state: "mastered") }
+
+        it "includes the version and level names" do
+          body    = read_resource("learn-hanzi://profile")
+          payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+          version = payload["hsk_breakdown"].find { |v| v["version"] == "HSK 3.0" }
+          expect(version).to be_present
+          level = version["levels"].find { |l| l["name"] == "HSK 1" }
+          expect(level).to be_present
+        end
+
+        it "reports the correct mastered count per level" do
+          body    = read_resource("learn-hanzi://profile")
+          payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+          level = payload["hsk_breakdown"]
+            .find { |v| v["version"] == "HSK 3.0" }["levels"]
+            .find { |l| l["name"] == "HSK 1" }
+          expect(level["mastered"]).to eq(1)
+        end
+      end
+    end
+
+    describe "learn-hanzi://vocabulary/mastered" do
+      it "returns vocabulary as an array" do
+        body    = read_resource("learn-hanzi://vocabulary/mastered")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_an(Array)
+      end
+
+      it "returns only the authenticated user's mastered entries" do
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: create(:user), state: "mastered")
+
+        body    = read_resource("learn-hanzi://vocabulary/mastered")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"].length).to eq(2)
+      end
+
+      it "excludes non-mastered entries" do
+        create(:user_learning, user: user, state: "learning")
+        body    = read_resource("learn-hanzi://vocabulary/mastered")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_empty
+      end
+
+      it "includes hanzi, pinyin, meaning and mastered_at for each entry" do
+        create(:user_learning, user: user, state: "mastered",
+               mastered_at: 1.day.ago)
+        body    = read_resource("learn-hanzi://vocabulary/mastered")
+        entry   = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry).to include("hanzi", "pinyin", "meaning", "mastered_at")
+      end
+
+      it "orders entries by mastered_at descending" do
+        older = create(:user_learning, user: user, state: "mastered",
+                       mastered_at: 2.days.ago)
+        newer = create(:user_learning, user: user, state: "mastered",
+                       mastered_at: 1.day.ago)
+        body     = read_resource("learn-hanzi://vocabulary/mastered")
+        entries  = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
+        returned = entries.map { |e| e["hanzi"] }
+        expect(returned).to eq([
+          newer.dictionary_entry.text,
+          older.dictionary_entry.text
+        ])
+      end
+    end
+
+    describe "learn-hanzi://vocabulary/active" do
+      it "returns vocabulary as an array" do
+        body    = read_resource("learn-hanzi://vocabulary/active")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_an(Array)
+      end
+
+      it "only includes learning-state entries for the authenticated user" do
+        create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: create(:user), state: "learning")
+
+        body    = read_resource("learn-hanzi://vocabulary/active")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"].length).to eq(1)
+      end
+
+      it "includes hanzi, pinyin, meaning, next_due and factor" do
+        create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
+        body  = read_resource("learn-hanzi://vocabulary/active")
+        entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry).to include("hanzi", "pinyin", "meaning", "next_due", "factor")
+      end
+
+      it "orders by next_due ascending" do
+        later  = create(:user_learning, user: user, state: "learning", next_due: 7.days.from_now)
+        sooner = create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
+
+        body    = read_resource("learn-hanzi://vocabulary/active")
+        entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
+        expect(entries.first["hanzi"]).to eq(sooner.dictionary_entry.text)
+        expect(entries.last["hanzi"]).to eq(later.dictionary_entry.text)
+      end
+
+      it "includes overdue entries (next_due in the past)" do
+        create(:user_learning, user: user, state: "learning", next_due: 2.days.ago)
+        body    = read_resource("learn-hanzi://vocabulary/active")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"].length).to eq(1)
+      end
+    end
+
+    describe "learn-hanzi://vocabulary/recent" do
+      it "returns vocabulary as an array" do
+        body    = read_resource("learn-hanzi://vocabulary/recent")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_an(Array)
+      end
+
+      it "includes entries mastered within the last 30 days" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 15.days.ago)
+        body    = read_resource("learn-hanzi://vocabulary/recent")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"].length).to eq(1)
+      end
+
+      it "excludes entries mastered more than 30 days ago" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 31.days.ago)
+        body    = read_resource("learn-hanzi://vocabulary/recent")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_empty
+      end
+
+      it "excludes other users' entries" do
+        create(:user_learning, user: create(:user), state: "mastered", mastered_at: 1.day.ago)
+        body    = read_resource("learn-hanzi://vocabulary/recent")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_empty
+      end
+
+      it "includes hanzi, pinyin, meaning and mastered_at" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body  = read_resource("learn-hanzi://vocabulary/recent")
+        entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry).to include("hanzi", "pinyin", "meaning", "mastered_at")
+      end
+
+      it "orders by mastered_at descending" do
+        older = create(:user_learning, user: user, state: "mastered", mastered_at: 10.days.ago)
+        newer = create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body    = read_resource("learn-hanzi://vocabulary/recent")
+        entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
+        expect(entries.first["hanzi"]).to eq(newer.dictionary_entry.text)
+        expect(entries.last["hanzi"]).to eq(older.dictionary_entry.text)
+      end
+    end
+
+    describe "learn-hanzi://vocabulary/struggling" do
+      it "returns vocabulary as an array" do
+        body    = read_resource("learn-hanzi://vocabulary/struggling")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_an(Array)
+      end
+
+      it "only includes learning-state entries for the authenticated user" do
+        create(:user_learning, user: user, state: "learning")
+        create(:user_learning, user: user, state: "mastered")
+        create(:user_learning, user: create(:user), state: "learning")
+
+        body    = read_resource("learn-hanzi://vocabulary/struggling")
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"].length).to eq(1)
+      end
+
+      it "includes hanzi, pinyin, meaning, lapse_count and factor for each entry" do
+        create(:user_learning, user: user, state: "learning")
+        body  = read_resource("learn-hanzi://vocabulary/struggling")
+        entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry).to include("hanzi", "pinyin", "meaning", "lapse_count", "factor")
+      end
+
+      it "returns lapse_count 0 for an entry with no lapses" do
+        create(:user_learning, user: user, state: "learning")
+        body  = read_resource("learn-hanzi://vocabulary/struggling")
+        entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry["lapse_count"]).to eq(0)
+      end
+
+      it "orders by lapse_count descending" do
+        low  = create(:user_learning, user: user, state: "learning")
+        high = create(:user_learning, user: user, state: "learning")
+        create(:review_log, user_learning: high, ease: 1)
+        create(:review_log, user_learning: high, ease: 1)
+        create(:review_log, user_learning: low,  ease: 1)
+
+        body    = read_resource("learn-hanzi://vocabulary/struggling")
+        entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
+        expect(entries.first["lapse_count"]).to eq(2)
+        expect(entries.last["lapse_count"]).to eq(1)
+      end
+
+      it "uses factor ascending as a tiebreaker" do
+        lower_factor = create(:user_learning, user: user, state: "learning", factor: 1800)
+        higher_factor = create(:user_learning, user: user, state: "learning", factor: 2500)
+
+        body    = read_resource("learn-hanzi://vocabulary/struggling")
+        entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
+        expect(entries.first["hanzi"]).to eq(lower_factor.dictionary_entry.text)
+      end
+
+      it "counts only ease=1 logs as lapses, not other ease values" do
+        ul = create(:user_learning, user: user, state: "learning")
+        create(:review_log, user_learning: ul, ease: 1)
+        create(:review_log, user_learning: ul, ease: 3)
+        create(:review_log, user_learning: ul, ease: 4)
+
+        body  = read_resource("learn-hanzi://vocabulary/struggling")
+        entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
+        expect(entry["lapse_count"]).to eq(1)
+      end
+    end
+
+    describe "error handling" do
+      it "returns a JSON-RPC parse error (-32700) for invalid JSON" do
+        post "/mcp",
+          params: "not: valid json{{",
+          headers: auth_headers.merge("Content-Type" => "application/json")
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32700)
+      end
+
+      it "returns a JSON-RPC invalid request error (-32600) for a JSON array body" do
+        post "/mcp",
+          params: "[1, 2, 3]",
+          headers: auth_headers.merge("Content-Type" => "application/json")
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32600)
+      end
+
+      it "returns a JSON-RPC method-not-found error (-32601) for unknown methods" do
+        session_id = establish_mcp_session(auth_headers)
+        post "/mcp",
+          params: { jsonrpc: "2.0", id: 2, method: "unknown/method" },
+          headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+          as: :json
+        body = JSON.parse(response.body)
+        expect(body["error"]["code"]).to eq(-32601)
+      end
+    end
+  end
+end
+
 RSpec.describe "MCP", type: :request do
   let(:user) { create(:user) }
 
@@ -11,42 +465,42 @@ RSpec.describe "MCP", type: :request do
 
   describe "POST /mcp" do
     context "when unauthenticated" do
-      it "returns 401 when CF-Access-Jwt-Assertion header is absent" do
+      it "returns 401 when no auth is presented" do
         post "/mcp", as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns 401 with a malformed token" do
+      it "returns 401 with a malformed CF assertion token" do
         post "/mcp", headers: cf_assertion_header("not.a.jwt"), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns 401 with an expired token" do
-        token = cf_access_token(email: user.email_address, exp: 1.hour.ago.to_i)
+      it "returns 401 with a malformed bearer token" do
+        post "/mcp", headers: { "Authorization" => "Bearer not-a-real-token" }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "returns 401 with an expired CF service token" do
+        token = cf_service_token(common_name: "abc123def456.access", exp: 1.hour.ago.to_i)
         post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns 401 with the wrong issuer" do
-        token = cf_access_token(email: user.email_address, iss: "https://evil.example.com")
+      it "returns 401 with the wrong CF issuer" do
+        token = cf_service_token(common_name: "abc123def456.access", iss: "https://evil.example.com")
         post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns 401 with the wrong audience" do
-        token = cf_access_token(email: user.email_address, aud: "wrong-aud")
+      it "returns 401 with the wrong CF audience" do
+        token = cf_service_token(common_name: "abc123def456.access", aud: "wrong-aud")
         post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it "returns 401 when the email claim is absent" do
-        token = cf_access_token(email: user.email_address, omit_email: true)
-        post "/mcp", headers: cf_assertion_header(token), as: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
-
-      it "returns 401 when the email does not match any user" do
-        token = cf_access_token(email: "nobody@example.com")
+      it "returns 401 when the CF JWKS fetch raises an unexpected error" do
+        stub_request(:get, CfAccessHelpers::JWKS_URI).to_raise(Net::OpenTimeout)
+        token = cf_service_token(common_name: "abc123def456.access")
         post "/mcp", headers: cf_assertion_header(token), as: :json
         expect(response).to have_http_status(:unauthorized)
       end
@@ -55,12 +509,15 @@ RSpec.describe "MCP", type: :request do
     context "when authenticated via service token" do
       let(:common_name) { "abc123def456.access" }
       let(:token) { cf_service_token(common_name: common_name) }
+      let(:auth_headers) { cf_assertion_header(token) }
 
       before { user.update!(mcp_service_token_id: "abc123def456") }
 
+      it_behaves_like "an authenticated MCP session"
+
       it "authenticates and returns an MCP session" do
         post "/mcp",
-          headers: cf_assertion_header(token),
+          headers: auth_headers,
           params: { jsonrpc: "2.0", id: 1, method: "initialize",
                     params: { protocolVersion: "2025-03-26", capabilities: {},
                               clientInfo: { name: "test", version: "1" } } },
@@ -71,7 +528,7 @@ RSpec.describe "MCP", type: :request do
 
       it "returns 401 when no user has a matching mcp_service_token_id" do
         user.update!(mcp_service_token_id: nil)
-        post "/mcp", headers: cf_assertion_header(token), as: :json
+        post "/mcp", headers: auth_headers, as: :json
         expect(response).to have_http_status(:unauthorized)
       end
 
@@ -94,471 +551,59 @@ RSpec.describe "MCP", type: :request do
       end
     end
 
-    context "when authenticated" do
-      let(:token) { cf_access_token(email: user.email_address) }
+    context "when authenticated via Doorkeeper bearer token" do
+      let(:access_token) { doorkeeper_access_token_for(user) }
+      let(:auth_headers) { bearer_header(access_token) }
 
-      it "does not expose internal error detail on auth failure" do
-        bad_token = cf_access_token(email: "nobody@example.com")
-        post "/mcp", headers: cf_assertion_header(bad_token), as: :json
-        expect(response.body).not_to include("ActiveRecord")
-        expect(response.body).not_to include("exception")
+      it_behaves_like "an authenticated MCP session"
+
+      it "authenticates and returns an MCP session" do
+        post "/mcp",
+          headers: auth_headers,
+          params: { jsonrpc: "2.0", id: 1, method: "initialize",
+                    params: { protocolVersion: "2025-03-26", capabilities: {},
+                              clientInfo: { name: "test", version: "1" } } },
+          as: :json
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Mcp-Session-Id"]).to be_present
       end
 
-      describe "initialize" do
-        let(:init_params) do
-          {
-            jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
-            params: {
-              protocolVersion: "2025-03-26",
-              capabilities: {},
-              clientInfo: { name: "TestClient", version: "1.0" }
-            }
-          }
-        end
-
-        it "returns a JSON-RPC 2.0 envelope with the request id" do
-          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
-          body = JSON.parse(response.body)
-          expect(body["jsonrpc"]).to eq("2.0")
-          expect(body["id"]).to eq(1)
-        end
-
-        it "returns the negotiated protocol version" do
-          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
-          body = JSON.parse(response.body)
-          expect(body["result"]["protocolVersion"]).to eq("2025-03-26")
-        end
-
-        it "advertises resource capabilities" do
-          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
-          body = JSON.parse(response.body)
-          expect(body["result"]["capabilities"]["resources"]).to be_present
-        end
-
-        it "returns server info" do
-          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
-          body = JSON.parse(response.body)
-          expect(body["result"]["serverInfo"]["name"]).to eq("learn-hanzi")
-        end
-
-        it "issues a session ID in the response header" do
-          post "/mcp", params: init_params, headers: cf_assertion_header(token), as: :json
-          expect(response.headers["Mcp-Session-Id"]).to be_present
-        end
+      it "returns 401 with an expired token" do
+        expired = doorkeeper_access_token_for(user, expires_in: -1)
+        post "/mcp", headers: bearer_header(expired), as: :json
+        expect(response).to have_http_status(:unauthorized)
       end
 
-      describe "notifications/initialized" do
-        it "returns 200 with a valid session" do
-          session_id = establish_mcp_session(token)
-          post "/mcp",
-            params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "returns 404 with no session ID" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: cf_assertion_header(token),
-            as: :json
-          expect(response).to have_http_status(:not_found)
-        end
-
-        it "returns 404 with an unknown session ID" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", method: "notifications/initialized" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => "bogus-session-id"),
-            as: :json
-          expect(response).to have_http_status(:not_found)
-        end
+      it "returns 401 with a revoked token" do
+        access_token.revoke
+        post "/mcp", headers: auth_headers, as: :json
+        expect(response).to have_http_status(:unauthorized)
       end
 
-      describe "resources/list" do
-        let(:session_id) { establish_mcp_session(token) }
-
-        it "returns a JSON-RPC 2.0 envelope" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          body = JSON.parse(response.body)
-          expect(body["jsonrpc"]).to eq("2.0")
-          expect(body["id"]).to eq(2)
-        end
-
-        it "returns all five resources" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          resources = JSON.parse(response.body).dig("result", "resources")
-          expect(resources.length).to eq(5)
-        end
-
-        it "includes all expected resource URIs" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          uris = JSON.parse(response.body).dig("result", "resources").map { |r| r["uri"] }
-          expect(uris).to contain_exactly(
-            "learn-hanzi://profile",
-            "learn-hanzi://vocabulary/mastered",
-            "learn-hanzi://vocabulary/struggling",
-            "learn-hanzi://vocabulary/recent",
-            "learn-hanzi://vocabulary/active"
-          )
-        end
-
-        it "includes a name and mimeType for each resource" do
-          post "/mcp",
-            params: { jsonrpc: "2.0", id: 2, method: "resources/list" },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          resources = JSON.parse(response.body).dig("result", "resources")
-          resources.each do |resource|
-            expect(resource["name"]).to be_present
-            expect(resource["mimeType"]).to eq("application/json")
-          end
-        end
+      it "returns 401 with a token missing the mcp scope" do
+        scopeless = doorkeeper_access_token_for(user, scopes: "")
+        post "/mcp", headers: bearer_header(scopeless), as: :json
+        expect(response).to have_http_status(:unauthorized)
       end
 
-      describe "resources/read" do
-        let(:session_id) { establish_mcp_session(token) }
+      it "cannot read another user's resources" do
+        other_user = create(:user)
+        create(:user_learning, user: other_user, state: "mastered")
 
-        def read_resource(uri)
-          post "/mcp",
-            params: { jsonrpc: "2.0", id: 3, method: "resources/read", params: { uri: uri } },
-            headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-            as: :json
-          JSON.parse(response.body)
-        end
-
-        it "returns -32602 for an unknown resource URI" do
-          body = read_resource("learn-hanzi://does-not-exist")
-          expect(body["error"]["code"]).to eq(-32602)
-        end
-
-        describe "learn-hanzi://profile" do
-          it "returns a JSON-RPC 2.0 envelope with contents" do
-            body = read_resource("learn-hanzi://profile")
-            expect(body["jsonrpc"]).to eq("2.0")
-            expect(body["id"]).to eq(3)
-            contents = body.dig("result", "contents")
-            expect(contents).to be_an(Array)
-            expect(contents.first["uri"]).to eq("learn-hanzi://profile")
-            expect(contents.first["mimeType"]).to eq("application/json")
-          end
-
-          it "returns a parseable JSON text payload" do
-            body = read_resource("learn-hanzi://profile")
-            text = body.dig("result", "contents", 0, "text")
-            expect { JSON.parse(text) }.not_to raise_error
-          end
-
-          it "includes state counts for the authenticated user only" do
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: user, state: "learning")
-            other = create(:user)
-            create(:user_learning, user: other, state: "mastered")
-
-            body   = read_resource("learn-hanzi://profile")
-            summary = JSON.parse(body.dig("result", "contents", 0, "text"))["summary"]
-            expect(summary["mastered"]).to eq(2)
-            expect(summary["learning"]).to eq(1)
-            expect(summary["total"]).to eq(3)
-          end
-
-          it "includes new and suspended counts" do
-            create(:user_learning, user: user, state: "new")
-            create(:user_learning, user: user, state: "suspended")
-
-            body    = read_resource("learn-hanzi://profile")
-            summary = JSON.parse(body.dig("result", "contents", 0, "text"))["summary"]
-            expect(summary["new"]).to eq(1)
-            expect(summary["suspended"]).to eq(1)
-          end
-
-          it "includes an hsk_breakdown key" do
-            body    = read_resource("learn-hanzi://profile")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload).to have_key("hsk_breakdown")
-          end
-
-          it "returns an empty hsk_breakdown array when no HSK tags exist" do
-            body    = read_resource("learn-hanzi://profile")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["hsk_breakdown"]).to eq([])
-          end
-
-          context "with an HSK tag hierarchy" do
-            let!(:hsk_root)  { create(:tag, name: "HSK", parent: nil) }
-            let!(:hsk3)      { create(:tag, name: "HSK 3.0", parent: hsk_root) }
-            let!(:hsk1)      { create(:tag, name: "HSK 1", parent: hsk3) }
-            let!(:entry)     { create(:dictionary_entry).tap { |e| e.tags << hsk1 } }
-            let!(:learning)  { create(:user_learning, user: user, dictionary_entry: entry, state: "mastered") }
-
-            it "includes the version and level names" do
-              body    = read_resource("learn-hanzi://profile")
-              payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-              version = payload["hsk_breakdown"].find { |v| v["version"] == "HSK 3.0" }
-              expect(version).to be_present
-              level = version["levels"].find { |l| l["name"] == "HSK 1" }
-              expect(level).to be_present
-            end
-
-            it "reports the correct mastered count per level" do
-              body    = read_resource("learn-hanzi://profile")
-              payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-              level = payload["hsk_breakdown"]
-                .find { |v| v["version"] == "HSK 3.0" }["levels"]
-                .find { |l| l["name"] == "HSK 1" }
-              expect(level["mastered"]).to eq(1)
-            end
-          end
-        end
-
-        describe "learn-hanzi://vocabulary/mastered" do
-          it "returns vocabulary as an array" do
-            body    = read_resource("learn-hanzi://vocabulary/mastered")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_an(Array)
-          end
-
-          it "returns only the authenticated user's mastered entries" do
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: create(:user), state: "mastered")
-
-            body    = read_resource("learn-hanzi://vocabulary/mastered")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"].length).to eq(2)
-          end
-
-          it "excludes non-mastered entries" do
-            create(:user_learning, user: user, state: "learning")
-            body    = read_resource("learn-hanzi://vocabulary/mastered")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_empty
-          end
-
-          it "includes hanzi, pinyin, meaning and mastered_at for each entry" do
-            create(:user_learning, user: user, state: "mastered",
-                   mastered_at: 1.day.ago)
-            body    = read_resource("learn-hanzi://vocabulary/mastered")
-            entry   = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry).to include("hanzi", "pinyin", "meaning", "mastered_at")
-          end
-
-          it "orders entries by mastered_at descending" do
-            older = create(:user_learning, user: user, state: "mastered",
-                           mastered_at: 2.days.ago)
-            newer = create(:user_learning, user: user, state: "mastered",
-                           mastered_at: 1.day.ago)
-            body     = read_resource("learn-hanzi://vocabulary/mastered")
-            entries  = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
-            returned = entries.map { |e| e["hanzi"] }
-            expect(returned).to eq([
-              newer.dictionary_entry.text,
-              older.dictionary_entry.text
-            ])
-          end
-        end
-
-        describe "learn-hanzi://vocabulary/active" do
-          it "returns vocabulary as an array" do
-            body    = read_resource("learn-hanzi://vocabulary/active")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_an(Array)
-          end
-
-          it "only includes learning-state entries for the authenticated user" do
-            create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: create(:user), state: "learning")
-
-            body    = read_resource("learn-hanzi://vocabulary/active")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"].length).to eq(1)
-          end
-
-          it "includes hanzi, pinyin, meaning, next_due and factor" do
-            create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
-            body  = read_resource("learn-hanzi://vocabulary/active")
-            entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry).to include("hanzi", "pinyin", "meaning", "next_due", "factor")
-          end
-
-          it "orders by next_due ascending" do
-            later  = create(:user_learning, user: user, state: "learning", next_due: 7.days.from_now)
-            sooner = create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
-
-            body    = read_resource("learn-hanzi://vocabulary/active")
-            entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
-            expect(entries.first["hanzi"]).to eq(sooner.dictionary_entry.text)
-            expect(entries.last["hanzi"]).to eq(later.dictionary_entry.text)
-          end
-
-          it "includes overdue entries (next_due in the past)" do
-            create(:user_learning, user: user, state: "learning", next_due: 2.days.ago)
-            body    = read_resource("learn-hanzi://vocabulary/active")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"].length).to eq(1)
-          end
-        end
-
-        describe "learn-hanzi://vocabulary/recent" do
-          it "returns vocabulary as an array" do
-            body    = read_resource("learn-hanzi://vocabulary/recent")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_an(Array)
-          end
-
-          it "includes entries mastered within the last 30 days" do
-            create(:user_learning, user: user, state: "mastered", mastered_at: 15.days.ago)
-            body    = read_resource("learn-hanzi://vocabulary/recent")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"].length).to eq(1)
-          end
-
-          it "excludes entries mastered more than 30 days ago" do
-            create(:user_learning, user: user, state: "mastered", mastered_at: 31.days.ago)
-            body    = read_resource("learn-hanzi://vocabulary/recent")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_empty
-          end
-
-          it "excludes other users' entries" do
-            create(:user_learning, user: create(:user), state: "mastered", mastered_at: 1.day.ago)
-            body    = read_resource("learn-hanzi://vocabulary/recent")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_empty
-          end
-
-          it "includes hanzi, pinyin, meaning and mastered_at" do
-            create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
-            body  = read_resource("learn-hanzi://vocabulary/recent")
-            entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry).to include("hanzi", "pinyin", "meaning", "mastered_at")
-          end
-
-          it "orders by mastered_at descending" do
-            older = create(:user_learning, user: user, state: "mastered", mastered_at: 10.days.ago)
-            newer = create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
-            body    = read_resource("learn-hanzi://vocabulary/recent")
-            entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
-            expect(entries.first["hanzi"]).to eq(newer.dictionary_entry.text)
-            expect(entries.last["hanzi"]).to eq(older.dictionary_entry.text)
-          end
-        end
-
-        describe "learn-hanzi://vocabulary/struggling" do
-          it "returns vocabulary as an array" do
-            body    = read_resource("learn-hanzi://vocabulary/struggling")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"]).to be_an(Array)
-          end
-
-          it "only includes learning-state entries for the authenticated user" do
-            create(:user_learning, user: user, state: "learning")
-            create(:user_learning, user: user, state: "mastered")
-            create(:user_learning, user: create(:user), state: "learning")
-
-            body    = read_resource("learn-hanzi://vocabulary/struggling")
-            payload = JSON.parse(body.dig("result", "contents", 0, "text"))
-            expect(payload["vocabulary"].length).to eq(1)
-          end
-
-          it "includes hanzi, pinyin, meaning, lapse_count and factor for each entry" do
-            create(:user_learning, user: user, state: "learning")
-            body  = read_resource("learn-hanzi://vocabulary/struggling")
-            entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry).to include("hanzi", "pinyin", "meaning", "lapse_count", "factor")
-          end
-
-          it "returns lapse_count 0 for an entry with no lapses" do
-            create(:user_learning, user: user, state: "learning")
-            body  = read_resource("learn-hanzi://vocabulary/struggling")
-            entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry["lapse_count"]).to eq(0)
-          end
-
-          it "orders by lapse_count descending" do
-            low  = create(:user_learning, user: user, state: "learning")
-            high = create(:user_learning, user: user, state: "learning")
-            create(:review_log, user_learning: high, ease: 1)
-            create(:review_log, user_learning: high, ease: 1)
-            create(:review_log, user_learning: low,  ease: 1)
-
-            body    = read_resource("learn-hanzi://vocabulary/struggling")
-            entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
-            expect(entries.first["lapse_count"]).to eq(2)
-            expect(entries.last["lapse_count"]).to eq(1)
-          end
-
-          it "uses factor ascending as a tiebreaker" do
-            lower_factor = create(:user_learning, user: user, state: "learning", factor: 1800)
-            higher_factor = create(:user_learning, user: user, state: "learning", factor: 2500)
-
-            body    = read_resource("learn-hanzi://vocabulary/struggling")
-            entries = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"]
-            expect(entries.first["hanzi"]).to eq(lower_factor.dictionary_entry.text)
-          end
-
-          it "counts only ease=1 logs as lapses, not other ease values" do
-            ul = create(:user_learning, user: user, state: "learning")
-            create(:review_log, user_learning: ul, ease: 1)
-            create(:review_log, user_learning: ul, ease: 3)
-            create(:review_log, user_learning: ul, ease: 4)
-
-            body  = read_resource("learn-hanzi://vocabulary/struggling")
-            entry = JSON.parse(body.dig("result", "contents", 0, "text"))["vocabulary"].first
-            expect(entry["lapse_count"]).to eq(1)
-          end
-        end
-
-        describe "error handling" do
-          it "returns a JSON-RPC parse error (-32700) for invalid JSON" do
-            post "/mcp",
-              params: "not: valid json{{",
-              headers: cf_assertion_header(token).merge("Content-Type" => "application/json")
-            body = JSON.parse(response.body)
-            expect(body["error"]["code"]).to eq(-32700)
-          end
-
-          it "returns a JSON-RPC invalid request error (-32600) for a JSON array body" do
-            post "/mcp",
-              params: "[1, 2, 3]",
-              headers: cf_assertion_header(token).merge("Content-Type" => "application/json")
-            body = JSON.parse(response.body)
-            expect(body["error"]["code"]).to eq(-32600)
-          end
-
-          it "returns 401 when JWKS fetch raises an unexpected error" do
-            stub_request(:get, CfAccessHelpers::JWKS_URI).to_raise(Net::OpenTimeout)
-            post "/mcp", headers: cf_assertion_header(cf_access_token(email: user.email_address)), as: :json
-            expect(response).to have_http_status(:unauthorized)
-          end
-
-          it "returns a JSON-RPC method-not-found error (-32601) for unknown methods" do
-            session_id = establish_mcp_session(token)
-            post "/mcp",
-              params: { jsonrpc: "2.0", id: 2, method: "unknown/method" },
-              headers: cf_assertion_header(token).merge("Mcp-Session-Id" => session_id),
-              as: :json
-            body = JSON.parse(response.body)
-            expect(body["error"]["code"]).to eq(-32601)
-          end
-        end
+        session_id = establish_mcp_session(auth_headers)
+        post "/mcp",
+          params: { jsonrpc: "2.0", id: 3, method: "resources/read",
+                    params: { uri: "learn-hanzi://vocabulary/mastered" } },
+          headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+          as: :json
+        body = JSON.parse(response.body)
+        payload = JSON.parse(body.dig("result", "contents", 0, "text"))
+        expect(payload["vocabulary"]).to be_empty
       end
     end
   end
 
-  def establish_mcp_session(token)
+  def establish_mcp_session(headers)
     post "/mcp",
       params: {
         jsonrpc: "2.0",
@@ -566,7 +611,7 @@ RSpec.describe "MCP", type: :request do
         method: "initialize",
         params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "Test", version: "1.0" } }
       },
-      headers: cf_assertion_header(token),
+      headers: headers,
       as: :json
     response.headers["Mcp-Session-Id"]
   end

--- a/spec/requests/oauth/authorization_code_flow_spec.rb
+++ b/spec/requests/oauth/authorization_code_flow_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe "OAuth authorization code + PKCE flow, end to end", type: :request do
+  let(:user) { create(:user) }
+  let(:client_id_url) { "https://good.example.com/mcp-client.json" }
+  let(:redirect_uri) { "https://good.example.com/callback" }
+  let(:code_verifier) { "a" * 43 }
+  let(:code_challenge) { Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false) }
+  let(:metadata) do
+    { client_id: client_id_url, client_name: "Test MCP Client", redirect_uris: [ redirect_uri ] }
+  end
+
+  before do
+    Rails.cache.clear
+    allow(Resolv).to receive(:getaddresses).with("good.example.com").and_return([ "93.184.216.34" ])
+    stub_request(:get, client_id_url)
+      .to_return(status: 200, body: metadata.to_json, headers: { "Content-Type" => "application/json" })
+    sign_in user
+  end
+
+  it "completes authorize -> consent -> token -> /mcp for a CIMD client" do
+    # 1. The client's browser lands on the authorize endpoint; the CIMD
+    #    document is resolved and the consent screen renders.
+    get "/oauth/authorize", params: {
+      client_id: client_id_url,
+      redirect_uri: redirect_uri,
+      response_type: "code",
+      code_challenge: code_challenge,
+      code_challenge_method: "S256"
+    }
+    expect(response).to have_http_status(:ok)
+
+    # 2. The user clicks "Authorize" — this is the form the consent view
+    #    actually submits, carrying the same params back as hidden fields.
+    post "/oauth/authorize", params: {
+      client_id: client_id_url,
+      redirect_uri: redirect_uri,
+      response_type: "code",
+      code_challenge: code_challenge,
+      code_challenge_method: "S256"
+    }
+    expect(response).to have_http_status(:found)
+    expect(response.location).to start_with(redirect_uri)
+
+    code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+    expect(code).to be_present
+
+    # 3. The client exchanges the code for a token, proving the verifier
+    #    presented here actually has to match the challenge sent in step 1.
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: redirect_uri,
+      client_id: client_id_url,
+      code_verifier: code_verifier
+    }
+    expect(response).to have_http_status(:ok)
+    token_body = JSON.parse(response.body)
+    access_token = token_body["access_token"]
+    expect(access_token).to be_present
+    expect(token_body["refresh_token"]).to be_present
+
+    # 4. The resulting bearer token actually authenticates against /mcp,
+    #    scoped to the user who completed the consent screen.
+    post "/mcp",
+      headers: { "Authorization" => "Bearer #{access_token}" },
+      params: { jsonrpc: "2.0", id: 1, method: "initialize",
+                params: { protocolVersion: "2025-03-26", capabilities: {},
+                          clientInfo: { name: "test", version: "1" } } },
+      as: :json
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "rejects the token exchange when the code_verifier does not match the challenge" do
+    get "/oauth/authorize", params: {
+      client_id: client_id_url, redirect_uri: redirect_uri, response_type: "code",
+      code_challenge: code_challenge, code_challenge_method: "S256"
+    }
+    post "/oauth/authorize", params: {
+      client_id: client_id_url, redirect_uri: redirect_uri, response_type: "code",
+      code_challenge: code_challenge, code_challenge_method: "S256"
+    }
+    code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code", code: code, redirect_uri: redirect_uri,
+      client_id: client_id_url, code_verifier: "wrong-verifier-wrong-verifier-wrong-verifier"
+    }
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "rejects the token exchange when no code_verifier is presented at all" do
+    get "/oauth/authorize", params: {
+      client_id: client_id_url, redirect_uri: redirect_uri, response_type: "code",
+      code_challenge: code_challenge, code_challenge_method: "S256"
+    }
+    post "/oauth/authorize", params: {
+      client_id: client_id_url, redirect_uri: redirect_uri, response_type: "code",
+      code_challenge: code_challenge, code_challenge_method: "S256"
+    }
+    code = Rack::Utils.parse_query(URI.parse(response.location).query)["code"]
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code", code: code, redirect_uri: redirect_uri, client_id: client_id_url
+    }
+    expect(response).to have_http_status(:bad_request)
+  end
+end

--- a/spec/requests/oauth/authorizations_cimd_spec.rb
+++ b/spec/requests/oauth/authorizations_cimd_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "OAuth authorize — CIMD client resolution", type: :request do
+  let(:user) { create(:user) }
+  let(:client_id_url) { "https://good.example.com/mcp-client.json" }
+  let(:redirect_uri) { "https://good.example.com/callback" }
+  let(:metadata) do
+    { client_id: client_id_url, client_name: "Test MCP Client", redirect_uris: [ redirect_uri ] }
+  end
+  let(:authorize_params) do
+    {
+      client_id: client_id_url,
+      redirect_uri: redirect_uri,
+      response_type: "code",
+      code_challenge: "a" * 43,
+      code_challenge_method: "S256"
+    }
+  end
+
+  before do
+    Rails.cache.clear
+    allow(Resolv).to receive(:getaddresses).with("good.example.com").and_return([ "93.184.216.34" ])
+  end
+
+  context "when unauthenticated" do
+    it "redirects to sign in" do
+      get "/oauth/authorize", params: authorize_params
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  context "when authenticated" do
+    before { sign_in user }
+
+    context "with a valid CIMD client_id" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: metadata.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "resolves and persists the client, then renders the consent screen" do
+        get "/oauth/authorize", params: authorize_params
+        expect(response).to have_http_status(:ok)
+
+        application = Doorkeeper::Application.find_by(metadata_url: client_id_url)
+        expect(application).to be_present
+        expect(application.name).to eq("Test MCP Client")
+        expect(application.redirect_uri).to eq(redirect_uri)
+        expect(application.confidential?).to be false
+      end
+    end
+
+    context "when the client_id resolves to a private IP (SSRF attempt)" do
+      before do
+        allow(Resolv).to receive(:getaddresses).with("evil.example.com").and_return([ "127.0.0.1" ])
+      end
+
+      it "does not create an application and does not authorize the request" do
+        get "/oauth/authorize", params: authorize_params.merge(
+          client_id: "https://evil.example.com/client.json",
+          redirect_uri: "https://evil.example.com/callback"
+        )
+
+        expect(Doorkeeper::Application.where(metadata_url: "https://evil.example.com/client.json")).not_to exist
+        expect(response).not_to redirect_to(%r{\Ahttps://evil\.example\.com})
+      end
+    end
+
+    context "when the CIMD document is invalid" do
+      before do
+        stub_request(:get, client_id_url).to_return(status: 200, body: "not json")
+      end
+
+      it "does not create an application" do
+        get "/oauth/authorize", params: authorize_params
+        expect(Doorkeeper::Application.where(metadata_url: client_id_url)).not_to exist
+      end
+    end
+
+    context "with a non-CIMD (plain) client_id" do
+      it "leaves classic client lookup untouched" do
+        get "/oauth/authorize", params: authorize_params.merge(client_id: "some-plain-client-id")
+        expect(Doorkeeper::Application.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -47,6 +47,32 @@ RSpec.describe "Settings", type: :request do
           expect(response.body).not_to include("Advisor suggestion")
         end
       end
+
+      context "connected apps" do
+        it "shows a message when no apps are connected" do
+          get settings_path
+          expect(response.body).to include("No AI tools are currently connected")
+        end
+
+        it "lists an application with an active access token" do
+          token = doorkeeper_access_token_for(user)
+          get settings_path
+          expect(response.body).to include(token.application.name)
+        end
+
+        it "does not list another user's connected apps" do
+          other_token = doorkeeper_access_token_for(create(:user))
+          get settings_path
+          expect(response.body).not_to include(other_token.application.name)
+        end
+
+        it "does not list an application whose token has been revoked" do
+          token = doorkeeper_access_token_for(user)
+          token.revoke
+          get settings_path
+          expect(response.body).not_to include(token.application.name)
+        end
+      end
     end
   end
 
@@ -107,6 +133,36 @@ RSpec.describe "Settings", type: :request do
           patch settings_path, params: { user: { session_size: 5, new_cards_per_session: 10 } }
           expect(response).to have_http_status(:unprocessable_content)
         end
+      end
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # DELETE /settings/connected_apps/:id
+  # -------------------------------------------------------------------------
+  describe "DELETE /settings/connected_apps/:id" do
+    context "when unauthenticated" do
+      it "redirects to login" do
+        delete revoke_connected_app_path(1)
+        expect(response).to redirect_to("/sign_in")
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "revokes the access token and redirects back to settings" do
+        token = doorkeeper_access_token_for(user)
+        delete revoke_connected_app_path(token.application_id)
+        expect(token.reload).to be_revoked
+        expect(response).to redirect_to(settings_path)
+      end
+
+      it "does not revoke another user's access token for that application" do
+        other_user  = create(:user)
+        other_token = doorkeeper_access_token_for(other_user)
+        delete revoke_connected_app_path(other_token.application_id)
+        expect(other_token.reload).not_to be_revoked
       end
     end
   end

--- a/spec/requests/well_known_spec.rb
+++ b/spec/requests/well_known_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Well-known OAuth discovery endpoints", type: :request do
+  describe "GET /.well-known/oauth-protected-resource" do
+    it "returns 200 with the resource metadata" do
+      get "/.well-known/oauth-protected-resource"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "identifies the MCP endpoint as the resource" do
+      get "/.well-known/oauth-protected-resource"
+      body = JSON.parse(response.body)
+      expect(body["resource"]).to eq(mcp_url(host: "www.example.com"))
+    end
+
+    it "advertises this app as the authorization server" do
+      get "/.well-known/oauth-protected-resource"
+      body = JSON.parse(response.body)
+      expect(body["authorization_servers"]).to eq([ root_url(host: "www.example.com").chomp("/") ])
+    end
+
+    it "advertises the mcp scope and header bearer method" do
+      get "/.well-known/oauth-protected-resource"
+      body = JSON.parse(response.body)
+      expect(body["scopes_supported"]).to eq([ "mcp" ])
+      expect(body["bearer_methods_supported"]).to eq([ "header" ])
+    end
+  end
+
+  describe "GET /.well-known/oauth-authorization-server" do
+    it "returns 200 with the authorization server metadata" do
+      get "/.well-known/oauth-authorization-server"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "advertises the authorization, token, and revocation endpoints" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+      expect(body["authorization_endpoint"]).to eq(oauth_authorization_url(host: "www.example.com"))
+      expect(body["token_endpoint"]).to eq(oauth_token_url(host: "www.example.com"))
+      expect(body["revocation_endpoint"]).to eq(oauth_revoke_url(host: "www.example.com"))
+    end
+
+    it "advertises authorization_code as the only supported grant type" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+      expect(body["grant_types_supported"]).to eq([ "authorization_code", "refresh_token" ])
+    end
+
+    it "advertises S256 PKCE support" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+      expect(body["code_challenge_methods_supported"]).to eq([ "S256" ])
+    end
+
+    it "advertises CIMD support and no client_secret auth methods" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+      expect(body["client_id_metadata_document_supported"]).to be true
+      expect(body["token_endpoint_auth_methods_supported"]).to eq([ "none" ])
+    end
+
+    it "does not advertise a registration_endpoint" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+      expect(body).not_to have_key("registration_endpoint")
+    end
+  end
+end

--- a/spec/requests/well_known_spec.rb
+++ b/spec/requests/well_known_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Well-known OAuth discovery endpoints", type: :request do
       expect(body["revocation_endpoint"]).to eq(oauth_revoke_url(host: "www.example.com"))
     end
 
-    it "advertises authorization_code as the only supported grant type" do
+    it "advertises authorization_code and refresh_token as the supported grant types" do
       get "/.well-known/oauth-authorization-server"
       body = JSON.parse(response.body)
       expect(body["grant_types_supported"]).to eq([ "authorization_code", "refresh_token" ])

--- a/spec/services/oauth/cimd_client_resolver_spec.rb
+++ b/spec/services/oauth/cimd_client_resolver_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Oauth::CimdClientResolver do
       expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /userinfo/)
     end
 
+    it "rejects a client_id with an explicit default port" do
+      resolver = described_class.new("https://good.example.com:443/client.json")
+      expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /port/)
+    end
+
     context "when the hostname resolves to a private/loopback address" do
       before do
         allow(Resolv).to receive(:getaddresses).with("evil.example.com").and_return([ "127.0.0.1" ])

--- a/spec/services/oauth/cimd_client_resolver_spec.rb
+++ b/spec/services/oauth/cimd_client_resolver_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+RSpec.describe Oauth::CimdClientResolver do
+  let(:client_id_url) { "https://good.example.com/mcp-client.json" }
+  let(:valid_metadata) do
+    {
+      client_id: client_id_url,
+      client_name: "Test MCP Client",
+      redirect_uris: [ "https://good.example.com/callback" ]
+    }
+  end
+
+  before do
+    Rails.cache.clear
+    # SsrfFilter resolves hostnames via Resolv before ever touching webmock's
+    # stubbed HTTP layer, so DNS is stubbed here rather than hitting the network.
+    allow(Resolv).to receive(:getaddresses).with("good.example.com").and_return([ "93.184.216.34" ])
+  end
+
+  describe "#resolve!" do
+    it "rejects a client_id that is not https" do
+      resolver = described_class.new("http://good.example.com/mcp-client.json")
+      expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /https/)
+    end
+
+    it "rejects a client_id with no path" do
+      resolver = described_class.new("https://good.example.com")
+      expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /path/)
+    end
+
+    it "rejects a client_id with a fragment" do
+      resolver = described_class.new("https://good.example.com/client.json#frag")
+      expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /fragment/)
+    end
+
+    it "rejects a client_id with userinfo" do
+      resolver = described_class.new("https://user:pass@good.example.com/client.json")
+      expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /userinfo/)
+    end
+
+    context "when the hostname resolves to a private/loopback address" do
+      before do
+        allow(Resolv).to receive(:getaddresses).with("evil.example.com").and_return([ "127.0.0.1" ])
+      end
+
+      it "blocks the fetch" do
+        resolver = described_class.new("https://evil.example.com/client.json")
+        expect { resolver.resolve! }.to raise_error(described_class::FetchError, /blocked/)
+      end
+    end
+
+    context "with a successful fetch" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "creates a public Doorkeeper::Application keyed by the metadata URL" do
+        resolver = described_class.new(client_id_url)
+        application = resolver.resolve!
+
+        expect(application).to be_a(Doorkeeper::Application)
+        expect(application.uid).to eq(client_id_url)
+        expect(application.metadata_url).to eq(client_id_url)
+        expect(application.confidential?).to be false
+        expect(application.name).to eq("Test MCP Client")
+        expect(application.redirect_uri).to eq("https://good.example.com/callback")
+      end
+
+      it "caches the fetched document and does not refetch within the TTL" do
+        described_class.new(client_id_url).resolve!
+        described_class.new(client_id_url).resolve!
+
+        expect(WebMock).to have_requested(:get, client_id_url).once
+      end
+
+      it "re-syncs an existing application's fields rather than creating a duplicate" do
+        first = described_class.new(client_id_url).resolve!
+
+        Rails.cache.clear
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.merge(client_name: "Renamed Client").to_json,
+                     headers: { "Content-Type" => "application/json" })
+
+        second = described_class.new(client_id_url).resolve!
+
+        expect(second.id).to eq(first.id)
+        expect(second.name).to eq("Renamed Client")
+        expect(Doorkeeper::Application.where(metadata_url: client_id_url).count).to eq(1)
+      end
+    end
+
+    context "when the fetch times out" do
+      before do
+        stub_request(:get, client_id_url).to_timeout
+      end
+
+      it "raises a FetchError" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::FetchError)
+      end
+
+      it "does not cache the failure" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::FetchError)
+        expect(Rails.cache.exist?("cimd_client_metadata:#{client_id_url}")).to be false
+      end
+    end
+
+    context "when the response exceeds the size cap" do
+      before do
+        oversized_body = { client_id: client_id_url, redirect_uris: [ "https://good.example.com/callback" ],
+                            padding: "x" * described_class::MAX_BODY_BYTES }.to_json
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: oversized_body, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "raises a FetchError" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::FetchError, /exceeded/)
+      end
+    end
+
+    context "when the response is not valid JSON" do
+      before do
+        stub_request(:get, client_id_url).to_return(status: 200, body: "not json")
+      end
+
+      it "raises an InvalidMetadata error" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /JSON/)
+      end
+    end
+
+    context "when the document's client_id does not match the fetched URL" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.merge(client_id: "https://different.example.com/x.json").to_json)
+      end
+
+      it "raises an InvalidMetadata error" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /does not match/)
+      end
+    end
+
+    context "when redirect_uris is missing" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.except(:redirect_uris).to_json)
+      end
+
+      it "raises an InvalidMetadata error" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /redirect_uris/)
+      end
+    end
+
+    context "when the document declares a confidential auth method" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.merge(token_endpoint_auth_method: "client_secret_post").to_json)
+      end
+
+      it "raises an InvalidMetadata error" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /public/)
+      end
+    end
+
+    context "when the document includes a client_secret" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.merge(client_secret: "sneaky").to_json)
+      end
+
+      it "raises an InvalidMetadata error" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::InvalidMetadata, /client_secret/)
+      end
+    end
+
+    context "when the server redirects" do
+      before do
+        stub_request(:get, client_id_url)
+          .to_return(status: 302, headers: { "Location" => "https://good.example.com/other.json" })
+      end
+
+      it "raises a FetchError rather than following the redirect" do
+        resolver = described_class.new(client_id_url)
+        expect { resolver.resolve! }.to raise_error(described_class::FetchError)
+      end
+    end
+  end
+end

--- a/spec/support/cf_access_helpers.rb
+++ b/spec/support/cf_access_helpers.rb
@@ -23,12 +23,6 @@ module CfAccessHelpers
       )
   end
 
-  def cf_access_token(email:, aud: CfAccessHelpers::AUD, iss: CfAccessHelpers::ISSUER, exp: 1.hour.from_now.to_i, omit_email: false)
-    payload = { iss: iss, sub: email, aud: [ aud ], exp: exp, iat: Time.current.to_i }
-    payload[:email] = email unless omit_email
-    JWT.encode(payload, CfAccessHelpers.private_key, "RS256", { kid: "test-kid-1" })
-  end
-
   def cf_service_token(common_name:, aud: CfAccessHelpers::AUD, iss: CfAccessHelpers::ISSUER, exp: 1.hour.from_now.to_i)
     payload = { type: "app", iss: iss, sub: "", aud: [ aud ], exp: exp, iat: Time.current.to_i }
     payload[:common_name] = common_name unless common_name.nil?

--- a/spec/support/doorkeeper_helpers.rb
+++ b/spec/support/doorkeeper_helpers.rb
@@ -1,0 +1,19 @@
+module DoorkeeperHelpers
+  def doorkeeper_access_token_for(user, scopes: "mcp", expires_in: 2.hours)
+    application = Doorkeeper::Application.create!(
+      name: "Test MCP Client",
+      redirect_uri: "https://example.com/callback",
+      confidential: false
+    )
+    Doorkeeper::AccessToken.create!(
+      resource_owner_id: user.id,
+      application: application,
+      scopes: scopes,
+      expires_in: expires_in
+    )
+  end
+
+  def bearer_header(access_token)
+    { "Authorization" => "Bearer #{access_token.plaintext_token}" }
+  end
+end


### PR DESCRIPTION
## Summary

Replaces the single-owner-only Cloudflare Access model for `/mcp` with an app-native OAuth 2.1 authorization server, as a step toward supporting other users' MCP clients without needing Huw to manually mint a Cloudflare Access service token for each one.

- **Doorkeeper** provides the authorization-code + PKCE + token/refresh lifecycle. Every client this server registers is public (`confidential: false`, PKCE mandatory via `force_pkce`) — there is no path that hands out a client secret.
- **Client identification via CIMD** (OAuth Client ID Metadata Documents), not classic RFC 7591 Dynamic Client Registration — `client_id` is an `https://` URL the server fetches and validates on demand, rather than a stateful, unauthenticated `POST /register` endpoint an attacker could spam. This is the mechanism the MCP authorization spec's November 2025 revision recommends (SHOULD) for exactly this case, and downgrades DCR to optional (MAY). PocketID (this app's existing IdP) doesn't support DCR yet either — confirmed via its open feature request and an in-progress, unmerged PR implementing this same CIMD mechanism.
- The resource-owner login step reuses the app's existing PocketID-backed session — no new identity system.
- `/mcp` accepts a Doorkeeper bearer token **or** the existing CF Access service-token fallback during the transition. The CF Access **email-match** branch is deleted outright (not kept) — it relied on Cloudflare Access's own policy having vetted callers before issuing a JWT, an assumption that breaks once that policy is loosened to "allow anyone" (planned, out-of-band).
- Users can see and revoke connected apps from **Settings → Connected apps**.

Full design rationale and threat model: `docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md`.

## Deliberate decisions

- **CIMD over RFC 7591 DCR** — see above; avoids a public registration-spam vector entirely, at the cost of a server-side fetch of a client-supplied URL, hardened via `ssrf_filter` (validated-IP pinning, no redirects, timeouts, size cap — see `Oauth::CimdClientResolver`).
- **Additive rollout, not rip-and-replace** — `/mcp` accepts both auth strategies in this PR. Full CF Access removal is a dated follow-up once this is proven in production, tracked in the threat assessment's "Outstanding configuration."
- **No token introspection endpoint, no client_credentials/implicit/password grants** — no consumer needs them; smaller surface to secure and pentest.
- **No CIMD garbage collection job in this PR** — deferred as a cheap follow-up; the security-critical work was the fetch-time hardening, not row cleanup.

## Test plan

- [x] `bundle exec rspec` — 990 examples, 0 failures, 96.13% coverage
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman` — no warnings
- [x] End-to-end request spec drives the full authorize → consent → token → `/mcp` loop for a CIMD client, including PKCE verifier mismatch/absence negative cases (`spec/requests/oauth/authorization_code_flow_spec.rb`)
- [x] SSRF/size-cap/redirect/malformed-document negative cases for the CIMD resolver (`spec/services/oauth/cimd_client_resolver_spec.rb`)
- [x] Cross-user isolation regression test — a token minted for one user cannot read another's MCP resources
- [x] CF Access service-token fallback path re-verified unchanged (shared example run against both auth strategies in `spec/requests/mcp_spec.rb`)
- [x] Manual smoke test against a running server: `.well-known` endpoints, unauthenticated `/mcp` → 401, unauthenticated `/oauth/authorize` → redirects to sign-in
- [ ] Live pentest against this flow before Cloudflare Access is opened to "allow anyone" and this is advertised as self-service (planned, not part of this PR — see threat assessment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDi7gRJxFNnYYP6bjmA9su