### PR TITLE
feat: mastery-tracking foundation for #391

### DIFF
--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -13,11 +13,13 @@ class ProgressController < ApplicationController
       .group_by { |dt| dt.to_date.to_s }
       .transform_values(&:count)
 
+    # Keyed on first_mastered_at (durable, never cleared on lapse) rather
+    # than state/mastered_at, so a later lapse doesn't retroactively lower
+    # this count at every date since the original mastery. See #391.
     mastered_per_day = Current.user.user_learnings
-      .where(state: "mastered")
-      .where.not(mastered_at: nil)
-      .group("date(mastered_at)")
-      .order("date(mastered_at)")
+      .where.not(first_mastered_at: nil)
+      .group("date(first_mastered_at)")
+      .order("date(first_mastered_at)")
       .count
 
     all_dates = (learning_per_day.keys + mastered_per_day.keys).uniq.sort
@@ -44,16 +46,18 @@ class ProgressController < ApplicationController
   end
 
   def character_chart_data
+    # Keyed on first_mastered_at (durable, never cleared on lapse) rather
+    # than state/mastered_at, so a later lapse doesn't drop the word's
+    # characters out of this count. See #391.
     mastered = Current.user.user_learnings
-      .where(state: "mastered")
-      .where.not(mastered_at: nil)
+      .where.not(first_mastered_at: nil)
       .joins(:dictionary_entry)
-      .select("dictionary_entries.text, user_learnings.mastered_at")
+      .select("dictionary_entries.text, user_learnings.first_mastered_at")
 
     # For each character find the earliest date it appeared in a mastered word
     char_first_mastered = {}
     mastered.each do |ul|
-      date = ul.mastered_at.to_date.to_s
+      date = ul.first_mastered_at.to_date.to_s
       ul.text.chars.each do |char|
         char_first_mastered[char] = date if char_first_mastered[char].nil? || date < char_first_mastered[char]
       end

--- a/app/models/user_learning.rb
+++ b/app/models/user_learning.rb
@@ -23,8 +23,11 @@ class UserLearning < ApplicationRecord
   private
 
   def set_mastered_at
-    if state_changed? && state == "mastered" && mastered_at.nil?
-      self.mastered_at = Time.current
+    if state_changed? && state == "mastered"
+      self.mastered_at ||= Time.current
+      # Durable "did this word ever graduate" fact — unlike mastered_at,
+      # never cleared on lapse. See #391.
+      self.first_mastered_at ||= mastered_at
     elsif state_changed? && state_was == "mastered"
       self.mastered_at = nil
     end

--- a/db/migrate/20260712102207_add_first_mastered_at_to_user_learnings.rb
+++ b/db/migrate/20260712102207_add_first_mastered_at_to_user_learnings.rb
@@ -1,0 +1,8 @@
+class AddFirstMasteredAtToUserLearnings < ActiveRecord::Migration[8.1]
+  def change
+    # Durable "did this word ever graduate, and when" — unlike mastered_at,
+    # never cleared on lapse. See #391.
+    add_column :user_learnings, :first_mastered_at, :datetime
+    add_index :user_learnings, :first_mastered_at
+  end
+end

--- a/db/migrate/20260712102217_backfill_first_mastered_at_from_review_logs.rb
+++ b/db/migrate/20260712102217_backfill_first_mastered_at_from_review_logs.rb
@@ -1,0 +1,36 @@
+class BackfillFirstMasteredAtFromReviewLogs < ActiveRecord::Migration[8.1]
+  # Mirrors SpacedRepetition::SM2#calculated_state's transition table
+  # (sm2.rb:56-68) — suspended is a manual override outside this table and
+  # is left untouched by review history.
+  TRANSITIONS = {
+    "new"      => { 1 => "learning", 2 => "learning", 3 => "learning", 4 => "learning" },
+    "learning" => { 1 => "learning", 2 => "learning", 3 => "mastered", 4 => "mastered" },
+    "mastered" => { 1 => "learning", 2 => "mastered", 3 => "mastered", 4 => "mastered" }
+  }.freeze
+
+  def up
+    UserLearning.find_each do |user_learning|
+      first_mastered_at = replay_first_mastered_at(user_learning)
+      user_learning.update_column(:first_mastered_at, first_mastered_at) if first_mastered_at
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def replay_first_mastered_at(user_learning)
+    state = "new"
+    user_learning.review_logs.order(:created_at).each do |log|
+      new_state = TRANSITIONS.dig(state, log.ease)
+      next if new_state.nil?
+
+      return log.created_at if new_state == "mastered" && state != "mastered"
+
+      state = new_state
+    end
+    nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_105039) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_102207) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -260,6 +260,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_105039) do
     t.datetime "created_at", null: false
     t.integer "dictionary_entry_id", null: false
     t.integer "factor", default: 2500, null: false
+    t.datetime "first_mastered_at"
     t.integer "last_interval"
     t.datetime "mastered_at"
     t.datetime "next_due"
