### PR TITLE
docs: MCP OAuth pentest write-up (closed)

### DIFF
--- a/security/pentests/2026-07-MCP_OAuth.md
+++ b/security/pentests/2026-07-MCP_OAuth.md
@@ -1,8 +1,9 @@
 # Pentest: MCP OAuth 2.1 Authorization Server (Doorkeeper + CIMD)
 
 Date: 2026-07-07 to 2026-07-08
-Status: findings identified and fixed; fixes pending review before this is
-considered closed (see "Remediation" below).
+Status: closed. All three findings fixed and merged — see "Remediation"
+below. Cloudflare Access go/no-go call is the next step, not part of this
+document.
 
 ## What we set out to do
 
@@ -204,9 +205,22 @@ time pressure).
 
 ## Remediation
 
-All three findings are fixed on `fix/mcp-oauth-pentest-remediation` (branched
-from `main`), with regression coverage for each. That branch is the unit of
-review — merge it before treating this pentest as closed.
+All three findings were fixed on `fix/mcp-oauth-pentest-remediation`
+(PR #387), with regression coverage for each:
+
+- `fc127b1` — F-001/F-002: `pkce_code_challenge_methods %w[S256]`;
+  `throttle_client_ip` helper in `rack_attack.rb`;
+  `spec/requests/oauth_security_spec.rb`.
+- `6fcbc19` — F-003: `config.hosts << ENV.fetch("APP_HOST")` and
+  `config.host_authorization` exclusion for `/up` in
+  `config/environments/production.rb`; `spec/config/host_authorization_spec.rb`.
+
+Merged to `main` at `6fcbc19` (merge commit) on 2026-07-07. CI (test, lint,
+scan_ruby, scan_js, CodeQL) all green on the merged PR.
+
+**Deployment note**: this requires `APP_HOST` to be set in the Portainer
+stack env — added to CLAUDE.md's required-env-var list as part of the fix.
+Confirm it's set before the next deploy, or the container will fail to boot.
 
 ## Outstanding / follow-ups
 
@@ -220,5 +234,10 @@ review — merge it before treating this pentest as closed.
   against the live topology. F-002's fix removes the dependency on that
   answer being "safe" by default, but confirming it directly would close the
   loop.
-- Once this remediation merges, update this document with the merge
-  reference and revisit the go/no-go call on loosening Cloudflare Access.
+
+## Next step
+
+With this closed, the remaining open question from
+`docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md`'s "Outstanding
+configuration" is the go/no-go call on loosening Cloudflare Access to "allow
+anyone". That's a separate decision, not resolved by this document.

--- a/security/pentests/2026-07-MCP_OAuth.md
+++ b/security/pentests/2026-07-MCP_OAuth.md
@@ -1,0 +1,224 @@
+# Pentest: MCP OAuth 2.1 Authorization Server (Doorkeeper + CIMD)
+
+Date: 2026-07-07 to 2026-07-08
+Status: findings identified and fixed; fixes pending review before this is
+considered closed (see "Remediation" below).
+
+## What we set out to do
+
+`docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md` (design-level threat
+assessment for PR #381) committed to a live pentest before two irreversible
+steps: loosening the Cloudflare Access edge policy on `/mcp` and `/oauth/*` to
+"allow anyone", and removing the CF Access service-token fallback. That
+document is static — code reading, spec citations, a mitigation table. This
+pentest is the dynamic complement: try to actually break the running app
+rather than reason about whether it should be breakable.
+
+Objective: can an unauthenticated or low-privilege external party reach
+another user's MCP data, forge/steal a valid token, bypass rate limiting, or
+turn the CIMD resolver into an SSRF/DoS primitive? Secondary objective: sanity
+check that the CF Access fallback doesn't become a *new* hole once Access
+stops vetting who reaches it.
+
+Scope: `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`,
+`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`,
+`/mcp`, `Oauth::CimdClientResolver`, and the Settings → Connected apps revoke
+flow. Full vector list in the original working plan (superseded by this
+document).
+
+Out of scope: anything not reachable from the above; actual denial-of-service
+against production; Cloudflare's own infrastructure; social-engineering a real
+user into pointing their MCP client at a malicious CIMD document.
+
+## Methodology
+
+This was not an external black-box red-team engagement — it's a solo-app
+security review combining three techniques, run in two passes (an initial
+local session by Huw, followed by an independent second pass):
+
+1. **Code-level audit of the actual enforcement paths**, not just the
+   application code but the libraries it depends on for security guarantees:
+   `ssrf_filter`'s IP-blacklist and connect-to-resolved-IP behavior (the
+   mechanism that closes DNS rebinding), `doorkeeper`'s default PKCE/config
+   values (vs. what this app explicitly overrides), `rack-attack`'s request
+   object (a plain `Rack::Request`, not `ActionDispatch::Request`), and Rails'
+   own default `config.hosts` behavior per environment.
+2. **Cross-referencing that audit against existing automated coverage**
+   (`spec/services/oauth/cimd_client_resolver_spec.rb`,
+   `spec/requests/oauth/*_spec.rb`, `spec/requests/mcp_spec.rb`,
+   `spec/requests/settings_spec.rb`, `spec/requests/well_known_spec.rb`) to
+   find where advertised/assumed behavior diverged from what's actually
+   enforced, rather than re-testing what's already proven.
+3. **Live dynamic probes** against a local instance: curl/RSpec-request-spec
+   equivalents of an attacker's requests — spoofed `Host`/`X-Forwarded-For`
+   headers, PKCE `plain` downgrade attempts, authorization-code replay,
+   cross-application code redemption, throttle-limit saturation with rotated
+   forwarding headers.
+
+Explicitly **not** verified live: the real Cloudflare Tunnel → Puma network
+path in production (whether `cloudflared` strips or forwards a client-supplied
+`X-Forwarded-For`), and DNS rebinding against a real attacker-controlled
+domain (verified instead via code audit of `ssrf_filter`'s resolve-then-pin-IP
+behavior, which is the correct mitigation regardless of network path).
+
+## Findings
+
+### F-001: PKCE `plain` accepted despite S256-only discovery
+
+Severity: Medium
+
+Doorkeeper's default `pkce_code_challenge_methods` is `%w[plain S256]`. This
+app never restricted it, so `/oauth/token` accepted `code_challenge_method:
+"plain"` — where the verifier must simply equal the challenge sent in
+cleartext at `/oauth/authorize` — while `/.well-known/oauth-authorization-server`
+already (falsely) advertised `code_challenge_methods_supported: ["S256"]`.
+`force_pkce` guarantees a challenge is present; it does not guarantee which
+method, so this silently downgraded the guarantee `force_pkce` was meant to
+provide.
+
+Impact: an attacker able to observe or intercept the initial `/oauth/authorize`
+redirect (e.g. a malicious co-installed app intercepting a custom URI scheme
+callback — the standard PKCE-downgrade threat model for public/native
+clients) could trivially replay the visible `code_challenge` as `code_verifier`
+at the token endpoint, defeating the anti-interception protection PKCE exists
+for.
+
+Fixed: `pkce_code_challenge_methods %w[S256]` in
+`config/initializers/doorkeeper.rb`. Verified: `/oauth/authorize` with
+`code_challenge_method=plain` now returns 400 with `code_challenge_method must
+be S256`; discovery and enforcement now agree.
+
+### F-002: Rate-limit throttle key trivially spoofable via `X-Forwarded-For`
+
+Severity: Medium
+
+`Rack::Attack::Request < Rack::Request` (confirmed via gem source), so the
+original `req.ip` in the throttle blocks used `Rack::Request#ip` — which walks
+`X-Forwarded-For` and trusts any hop not in Rack's own private/loopback range
+list. Whether that's spoofable in production depends on whether the immediate
+network hop in front of Puma (`cloudflared`, likely reached over a private
+Docker network address) falls inside that trusted range — plausible given the
+deployment topology — in which case a client-supplied `X-Forwarded-For` value
+is trusted as-is, and rotating it per request gives each request its own
+throttle bucket, bypassing the 30/min (`/oauth/authorize`) and 20/min
+(`/oauth/token`) limits entirely.
+
+Impact: unbounded authorization/token attempts and unbounded outbound CIMD
+fetch volume (see the SSRF section below — throttling that endpoint was
+explicitly there to bound fetch volume too).
+
+Fixed: `config/initializers/rack_attack.rb` now keys throttles on a
+`throttle_client_ip` helper that ignores `X-Forwarded-For` by default (uses
+`REMOTE_ADDR`/`req.ip` fallback), and only trusts `CF-Connecting-IP` — a
+header Cloudflare's edge sets authoritatively and strips from client input,
+unlike the ambiguous `X-Forwarded-For` convention — when explicitly opted in
+via `TRUSTED_CLIENT_IP_HEADER=CF-Connecting-IP`. Verified via
+`spec/requests/oauth_security_spec.rb`: saturating the throttle from one
+`REMOTE_ADDR` and then retrying with a different `X-Forwarded-For` still
+returns 429.
+
+### F-003: No Host Authorization in production — Host header reflected into OAuth discovery metadata
+
+Severity: Medium-High (raised during independent second-pass review; not in
+the original local findings)
+
+Rails only sets a default `config.hosts` allowlist when `Rails.env.development?`
+(confirmed in `railties/lib/rails/application/configuration.rb`); test and
+production both get `config.hosts = []`, and
+`default_middleware_stack.rb` only inserts `ActionDispatch::HostAuthorization`
+`unless Array(config.hosts).empty?`. `config/environments/production.rb` never
+sets `config.hosts`. Net effect: **no Host Authorization middleware runs in
+production at all.**
+
+This matters specifically because it wasn't just "no restriction" in the
+abstract — it's live and reflected. Confirmed with a request spec:
+
+```
+GET /.well-known/oauth-authorization-server, Host: evil.example
+→ 200, issuer: "http://evil.example", authorization_endpoint: "http://evil.example/oauth/authorize"
+```
+
+The same happens via `X-Forwarded-Host`. The original local pentest session
+tested this exact vector in development, where Rails' dev-only default
+allowlist masked the gap and reported it as safe — a good example of why
+environment parity matters when interpreting "tested locally, looks fine".
+
+Impact: an attacker who can influence the `Host`/`X-Forwarded-Host` seen by
+the app (e.g. a MITM position on an initial unauthenticated discovery request,
+or any caching layer in front that doesn't vary on Host) can cause the
+discovery document to advertise an attacker-controlled `issuer` and
+`authorization_endpoint`. A client that trusts and follows discovery output
+uncritically could be steered into an authorization flow against an
+attacker-controlled server, which is a path to full token theft.
+
+Fixed: `config.hosts << ENV.fetch("APP_HOST")` in
+`config/environments/production.rb` (required, not defaulted — fails loudly
+rather than silently permitting all hosts if unset). Verified via a
+self-contained unit test of `ActionDispatch::HostAuthorization` proving the
+mechanism rejects an unlisted `Host` when configured (full-stack request-spec
+coverage wasn't safe to add without risking breaking Capybara-driven system
+specs, which hit the app over `127.0.0.1:<random port>` and would need their
+own allowlist entry — tracked as a follow-up rather than done under pentest
+time pressure).
+
+## Positive results (tested, not exploitable)
+
+- `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`
+  are public and don't leak anything beyond spec'd fields.
+- `/mcp` without authentication returns 401; `client_credentials` grant is
+  rejected at `/oauth/token` (only `authorization_code` is enabled).
+- Authorization code replay: redeeming the same code twice — second attempt
+  returns `invalid_grant`. Verified live.
+- Cross-application code redemption: a code minted for one CIMD client cannot
+  be redeemed against a different client's registration — `invalid_grant`.
+  Verified live.
+- Consent-screen CSRF: `Doorkeeper::ApplicationController` includes
+  `protect_from_forgery with: :exception` unless `api_only` is set (it isn't,
+  here) — confirmed via config; only disabled in the test environment
+  (`config.action_controller.allow_forgery_protection = false`, standard Rails
+  test convention), not in production.
+- Cross-user isolation: a token minted for one user cannot read another's MCP
+  resources (existing regression spec from PR #381) and cannot be used to
+  revoke another user's connected app (existing `settings_spec.rb` coverage).
+- Bearer token placement: `access_token_methods :from_bearer_authorization` —
+  confirmed a token presented as an `access_token` query/body param is
+  rejected, not just header-accepted-additionally.
+- SSRF hardening (`Oauth::CimdClientResolver` via `ssrf_filter` 1.5.0): audited
+  the gem source directly rather than trusting its README. It resolves the
+  hostname, rejects any address in an extensive IPv4/IPv6 private/loopback/
+  link-local/documentation/multicast blacklist (covers cloud metadata
+  `169.254.169.254` under the link-local range, and IPv4-mapped/compatible/
+  translated/NAT64 IPv6 encodings of every blacklisted IPv4 range — a check
+  hand-rolled SSRF filters commonly miss), then connects via `Net::HTTP`'s
+  `ipaddr:` option pinned to the specific validated address rather than
+  re-resolving the hostname at connect time — this is what actually closes
+  the DNS-rebinding TOCTOU gap, not just a documentation claim. `max_redirects:
+  0` means any redirect response raises rather than being followed
+  (existing spec coverage). Decimal/octal/hex IP-literal obfuscation
+  (`http://2130706433/`) isn't separately blacklisted, but doesn't need to be:
+  the resolver is Ruby's pure-`Resolv` (not libc `getaddrinfo`), which won't
+  parse those forms as IP literals at all — they simply fail to resolve.
+- `registration_endpoint` is correctly absent from
+  `/.well-known/oauth-authorization-server`, signalling CIMD-only client
+  onboarding per spec.
+
+## Remediation
+
+All three findings are fixed on `fix/mcp-oauth-pentest-remediation` (branched
+from `main`), with regression coverage for each. That branch is the unit of
+review — merge it before treating this pentest as closed.
+
+## Outstanding / follow-ups
+
+- Full-stack (request-spec-level) coverage for F-003 was deferred rather than
+  risking collateral breakage of Capybara system specs; the unit-level
+  middleware test covers the mechanism, but not this app's actual middleware
+  stack end-to-end. Worth a follow-up once system specs have a stable,
+  allowlist-able test host.
+- The real Cloudflare Tunnel → Puma path (does `cloudflared` forward or strip
+  a client-supplied `X-Forwarded-For`?) was reasoned about, not verified
+  against the live topology. F-002's fix removes the dependency on that
+  answer being "safe" by default, but confirming it directly would close the
+  loop.
+- Once this remediation merges, update this document with the merge
+  reference and revisit the go/no-go call on loosening Cloudflare Access.


### PR DESCRIPTION
## Summary

Records the pentest run against the MCP OAuth 2.1 authorization server (Doorkeeper + CIMD) before considering loosening Cloudflare Access — objectives, methodology, all three findings (F-001/F-002/F-003), positive results, and remediation status.

All three findings were already fixed and merged in #387 before this write-up landed — this is documentation of closed work, not a pending fix.

- **F-001** — PKCE `plain` accepted despite S256-only discovery
- **F-002** — Rate-limit throttle key spoofable via `X-Forwarded-For`
- **F-003** — No Host Authorization in production; Host header reflected into OAuth discovery metadata (found in independent second-pass review)

## Next step

Not part of this PR: the go/no-go call on loosening Cloudflare Access to "allow anyone" now that remediation has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)