### PR TITLE
fix: remediate MCP OAuth pentest findings (F-001/F-002/F-003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,12 @@ rake provision:learn_hanzi
 - `RAILS_MASTER_KEY`
 - `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URI`
 - `STORAGE_PATH` — host path mounted to `/rails/storage` (holds the SQLite databases)
+- `APP_HOST` — the public hostname (no protocol), e.g. `learn-hanzi.example.com`.
+  Required at boot as of the MCP OAuth pentest remediation: `config.hosts` in
+  `config/environments/production.rb` now rejects any other Host header,
+  closing a gap where a spoofed Host was reflected into OAuth discovery
+  metadata. **Must be set in the Portainer stack before deploying this
+  change**, or the app will fail to boot (`ENV.fetch` with no default).
 - `SENTRY_DSN` (optional)
 
 The app runs on port 8037 externally, 3037 internally, with SolidQueue embedded in Puma (`SOLID_QUEUE_IN_PUMA=true`).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,12 +78,17 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # Enable DNS rebinding protection and other `Host` header attacks. Required
+  # (not defaulted) — an unset APP_HOST should fail loudly at boot rather
+  # than silently leave every Host header accepted, which is what happened
+  # before this line existed: the OAuth discovery endpoints reflected an
+  # arbitrary Host/X-Forwarded-Host straight into `issuer`/
+  # `authorization_endpoint` (see security/pentests/2026-07-MCP_OAuth.md,
+  # F-003).
+  config.hosts << ENV.fetch("APP_HOST")
+
+  # Skip DNS rebinding protection for the default health check endpoint —
+  # container health checks hit this over localhost/the container IP, not
+  # APP_HOST.
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -196,6 +196,7 @@ Doorkeeper.configure do
   # Every application this server creates is a public client (CIMD-resolved MCP
   # clients are always confidential: false), so PKCE is mandatory, not optional.
   force_pkce
+  pkce_code_challenge_methods %w[S256]
 
   # Hash access and refresh tokens before persisting them.
   # This will disable the possibility to use +reuse_access_token+

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,14 +3,28 @@ class Rack::Attack
   # than each worker's own in-memory store.
   Rack::Attack.cache.store = Rails.cache
 
+  class << self
+    def throttle_client_ip(req)
+      trusted_client_ip_header(req).presence || req.get_header("REMOTE_ADDR").presence || req.ip
+    end
+
+    private
+
+    def trusted_client_ip_header(req)
+      return unless ENV["TRUSTED_CLIENT_IP_HEADER"] == "CF-Connecting-IP"
+
+      req.get_header("HTTP_CF_CONNECTING_IP")
+    end
+  end
+
   # /oauth/authorize also triggers a CIMD metadata fetch for unrecognized
   # client_id URLs (see Oauth::CimdClientResolver), so throttling it bounds
   # outbound fetch volume from a single IP as well as authorization attempts.
   throttle("oauth/authorize", limit: 30, period: 1.minute) do |req|
-    req.ip if req.path == "/oauth/authorize"
+    Rack::Attack.throttle_client_ip(req) if req.path == "/oauth/authorize"
   end
 
   throttle("oauth/token", limit: 20, period: 1.minute) do |req|
-    req.ip if req.path == "/oauth/token" && req.post?
+    Rack::Attack.throttle_client_ip(req) if req.path == "/oauth/token" && req.post?
   end
 end

--- a/spec/config/host_authorization_spec.rb
+++ b/spec/config/host_authorization_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+# Regression coverage for security/pentests/2026-07-MCP_OAuth.md F-003: Rails
+# only sets a default config.hosts allowlist in development
+# (railties/lib/rails/application/configuration.rb checks Rails.env.development?
+# specifically), so production previously ran with no Host Authorization
+# middleware at all — a spoofed Host/X-Forwarded-Host header was reflected
+# straight into the OAuth discovery endpoints' issuer/authorization_endpoint.
+#
+# This can't be exercised as a full request spec without either destabilizing
+# the test environment's own middleware stack (which Capybara-driven system
+# specs depend on, hitting the app over 127.0.0.1:<random port> — see the
+# pentest doc's "Outstanding / follow-ups") or reloading the app with a
+# different Rails.env mid-suite. Instead: a unit test proves the mechanism
+# itself does what production.rb configures it to do, and a content check
+# guards against config/environments/production.rb silently losing the line
+# that wires it up.
+RSpec.describe "Host Authorization" do
+  describe "the ActionDispatch::HostAuthorization mechanism" do
+    let(:inner_app) { ->(_env) { [ 200, {}, [ "ok" ] ] } }
+    let(:middleware) { ActionDispatch::HostAuthorization.new(inner_app, [ "good.example.com" ]) }
+
+    def call_with_host(host)
+      middleware.call(Rack::MockRequest.env_for("/", "HTTP_HOST" => host))
+    end
+
+    it "allows a request with an allowlisted Host header" do
+      status, = call_with_host("good.example.com")
+      expect(status).to eq(200)
+    end
+
+    it "blocks a request with an unlisted Host header" do
+      status, = call_with_host("evil.example")
+      expect(status).to eq(403)
+    end
+
+    it "blocks a request that spoofs X-Forwarded-Host rather than Host" do
+      status, = middleware.call(
+        Rack::MockRequest.env_for("/", "HTTP_HOST" => "good.example.com", "HTTP_X_FORWARDED_HOST" => "evil.example")
+      )
+      expect(status).to eq(403)
+    end
+  end
+
+  describe "config/environments/production.rb" do
+    let(:source) { File.read(Rails.root.join("config/environments/production.rb")) }
+
+    it "sets config.hosts from a required APP_HOST env var" do
+      expect(source).to match(/config\.hosts\s*<<\s*ENV\.fetch\(["']APP_HOST["']\)/)
+    end
+
+    it "excludes the health check endpoint from host authorization" do
+      expect(source).to match(/config\.host_authorization\s*=\s*\{\s*exclude:/)
+    end
+  end
+end

--- a/spec/requests/oauth_security_spec.rb
+++ b/spec/requests/oauth_security_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe "OAuth/MCP security controls", type: :request do
+  before do
+    Rails.cache.clear
+    Rack::Attack.cache.store.clear
+  end
+
+  after do
+    Rack::Attack.cache.store.clear
+  end
+
+  describe "PKCE configuration" do
+    let(:user) { create(:user) }
+    let(:client_id_url) { "https://good.example.com/mcp-client.json" }
+    let(:redirect_uri) { "https://good.example.com/callback" }
+    let(:metadata) do
+      { client_id: client_id_url, client_name: "Test MCP Client", redirect_uris: [ redirect_uri ] }
+    end
+
+    before do
+      allow(Resolv).to receive(:getaddresses).with("good.example.com").and_return([ "93.184.216.34" ])
+      stub_request(:get, client_id_url)
+        .to_return(status: 200, body: metadata.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "advertises and enforces S256 as the only PKCE challenge method" do
+      get "/.well-known/oauth-authorization-server"
+      body = JSON.parse(response.body)
+
+      expect(body["code_challenge_methods_supported"]).to eq([ "S256" ])
+      expect(Doorkeeper.config.pkce_code_challenge_methods_supported).to eq([ "S256" ])
+    end
+
+    it "rejects authorization requests that try to use plain PKCE" do
+      sign_in user
+
+      get "/oauth/authorize", params: {
+        client_id: client_id_url,
+        redirect_uri: redirect_uri,
+        response_type: "code",
+        code_challenge: "plain-verifier-plain-verifier-plain-verifier",
+        code_challenge_method: "plain"
+      }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("code_challenge_method must be S256")
+    end
+  end
+
+  describe "MCP bearer token placement" do
+    it "does not accept access tokens from query parameters" do
+      post "/mcp",
+        params: { access_token: "not-a-real-token", jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+        as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "OAuth throttles" do
+    let(:authorize_path) do
+      "/oauth/authorize?client_id=plain-client&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcb" \
+        "&response_type=code&code_challenge=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        "&code_challenge_method=S256"
+    end
+
+    it "throttles /oauth/authorize by remote address and ignores X-Forwarded-For by default" do
+      30.times do
+        get authorize_path, headers: { "REMOTE_ADDR" => "198.51.100.10" }
+        expect(response).to have_http_status(:found)
+      end
+
+      get authorize_path, headers: { "REMOTE_ADDR" => "198.51.100.10" }
+      expect(response).to have_http_status(:too_many_requests)
+
+      get authorize_path, headers: {
+        "REMOTE_ADDR" => "198.51.100.10",
+        "X-Forwarded-For" => "203.0.113.123"
+      }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "throttles /oauth/token by remote address and ignores X-Forwarded-For by default" do
+      token_params = {
+        grant_type: "authorization_code",
+        code: "bogus",
+        redirect_uri: "http://localhost:9999/cb",
+        client_id: "bogus"
+      }
+
+      20.times do
+        post "/oauth/token", params: token_params, headers: { "REMOTE_ADDR" => "198.51.100.20" }
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      post "/oauth/token", params: token_params, headers: { "REMOTE_ADDR" => "198.51.100.20" }
+      expect(response).to have_http_status(:too_many_requests)
+
+      post "/oauth/token", params: token_params, headers: {
+        "REMOTE_ADDR" => "198.51.100.20",
+        "X-Forwarded-For" => "203.0.113.124"
+      }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes for all three findings from the MCP OAuth pentest (write-up landing separately on `pentest-writeup`, not merged yet — this branch is the actual unit of review):

- **F-001** — Doorkeeper's default `pkce_code_challenge_methods` (`%w[plain S256]`) was never restricted, so `/oauth/token` accepted `plain` PKCE despite the discovery endpoint already (falsely) advertising S256-only. Fixed by pinning `pkce_code_challenge_methods %w[S256]`.
- **F-002** — `Rack::Attack::Request` is a plain `Rack::Request`, so the throttle blocks' `req.ip` trusted `X-Forwarded-For`, plausibly spoofable given this app's Cloudflare Tunnel deployment. Fixed with a `throttle_client_ip` helper that ignores `X-Forwarded-For` by default and only trusts `CF-Connecting-IP` when explicitly opted in via `TRUSTED_CLIENT_IP_HEADER=CF-Connecting-IP`.
- **F-003** (found in independent second-pass review, not in the original local session) — Rails only sets a default `config.hosts` allowlist in `development`; production had none, so **no Host Authorization ran in production at all**. Confirmed live: a spoofed `Host`/`X-Forwarded-Host` header was reflected straight into `/.well-known/oauth-authorization-server`'s `issuer`/`authorization_endpoint`. Fixed with `config.hosts << ENV.fetch("APP_HOST")` (required, fails loudly if unset) plus excluding `/up` from host authorization for container health checks.

## ⚠️ Deployment requirement

**`APP_HOST` must be set in the Portainer stack env before this deploys**, or the app will fail to boot. It was already documented as "REQUIRED" in `.env.example` but never actually consumed in production, and wasn't in CLAUDE.md's required-env-var list — both gaps fixed here.

## Test plan

- [x] `bundle exec rspec` — 1001 examples, 0 failures, 96.13% coverage
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings
- [x] `spec/requests/oauth_security_spec.rb` — PKCE plain rejection, MCP bearer-token-via-query-param rejection, throttle-by-remote-address-ignoring-X-Forwarded-For for both `/oauth/authorize` and `/oauth/token`
- [x] `spec/config/host_authorization_spec.rb` — unit coverage of the `ActionDispatch::HostAuthorization` mechanism (allow/block/X-Forwarded-Host-spoof cases) plus a guard that `production.rb` actually wires up `config.hosts`/`config.host_authorization`
- [ ] Full-stack (request-spec) coverage for F-003 deferred — Capybara system specs hit the app over `127.0.0.1:<random port>` and would need their own allowlist entry; tracked as a follow-up rather than risking collateral breakage under pentest time pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)