@@ -267,6 +268,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_105039) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["dictionary_entry_id"], name: "index_user_learnings_on_dictionary_entry_id"
+    t.index ["first_mastered_at"], name: "index_user_learnings_on_first_mastered_at"
     t.index ["user_id", "dictionary_entry_id"], name: "index_user_learnings_on_user_and_entry", unique: true
     t.index ["user_id", "state"], name: "index_user_learnings_on_user_and_state"
     t.index ["user_id"], name: "index_user_learnings_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_102207) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_102217) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/docs/architecture/flashcard_session.md
+++ b/docs/architecture/flashcard_session.md
@@ -60,11 +60,12 @@ Starting values for new cards: `last_interval = 1`, `factor = 2500`.
 | Good   | max(1, last\_interval × factor ÷ 1000)        | unchanged             | advance¹     |
 | Easy   | Good interval × 1.3 easy bonus               | factor + 150          | → mastered   |
 
-¹ **State advancement on Good:**
+¹ **State advancement on Good:** depends on the card's state going into the
+review (`SpacedRepetition::SM2#calculated_state`, sm2.rb:56-68):
 - `new` → `learning` on first Good or Easy
-- `learning` → `mastered` on second consecutive Good or Easy (approximated by
-  `last_interval >= 2` after calculation — i.e. the card has graduated beyond the
-  minimum 1-day re-learning interval)
+- `learning` → `mastered` on a single Good or Easy — there is no
+  two-consecutive-rating requirement; one good rating is enough to graduate
+- `mastered` → `learning` on Again; stays `mastered` on Hard, Good, or Easy
 
 The `SpacedRepetition::SM2` service is a pure function: it takes a `UserLearning` and
 an ease integer, and returns new scheduling attributes. It has no side effects. The

--- a/spec/migrations/backfill_first_mastered_at_from_review_logs_spec.rb
+++ b/spec/migrations/backfill_first_mastered_at_from_review_logs_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260712102217_backfill_first_mastered_at_from_review_logs')
+
+# Tests for the BackfillFirstMasteredAtFromReviewLogs data migration.
+#
+# Replays each UserLearning's review_logs through the same new/learning/
+# mastered transition table as SpacedRepetition::SM2#calculated_state to
+# find the first learning -> mastered crossing, independent of the current
+# (possibly lapsed) state or the live mastered_at column. See #391.
+RSpec.describe "BackfillFirstMasteredAtFromReviewLogs migration" do
+  let(:migration) { BackfillFirstMasteredAtFromReviewLogs.new }
+  let(:user)      { create(:user) }
+
+  describe "#up" do
+    it "sets first_mastered_at to the timestamp of the graduating review" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 3.days.ago)
+      graduating_log = create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+    end
+
+    it "recovers first_mastered_at for a card that has since lapsed" do
+      # Graduated on the second review, relapsed on the third — mastered_at
+      # would already have been nulled by the live callback, so this is the
+      # only remaining source of truth for "was this ever mastered".
+      ul = create(:user_learning, user: user, state: "learning", mastered_at: nil)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 5.days.ago)
+      graduating_log = create(:review_log, user_learning: ul, ease: 4, created_at: 4.days.ago)
+      create(:review_log, user_learning: ul, ease: 1, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+    end
+
+    it "keeps the earliest graduation when a card graduates, relapses, and re-graduates" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 10.days.ago)
+      first_graduation = create(:review_log, user_learning: ul, ease: 3, created_at: 9.days.ago)
+      create(:review_log, user_learning: ul, ease: 1, created_at: 5.days.ago)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_within(1.second).of(first_graduation.created_at)
+    end
+
+    it "leaves first_mastered_at nil for a card that never graduated" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 1, created_at: 2.days.ago)
+      create(:review_log, user_learning: ul, ease: 2, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_nil
+    end
+
+    it "leaves first_mastered_at nil for a card with no review history" do
+      ul = create(:user_learning, user: user, state: "new")
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_nil
+    end
+  end
+end

--- a/spec/models/user_learning_spec.rb
+++ b/spec/models/user_learning_spec.rb
@@ -81,6 +81,43 @@ RSpec.describe UserLearning, type: :model do
     end
   end
 
+  describe 'first_mastered_at' do
+    it "sets first_mastered_at when state transitions to mastered" do
+      ul = create(:user_learning, user: user, state: "learning")
+      expect { ul.update!(state: "mastered") }
+        .to change { ul.first_mastered_at }.from(nil)
+    end
+
+    it "does not set first_mastered_at for non-mastered state transitions" do
+      ul = create(:user_learning, user: user, state: "new")
+      ul.update!(state: "learning")
+      expect(ul.first_mastered_at).to be_nil
+    end
+
+    it "does not overwrite first_mastered_at if already set" do
+      original = 5.days.ago
+      ul = create(:user_learning, user: user, state: "mastered", first_mastered_at: original)
+      ul.update!(factor: 2600)
+      expect(ul.first_mastered_at).to be_within(1.second).of(original)
+    end
+
+    it "does not clear first_mastered_at when state transitions away from mastered" do
+      ul = create(:user_learning, user: user, state: "mastered", mastered_at: 3.days.ago)
+      original = ul.first_mastered_at
+      ul.update!(state: "learning")
+      expect(ul.first_mastered_at).to be_within(1.second).of(original)
+    end
+
+    it "does not change first_mastered_at when re-mastered after a lapse" do
+      ul = create(:user_learning, user: user, state: "mastered", mastered_at: 3.days.ago)
+      original = ul.first_mastered_at
+      ul.update!(state: "learning")
+      expect { ul.update!(state: "mastered") }
+        .not_to change { ul.first_mastered_at }
+      expect(ul.first_mastered_at).to be_within(1.second).of(original)
+    end
+  end
+
   describe 'due-card scopes' do
     let!(:overdue_learning) do
       create(:user_learning, user: user, state: 'learning', next_due: 2.days.ago)

--- a/spec/requests/progress_spec.rb
+++ b/spec/requests/progress_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe "Progress", type: :request do
           get learn_progress_character_chart_data_path
           expect(parsed["series"].first["values"].last).to eq(2)
         end
+
+        it "keeps a lapsed word's characters counted (does not retroactively rewrite history)" do
+          lapsed_entry = create(:dictionary_entry, text: "学")
+          lapsed = create(:user_learning, user: user, state: "learning", dictionary_entry: lapsed_entry)
+          lapsed.update!(state: "mastered")
+          lapsed.update!(state: "learning")
+
+          get learn_progress_character_chart_data_path
+          expect(parsed["series"].first["values"].last).to eq(3)
+        end
       end
     end
   end
@@ -150,8 +160,22 @@ RSpec.describe "Progress", type: :request do
           expect(mastered["values"].last).to eq(1)
         end
 
-        it "excludes lapsed cards (state: learning with mastered_at set) from mastered count" do
-          # Simulate a card that was mastered then lapsed: mastered_at is set but state is learning
+        it "keeps a lapsed card in the mastered count (does not retroactively rewrite history)" do
+          # A card that graduated then lapsed still has first_mastered_at set,
+          # even though mastered_at (the live field) is cleared and state is
+          # no longer "mastered". The chart must not drop it. See #391.
+          lapsed = create(:user_learning, user: user, state: "learning")
+          lapsed.update!(state: "mastered")
+          lapsed.update!(state: "learning")
+
+          get learn_progress_chart_data_path
+          mastered = parsed["series"].find { |s| s["label"] == "Mastered" }
+          expect(mastered["values"].last).to eq(2)
+        end
+
+        it "excludes stale records with a leftover mastered_at but no first_mastered_at" do
+          # Data written before first_mastered_at existed, bypassing the
+          # model callback entirely — not a case the fix is expected to cover.
           create(:user_learning, user: user, state: "learning", mastered_at: 1.day.ago,
                  dictionary_entry: create(:dictionary_entry))
           get learn_progress_chart_data_path


### PR DESCRIPTION
## Summary

First slice of #391 (replace mastery `state` with Coverage + Trajectory
axes). Scoped deliberately to the foundation the rest of that issue
depends on, rather than the full two-facet model — the issue itself
leaves several thresholds and UI decisions open pending real review-count/
ease distributions, so this PR doesn't guess at those.

- Fixes the doc/code mismatch #391 called out:
  `docs/architecture/flashcard_session.md` claimed `learning → mastered`
  needs two consecutive Good ratings; the code
  (`SpacedRepetition::SM2#calculated_state`) advances on a single
  Good/Easy.
- Adds `first_mastered_at`: a durable "did this word ever graduate, and
  when" fact that, unlike `mastered_at`, is never cleared on lapse.
- Backfills `first_mastered_at` for existing data by replaying each
  word's `review_logs` through the same state-transition table SM2 uses,
  recovering history for words that already lapsed (and so already had
  `mastered_at` nulled) before this column existed.
- Fixes the `/progress` chart bug motivating the whole issue: both
  `chart_data` and `character_chart_data` filtered on
  `state == "mastered" && mastered_at`, so a single relapse retroactively
  lowered the "mastered" count at *every* past date, not just today.
  Keying on `first_mastered_at` instead makes the series monotonic again.

Left out of scope for a follow-up: the Coverage/Trajectory enums
themselves, their thresholds, and the two-panel `/progress` UI redesign
described in the issue.

## Test plan

- [x] `bundle exec rspec` — 1013 examples, 0 failures, 96.13% coverage
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings
- [x] New specs cover: the backfill migration's replay logic (graduation,
      lapse-then-recovery, relapse-then-regraduate, never-graduated,
      no-history cases), `first_mastered_at`'s persistence through lapse
      and re-mastery, and both `/progress` endpoints no longer dropping a
      lapsed word's historical contribution

Closes part of #391 (foundation only — Coverage/Trajectory UI is a
follow-up).

https://claude.ai/code/session_01Dxi5uYDffEFfwPr5mmo2Vy