### PR TITLE
feat: Coverage/Trajectory classification for #391

### DIFF
--- a/app/models/user_learning.rb
+++ b/app/models/user_learning.rb
@@ -28,6 +28,9 @@ class UserLearning < ApplicationRecord
       # Durable "did this word ever graduate" fact — unlike mastered_at,
       # never cleared on lapse. See #391.
       self.first_mastered_at ||= mastered_at
+      # Counts every crossing, unlike first_mastered_at which only records
+      # the first. Feeds Mastery::Trajectory's Chronic classification.
+      self.graduation_count += 1
     elsif state_changed? && state_was == "mastered"
       self.mastered_at = nil
     end

--- a/app/services/mastery/README.md
+++ b/app/services/mastery/README.md
@@ -30,8 +30,14 @@ before its trajectory means anything.
 |---|---|
 | `Chronic` | `graduation_count >= CHRONIC_MIN_GRADUATIONS` — graduated and relapsed more than once |
 | `Recovering` | graduated exactly once, currently lapsed (`state != "mastered"`) — hasn't relapsed a second time (yet) |
-| `Stalled` | never graduated, review count ≥ `STALLED_MIN_REVIEW_COUNT`, and the average ease over the last `STALLED_LOOKBACK_REVIEWS` reviews is ≤ `STALLED_MAX_RECENT_AVERAGE_EASE` |
+| `Stalled` | `coverage == Developing` (never graduated, review count ≥ `STALLED_MIN_REVIEW_COUNT` — see note below), and the average ease over the last `STALLED_LOOKBACK_REVIEWS` reviews is ≤ `STALLED_MAX_RECENT_AVERAGE_EASE` |
 | `Stable` | everything else: graduated once and still mastered, or still Developing but not flat/declining |
+
+`Mastery::Trajectory` does not take `review_count` itself and does not
+re-derive Coverage — it trusts the `coverage` the caller passes in. The
+`STALLED_MIN_REVIEW_COUNT` threshold is therefore only actually enforced
+when that `coverage` was computed via `Mastery::Coverage` in the first
+place; `Trajectory` on its own only ever checks `coverage == Developing`.
 
 ## Where the thresholds came from
 

--- a/app/services/mastery/README.md
+++ b/app/services/mastery/README.md
@@ -1,0 +1,80 @@
+# Mastery
+
+Derives two independent, read-only facets of a `UserLearning`'s history —
+**Coverage** (where a word sits right now) and **Trajectory** (the shape of
+its history) — as proposed in
+[#391](https://github.com/huwd/learn_hanzi/issues/391). Neither facet
+changes the SM-2 scheduler or the `state` column; both are computed from
+existing data.
+
+## Coverage
+
+`Unseen → Emerging → Developing → Established`, with `Suspended` as a
+manual override outside the sequence.
+
+| Bucket | Rule |
+|---|---|
+| `Suspended` | `state == "suspended"` |
+| `Unseen` | zero reviews |
+| `Established` | `first_mastered_at` present (has graduated at least once — durable, not cleared on lapse) |
+| `Emerging` | review count < `EMERGING_TO_DEVELOPING_REVIEW_COUNT` |
+| `Developing` | review count ≥ `EMERGING_TO_DEVELOPING_REVIEW_COUNT`, never graduated |
+
+## Trajectory
+
+`Stable / Recovering / Chronic / Stalled`, only meaningful for the
+`Developing` + `Established` population — a word needs enough history
+before its trajectory means anything.
+
+| Bucket | Rule |
+|---|---|
+| `Chronic` | `graduation_count >= CHRONIC_MIN_GRADUATIONS` — graduated and relapsed more than once |
+| `Recovering` | graduated exactly once, currently lapsed (`state != "mastered"`) — hasn't relapsed a second time (yet) |
+| `Stalled` | never graduated, review count ≥ `STALLED_MIN_REVIEW_COUNT`, and the average ease over the last `STALLED_LOOKBACK_REVIEWS` reviews is ≤ `STALLED_MAX_RECENT_AVERAGE_EASE` |
+| `Stable` | everything else: graduated once and still mastered, or still Developing but not flat/declining |
+
+## Where the thresholds came from
+
+Derived on 2026-07-12 from a real export of one user's 5,493-word
+learning history (`user_learnings` + full `review_logs`), not guessed in
+the abstract, per the issue's explicit requirement. Method: replay each
+word's `review_logs` in review-timestamp order through the same
+new → learning → mastered transition table `SpacedRepetition::SM2#calculated_state`
+uses, recording (a) the review index of the first `learning → mastered`
+crossing, and (b) the total number of such crossings.
+
+**`EMERGING_TO_DEVELOPING_REVIEW_COUNT = 5`**
+
+Review count at first graduation, across all 1,317 words that ever
+graduated: median 2, 90th percentile 5. So 90% of everything that ever
+graduates does so within 5 reviews — a word past that without graduating
+has moved from ordinary early-stage noise into something worth tracking
+separately. This also keeps the issue's own illustrative example ("a word
+with 3 reviews and low ease is normal Emerging noise") inside `Emerging`,
+not `Developing`.
+
+**`CHRONIC_MIN_GRADUATIONS = 2`**
+
+Taken directly from the issue text, not re-derived. Sanity-checked
+against the real data: 603 of 1,317 ever-graduated words (46%) have
+graduated ≥2 times — a large, meaningful population, confirming this
+isn't a rare edge case worth ignoring.
+
+**`STALLED_MIN_REVIEW_COUNT` / `STALLED_LOOKBACK_REVIEWS` / `STALLED_MAX_RECENT_AVERAGE_EASE`**
+
+Checked against the 29 words in the real dataset that were `Developing`
+(≥5 reviews, never graduated): every one of them had a last-3-review
+average ease ≤ 1.5 (most were long streaks of ease=1 "Again", e.g. a
+word with 47 reviews and 46 of them rated "Again"). Two candidate rules
+(last-review ease == 1; last-3-review average ≤ 1.5) produced identical
+results on the real data — the average was kept since it tolerates a
+single recent good rating without immediately reclassifying a word that
+may be turning around.
+
+## Re-deriving after real usage changes
+
+If review-count/ease distributions shift meaningfully (e.g. after many
+more months of data, or if SM-2's parameters change), re-run the same
+replay analysis against a fresh export rather than adjusting these
+numbers by feel. The methodology above is the reproducible part; the
+numbers in this file are a snapshot of one point-in-time analysis.

--- a/app/services/mastery/coverage.rb
+++ b/app/services/mastery/coverage.rb
@@ -22,8 +22,11 @@ module Mastery
 
     def call
       return SUSPENDED if @user_learning.state == "suspended"
-      return UNSEEN if @review_count.zero?
+      # first_mastered_at is the durable signal for Established and takes
+      # precedence over review_count, which the caller could pass scoped
+      # or stale.
       return ESTABLISHED if @user_learning.first_mastered_at.present?
+      return UNSEEN if @review_count.zero?
 
       @review_count < Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT ? EMERGING : DEVELOPING
     end

--- a/app/services/mastery/coverage.rb
+++ b/app/services/mastery/coverage.rb
@@ -1,0 +1,31 @@
+module Mastery
+  # Classifies where a word sits right now: Unseen -> Emerging -> Developing
+  # -> Established, with Suspended as a manual override outside that
+  # sequence. See README.md in this directory. #391.
+  class Coverage
+    UNSEEN      = "unseen"
+    EMERGING    = "emerging"
+    DEVELOPING  = "developing"
+    ESTABLISHED = "established"
+    SUSPENDED   = "suspended"
+
+    ALL = [ UNSEEN, EMERGING, DEVELOPING, ESTABLISHED, SUSPENDED ].freeze
+
+    def self.call(user_learning:, review_count:)
+      new(user_learning, review_count).call
+    end
+
+    def initialize(user_learning, review_count)
+      @user_learning = user_learning
+      @review_count = review_count
+    end
+
+    def call
+      return SUSPENDED if @user_learning.state == "suspended"
+      return UNSEEN if @review_count.zero?
+      return ESTABLISHED if @user_learning.first_mastered_at.present?
+
+      @review_count < Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT ? EMERGING : DEVELOPING
+    end
+  end
+end

--- a/app/services/mastery/thresholds.rb
+++ b/app/services/mastery/thresholds.rb
@@ -1,0 +1,27 @@
+module Mastery
+  # Configurable constants behind the Coverage/Trajectory classification
+  # (#391). See README.md in this directory for how each value was derived
+  # and how to re-derive it if the underlying learning data changes shape.
+  module Thresholds
+    # A word with fewer reviews than this and no graduation yet is
+    # "Emerging" (normal early-stage noise); at or above it, "Developing".
+    EMERGING_TO_DEVELOPING_REVIEW_COUNT = 5
+
+    # Number of distinct learning -> mastered crossings (UserLearning#graduation_count)
+    # at or above which a word is classified "Chronic".
+    CHRONIC_MIN_GRADUATIONS = 2
+
+    # A word can only be considered "Stalled" once it has at least this many
+    # reviews without ever graduating. Deliberately the same value as
+    # EMERGING_TO_DEVELOPING_REVIEW_COUNT: Stalled is a subset of Developing.
+    STALLED_MIN_REVIEW_COUNT = EMERGING_TO_DEVELOPING_REVIEW_COUNT
+
+    # How many of the most recent reviews to look at when checking whether
+    # a never-graduated word's ease has gone flat/declining.
+    STALLED_LOOKBACK_REVIEWS = 3
+
+    # A never-graduated word is "Stalled" when the average ease over its
+    # last STALLED_LOOKBACK_REVIEWS reviews is at or below this value.
+    STALLED_MAX_RECENT_AVERAGE_EASE = 1.5
+  end
+end

--- a/app/services/mastery/trajectory.rb
+++ b/app/services/mastery/trajectory.rb
@@ -29,7 +29,7 @@ module Mastery
       return NOT_APPLICABLE unless ELIGIBLE_COVERAGE.include?(@coverage)
       return CHRONIC if @user_learning.graduation_count >= Thresholds::CHRONIC_MIN_GRADUATIONS
       return RECOVERING if @user_learning.graduation_count == 1 && @user_learning.state != "mastered"
-      return STALLED if @user_learning.graduation_count.zero? && stalled?
+      return STALLED if @coverage == Coverage::DEVELOPING && stalled?
 
       STABLE
     end
@@ -37,7 +37,7 @@ module Mastery
     private
 
     def stalled?
-      return false if @recent_eases.empty?
+      return false if @recent_eases.size < Thresholds::STALLED_LOOKBACK_REVIEWS
 
       recent = @recent_eases.last(Thresholds::STALLED_LOOKBACK_REVIEWS)
       (recent.sum.to_f / recent.size) <= Thresholds::STALLED_MAX_RECENT_AVERAGE_EASE

--- a/app/services/mastery/trajectory.rb
+++ b/app/services/mastery/trajectory.rb
@@ -1,0 +1,46 @@
+module Mastery
+  # Classifies the shape of a word's history: Stable / Recovering / Chronic
+  # / Stalled. Only meaningful once a word has enough history — the caller
+  # supplies the word's Mastery::Coverage bucket, and this returns
+  # NOT_APPLICABLE for anything outside Developing/Established. See
+  # README.md in this directory. #391.
+  class Trajectory
+    STABLE         = "stable"
+    RECOVERING     = "recovering"
+    CHRONIC        = "chronic"
+    STALLED        = "stalled"
+    NOT_APPLICABLE = "not_applicable"
+
+    ALL = [ STABLE, RECOVERING, CHRONIC, STALLED, NOT_APPLICABLE ].freeze
+
+    ELIGIBLE_COVERAGE = [ Coverage::DEVELOPING, Coverage::ESTABLISHED ].freeze
+
+    def self.call(user_learning:, coverage:, recent_eases:)
+      new(user_learning, coverage, recent_eases).call
+    end
+
+    def initialize(user_learning, coverage, recent_eases)
+      @user_learning = user_learning
+      @coverage = coverage
+      @recent_eases = recent_eases
+    end
+
+    def call
+      return NOT_APPLICABLE unless ELIGIBLE_COVERAGE.include?(@coverage)
+      return CHRONIC if @user_learning.graduation_count >= Thresholds::CHRONIC_MIN_GRADUATIONS
+      return RECOVERING if @user_learning.graduation_count == 1 && @user_learning.state != "mastered"
+      return STALLED if @user_learning.graduation_count.zero? && stalled?
+
+      STABLE
+    end
+
+    private
+
+    def stalled?
+      return false if @recent_eases.empty?
+
+      recent = @recent_eases.last(Thresholds::STALLED_LOOKBACK_REVIEWS)
+      (recent.sum.to_f / recent.size) <= Thresholds::STALLED_MAX_RECENT_AVERAGE_EASE
+    end
+  end
+end

--- a/db/migrate/20260712104949_add_graduation_count_to_user_learnings.rb
+++ b/db/migrate/20260712104949_add_graduation_count_to_user_learnings.rb
@@ -1,0 +1,10 @@
+class AddGraduationCountToUserLearnings < ActiveRecord::Migration[8.1]
+  def change
+    # Durable count of learning -> mastered crossings, incremented on every
+    # such transition and never decremented. Lets Mastery::Trajectory
+    # classify "Chronic" (>=2 crossings) without replaying full review
+    # history per word on every request. See #391 and
+    # app/services/mastery/README.md.
+    add_column :user_learnings, :graduation_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260712104951_backfill_graduation_count_from_review_logs.rb
+++ b/db/migrate/20260712104951_backfill_graduation_count_from_review_logs.rb
@@ -24,7 +24,11 @@ class BackfillGraduationCountFromReviewLogs < ActiveRecord::Migration[8.1]
   def graduation_count(user_learning)
     state = "new"
     count = 0
-    user_learning.review_logs.order(:created_at).each do |log|
+    # created_at alone isn't a stable order: Anki-imported logs from the
+    # same import batch commonly share one created_at, with the actual
+    # review order captured in `time` (an Anki epoch-ms timestamp) instead.
+    # `id` is a final tiebreaker for the rare case both are equal.
+    user_learning.review_logs.order(:created_at, :time, :id).each do |log|
       new_state = TRANSITIONS.dig(state, log.ease)
       next if new_state.nil?
 

--- a/db/migrate/20260712104951_backfill_graduation_count_from_review_logs.rb
+++ b/db/migrate/20260712104951_backfill_graduation_count_from_review_logs.rb
@@ -1,0 +1,36 @@
+class BackfillGraduationCountFromReviewLogs < ActiveRecord::Migration[8.1]
+  # Mirrors SpacedRepetition::SM2#calculated_state's transition table
+  # (sm2.rb:56-68), same as BackfillFirstMasteredAtFromReviewLogs — counts
+  # every learning -> mastered crossing rather than stopping at the first.
+  TRANSITIONS = {
+    "new"      => { 1 => "learning", 2 => "learning", 3 => "learning", 4 => "learning" },
+    "learning" => { 1 => "learning", 2 => "learning", 3 => "mastered", 4 => "mastered" },
+    "mastered" => { 1 => "learning", 2 => "mastered", 3 => "mastered", 4 => "mastered" }
+  }.freeze
+
+  def up
+    UserLearning.find_each do |user_learning|
+      count = graduation_count(user_learning)
+      user_learning.update_column(:graduation_count, count) if count.positive?
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def graduation_count(user_learning)
+    state = "new"
+    count = 0
+    user_learning.review_logs.order(:created_at).each do |log|
+      new_state = TRANSITIONS.dig(state, log.ease)
+      next if new_state.nil?
+
+      count += 1 if new_state == "mastered" && state != "mastered"
+      state = new_state
+    end
+    count
+  end
+end

--- a/db/migrate/20260712120454_recompute_first_mastered_at_with_stable_replay_order.rb
+++ b/db/migrate/20260712120454_recompute_first_mastered_at_with_stable_replay_order.rb
@@ -1,0 +1,46 @@
+class RecomputeFirstMasteredAtWithStableReplayOrder < ActiveRecord::Migration[8.1]
+  # BackfillFirstMasteredAtFromReviewLogs (20260712102217, already merged
+  # and deployed) replayed review_logs ordered by created_at alone. That's
+  # not a stable order when logs share created_at, which batch-imported
+  # Anki logs commonly do (confirmed against a real export: ~15% of words
+  # have at least one such tie). Recompute with the corrected order —
+  # created_at, then the Anki epoch-ms `time`, then `id` as a final
+  # tiebreaker — same as BackfillGraduationCountFromReviewLogs
+  # (20260712104951). See #391 PR #395 review discussion.
+  #
+  # Measured impact on the real dataset this was checked against: 2 of
+  # 5,493 words had a different first_mastered_at under the old ordering;
+  # none had their presence (nil vs set) flip. This migration is a
+  # precision correction, not a data-integrity emergency.
+  TRANSITIONS = {
+    "new"      => { 1 => "learning", 2 => "learning", 3 => "learning", 4 => "learning" },
+    "learning" => { 1 => "learning", 2 => "learning", 3 => "mastered", 4 => "mastered" },
+    "mastered" => { 1 => "learning", 2 => "mastered", 3 => "mastered", 4 => "mastered" }
+  }.freeze
+
+  def up
+    UserLearning.find_each do |user_learning|
+      first_mastered_at = replay_first_mastered_at(user_learning)
+      user_learning.update_column(:first_mastered_at, first_mastered_at) if first_mastered_at
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def replay_first_mastered_at(user_learning)
+    state = "new"
+    user_learning.review_logs.order(:created_at, :time, :id).each do |log|
+      new_state = TRANSITIONS.dig(state, log.ease)
+      next if new_state.nil?
+
+      return log.created_at if new_state == "mastered" && state != "mastered"
+
+      state = new_state
+    end
+    nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_102217) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_104949) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -261,6 +261,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_102217) do
     t.integer "dictionary_entry_id", null: false
     t.integer "factor", default: 2500, null: false
     t.datetime "first_mastered_at"
+    t.integer "graduation_count", default: 0, null: false
     t.integer "last_interval"
     t.datetime "mastered_at"
     t.datetime "next_due"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_104951) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_120454) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_104949) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_104951) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/spec/migrations/backfill_graduation_count_from_review_logs_spec.rb
+++ b/spec/migrations/backfill_graduation_count_from_review_logs_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260712104951_backfill_graduation_count_from_review_logs')
+
+# Tests for the BackfillGraduationCountFromReviewLogs data migration.
+#
+# Counts every learning -> mastered crossing in a word's review history,
+# independent of the current (possibly lapsed) state. Feeds
+# Mastery::Trajectory's Chronic classification. See #391.
+RSpec.describe "BackfillGraduationCountFromReviewLogs migration" do
+  let(:migration) { BackfillGraduationCountFromReviewLogs.new }
+  let(:user)      { create(:user) }
+
+  describe "#up" do
+    it "counts a single graduation" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.graduation_count).to eq(1)
+    end
+
+    it "counts multiple graduations across relapses" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 10.days.ago) # -> learning
+      create(:review_log, user_learning: ul, ease: 3, created_at: 9.days.ago)  # -> mastered (1st)
+      create(:review_log, user_learning: ul, ease: 1, created_at: 5.days.ago)  # -> learning
+      create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)   # -> mastered (2nd)
+
+      migration.up
+
+      expect(ul.reload.graduation_count).to eq(2)
+    end
+
+    it "leaves graduation_count at zero for a word that never graduated" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 1, created_at: 2.days.ago)
+      create(:review_log, user_learning: ul, ease: 2, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.graduation_count).to eq(0)
+    end
+
+    it "leaves graduation_count at zero for a word with no review history" do
+      ul = create(:user_learning, user: user, state: "new")
+
+      migration.up
+
+      expect(ul.reload.graduation_count).to eq(0)
+    end
+  end
+end

--- a/spec/migrations/backfill_graduation_count_from_review_logs_spec.rb
+++ b/spec/migrations/backfill_graduation_count_from_review_logs_spec.rb
@@ -50,5 +50,24 @@ RSpec.describe "BackfillGraduationCountFromReviewLogs migration" do
 
       expect(ul.reload.graduation_count).to eq(0)
     end
+
+    it "orders by time (not insertion order) when created_at ties, as with a batch Anki import" do
+      # All four logs share created_at, as a batch-imported Anki import
+      # would. Inserted in reverse chronological order (by `time`) so that
+      # falling back to created_at/id order alone would replay them
+      # backwards and silently under-count graduations.
+      ul = create(:user_learning, user: user, state: "learning")
+      same_created_at = 1.day.ago
+      create(:review_log, user_learning: ul, ease: 3, time: 4000, created_at: same_created_at) # true order: 4th
+      create(:review_log, user_learning: ul, ease: 1, time: 3000, created_at: same_created_at) # true order: 3rd
+      create(:review_log, user_learning: ul, ease: 3, time: 2000, created_at: same_created_at) # true order: 2nd
+      create(:review_log, user_learning: ul, ease: 1, time: 1000, created_at: same_created_at) # true order: 1st
+
+      migration.up
+
+      # Correct time order [1, 3, 1, 3]: new->learning->mastered->learning->mastered = 2 graduations.
+      # Naive created_at/insertion order [3, 1, 3, 1]: new->learning->learning->mastered->learning = 1.
+      expect(ul.reload.graduation_count).to eq(2)
+    end
   end
 end

--- a/spec/migrations/recompute_first_mastered_at_with_stable_replay_order_spec.rb
+++ b/spec/migrations/recompute_first_mastered_at_with_stable_replay_order_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260712120454_recompute_first_mastered_at_with_stable_replay_order')
+
+# Tests for the RecomputeFirstMasteredAtWithStableReplayOrder migration.
+#
+# Corrects first_mastered_at values computed by the original backfill
+# (20260712102217), which ordered review_logs by created_at alone --
+# nondeterministic when logs share it, as batch-imported Anki logs
+# commonly do. See #391 PR #395 review discussion.
+RSpec.describe "RecomputeFirstMasteredAtWithStableReplayOrder migration" do
+  let(:migration) { RecomputeFirstMasteredAtWithStableReplayOrder.new }
+  let(:user)      { create(:user) }
+
+  describe "#up" do
+    it "recomputes first_mastered_at ordered by time when created_at ties" do
+      # Two logs share created_at (batch A, as a batch Anki import would),
+      # inserted in reverse-chronological (by `time`) order so a naive
+      # created_at/id fallback replays them backwards. In true time order
+      # batch A never crosses into mastered (new->learning->learning); in
+      # naive insertion order it wrongly does (new->learning->mastered),
+      # producing a different (and earlier, wrong) first_mastered_at than
+      # the real graduation in the distinctly-timestamped batch B below.
+      ul = create(:user_learning, user: user, state: "mastered", first_mastered_at: nil)
+      batch_a_created_at = 2.days.ago
+      create(:review_log, user_learning: ul, ease: 1, time: 2000, created_at: batch_a_created_at) # true order: 2nd
+      create(:review_log, user_learning: ul, ease: 3, time: 1000, created_at: batch_a_created_at) # true order: 1st
+      graduating_log = create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+    end
+
+    it "leaves an already-correct first_mastered_at unchanged" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago)
+      graduating_log = create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+    end
+
+    it "leaves first_mastered_at nil for a card that never graduated" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 1, created_at: 2.days.ago)
+
+      migration.up
+
+      expect(ul.reload.first_mastered_at).to be_nil
+    end
+  end
+end

--- a/spec/models/user_learning_spec.rb
+++ b/spec/models/user_learning_spec.rb
@@ -118,6 +118,34 @@ RSpec.describe UserLearning, type: :model do
     end
   end
 
+  describe 'graduation_count' do
+    it "increments graduation_count when state transitions to mastered" do
+      ul = create(:user_learning, user: user, state: "learning")
+      expect { ul.update!(state: "mastered") }
+        .to change { ul.graduation_count }.from(0).to(1)
+    end
+
+    it "does not increment graduation_count for non-mastered state transitions" do
+      ul = create(:user_learning, user: user, state: "new")
+      ul.update!(state: "learning")
+      expect(ul.graduation_count).to eq(0)
+    end
+
+    it "does not increment graduation_count on saves that don't change state" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      expect { ul.update!(factor: 2600) }
+        .not_to change { ul.graduation_count }
+    end
+
+    it "increments again on each re-mastery after a lapse, unlike first_mastered_at" do
+      ul = create(:user_learning, user: user, state: "learning")
+      ul.update!(state: "mastered")
+      ul.update!(state: "learning")
+      expect { ul.update!(state: "mastered") }
+        .to change { ul.graduation_count }.from(1).to(2)
+    end
+  end
+
   describe 'due-card scopes' do
     let!(:overdue_learning) do
       create(:user_learning, user: user, state: 'learning', next_due: 2.days.ago)

--- a/spec/services/mastery/coverage_spec.rb
+++ b/spec/services/mastery/coverage_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Mastery::Coverage do
+  def user_learning(state: "new", first_mastered_at: nil)
+    instance_double(UserLearning, state: state, first_mastered_at: first_mastered_at)
+  end
+
+  describe ".call" do
+    subject(:coverage) { described_class.call(user_learning: ul, review_count: review_count) }
+
+    context "when suspended, regardless of review count or history" do
+      let(:ul) { user_learning(state: "suspended", first_mastered_at: 2.days.ago) }
+      let(:review_count) { 10 }
+
+      it { is_expected.to eq(Mastery::Coverage::SUSPENDED) }
+    end
+
+    context "with zero reviews" do
+      let(:ul) { user_learning(state: "new") }
+      let(:review_count) { 0 }
+
+      it { is_expected.to eq(Mastery::Coverage::UNSEEN) }
+    end
+
+    context "when first_mastered_at is present" do
+      let(:ul) { user_learning(state: "learning", first_mastered_at: 5.days.ago) }
+      let(:review_count) { 20 }
+
+      it "is Established even though it has since lapsed" do
+        expect(coverage).to eq(Mastery::Coverage::ESTABLISHED)
+      end
+    end
+
+    context "when never graduated and below the threshold" do
+      let(:ul) { user_learning(state: "learning") }
+      let(:review_count) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT - 1 }
+
+      it { is_expected.to eq(Mastery::Coverage::EMERGING) }
+    end
+
+    context "when never graduated and at or above the threshold" do
+      let(:ul) { user_learning(state: "learning") }
+      let(:review_count) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+      it { is_expected.to eq(Mastery::Coverage::DEVELOPING) }
+    end
+  end
+end

--- a/spec/services/mastery/coverage_spec.rb
+++ b/spec/services/mastery/coverage_spec.rb
@@ -44,5 +44,14 @@ RSpec.describe Mastery::Coverage do
 
       it { is_expected.to eq(Mastery::Coverage::DEVELOPING) }
     end
+
+    context "when first_mastered_at is present but review_count is inconsistently zero" do
+      # first_mastered_at is the durable signal; a scoped or stale
+      # review_count passed by the caller must not override it.
+      let(:ul) { user_learning(state: "mastered", first_mastered_at: 5.days.ago) }
+      let(:review_count) { 0 }
+
+      it { is_expected.to eq(Mastery::Coverage::ESTABLISHED) }
+    end
   end
 end

--- a/spec/services/mastery/trajectory_spec.rb
+++ b/spec/services/mastery/trajectory_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe Mastery::Trajectory do
+  def user_learning(state: "learning", graduation_count: 0)
+    instance_double(UserLearning, state: state, graduation_count: graduation_count)
+  end
+
+  describe ".call" do
+    subject(:trajectory) do
+      described_class.call(user_learning: ul, coverage: coverage, recent_eases: recent_eases)
+    end
+
+    let(:recent_eases) { [] }
+
+    context "when coverage is Unseen, Emerging, or Suspended" do
+      let(:ul) { user_learning }
+
+      [ Mastery::Coverage::UNSEEN, Mastery::Coverage::EMERGING, Mastery::Coverage::SUSPENDED ].each do |ineligible|
+        context "with coverage #{ineligible}" do
+          let(:coverage) { ineligible }
+
+          it { is_expected.to eq(Mastery::Trajectory::NOT_APPLICABLE) }
+        end
+      end
+    end
+
+    context "when graduated twice or more" do
+      let(:ul) { user_learning(state: "mastered", graduation_count: 2) }
+      let(:coverage) { Mastery::Coverage::ESTABLISHED }
+
+      it { is_expected.to eq(Mastery::Trajectory::CHRONIC) }
+    end
+
+    context "when graduated once and currently lapsed" do
+      let(:ul) { user_learning(state: "learning", graduation_count: 1) }
+      let(:coverage) { Mastery::Coverage::ESTABLISHED }
+
+      it { is_expected.to eq(Mastery::Trajectory::RECOVERING) }
+    end
+
+    context "when graduated once and still mastered" do
+      let(:ul) { user_learning(state: "mastered", graduation_count: 1) }
+      let(:coverage) { Mastery::Coverage::ESTABLISHED }
+
+      it { is_expected.to eq(Mastery::Trajectory::STABLE) }
+    end
+
+    context "when never graduated with a flat/declining recent ease trend" do
+      let(:ul) { user_learning(state: "learning", graduation_count: 0) }
+      let(:coverage) { Mastery::Coverage::DEVELOPING }
+      let(:recent_eases) { [ 1, 1, 1, 1, 1 ] }
+
+      it { is_expected.to eq(Mastery::Trajectory::STALLED) }
+    end
+
+    context "when never graduated but recent eases are improving" do
+      let(:ul) { user_learning(state: "learning", graduation_count: 0) }
+      let(:coverage) { Mastery::Coverage::DEVELOPING }
+      let(:recent_eases) { [ 1, 1, 3, 3, 4 ] }
+
+      it { is_expected.to eq(Mastery::Trajectory::STABLE) }
+    end
+
+    context "when never graduated and no recent eases are supplied" do
+      let(:ul) { user_learning(state: "learning", graduation_count: 0) }
+      let(:coverage) { Mastery::Coverage::DEVELOPING }
+      let(:recent_eases) { [] }
+
+      it "does not misclassify as Stalled without data" do
+        expect(trajectory).to eq(Mastery::Trajectory::STABLE)
+      end
+    end
+
+    it "only looks at the last STALLED_LOOKBACK_REVIEWS eases" do
+      ul = user_learning(state: "learning", graduation_count: 0)
+      # An old bad streak followed by a recent improving run should not
+      # count as stalled once enough recent reviews have gone well.
+      eases = [ 1, 1, 1, 1, 1, 4, 4, 4 ]
+      result = described_class.call(user_learning: ul, coverage: Mastery::Coverage::DEVELOPING, recent_eases: eases)
+      expect(result).to eq(Mastery::Trajectory::STABLE)
+    end
+  end
+end

--- a/spec/services/mastery/trajectory_spec.rb
+++ b/spec/services/mastery/trajectory_spec.rb
@@ -79,5 +79,27 @@ RSpec.describe Mastery::Trajectory do
       result = described_class.call(user_learning: ul, coverage: Mastery::Coverage::DEVELOPING, recent_eases: eases)
       expect(result).to eq(Mastery::Trajectory::STABLE)
     end
+
+    context "when coverage is Established but graduation_count is inconsistently zero" do
+      # Established comes from first_mastered_at, graduation_count is a
+      # separate column — they should never disagree, but Stalled must not
+      # fire for Established regardless, since Stalled only makes sense for
+      # a word that has never graduated.
+      let(:ul) { user_learning(state: "mastered", graduation_count: 0) }
+      let(:coverage) { Mastery::Coverage::ESTABLISHED }
+      let(:recent_eases) { [ 1, 1, 1 ] }
+
+      it { is_expected.to eq(Mastery::Trajectory::STABLE) }
+    end
+
+    context "when never graduated but fewer than STALLED_LOOKBACK_REVIEWS eases are supplied" do
+      let(:ul) { user_learning(state: "learning", graduation_count: 0) }
+      let(:coverage) { Mastery::Coverage::DEVELOPING }
+      let(:recent_eases) { [ 1, 1 ] }
+
+      it "does not classify Stalled from a single bad rating" do
+        expect(trajectory).to eq(Mastery::Trajectory::STABLE)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Second slice of #391, built on the foundation from #394. Implements the
Coverage and Trajectory classifiers (Option 3 from the issue) as derived,
tested services -- no `/progress` UI changes yet, which stays a separate
follow-up since the issue itself describes the two-panel layout as "not
designed."

- **`app/services/mastery/`** -- a new module holding the classification
  logic and its configuration, so both are easy to find and re-derive
  later rather than scattered as inline magic numbers:
  - `thresholds.rb` -- the numeric constants
    (`EMERGING_TO_DEVELOPING_REVIEW_COUNT`, `CHRONIC_MIN_GRADUATIONS`,
    the Stalled ease-trend cutoffs)
  - `README.md` -- documents the real-data analysis behind each value
    and how to re-derive them later
  - `coverage.rb` / `trajectory.rb` -- the classifiers themselves

- **Threshold derivation**: rather than guess, as the issue explicitly
  warns against, the thresholds were derived from a real 5,493-word
  export of production review history, replayed through the same
  new/learning/mastered transition table
  `SpacedRepetition::SM2#calculated_state` uses. Full methodology and
  numbers are in the README. Notably: 46% of words that ever graduated
  (603 of 1,317) have relapsed and regraduated at least once -- the
  exact blind spot this issue exists to surface.

- **`graduation_count`**: a new durable counter column (+ backfill
  migration using the same replay technique as `first_mastered_at`),
  incremented on every learning -> mastered crossing. Needed so
  `Mastery::Trajectory` can classify Chronic (>=2 crossings) without
  replaying full review history per word on every request -- the same
  store-vs-recompute tradeoff the issue already decided for
  `first_mastered_at`, applied consistently.

- **`Mastery::Coverage`**: Unseen -> Emerging -> Developing ->
  Established, with Suspended as a manual override. Established is keyed
  on `first_mastered_at` so it's genuinely monotonic, matching the
  `/progress` chart fix from the foundation PR.

- **`Mastery::Trajectory`**: Stable / Recovering / Chronic / Stalled,
  restricted to the Developing+Established population. Takes the
  caller's already-computed Coverage bucket as input rather than
  re-deriving it, so an Emerging word can never be silently mislabelled
  by this class alone.

Both classifiers were verified against the real export directly (not
just unit tests against fabricated data) -- the shipped Ruby code
reproduces the exact distribution documented in the README.

## Test plan

- [x] `bundle exec rspec` -- 1036 examples, 0 failures, 96.21% coverage
- [x] `bin/rubocop` -- no offenses
- [x] `bin/brakeman --no-pager` -- no warnings
- [x] New specs cover: `graduation_count`'s persistence/increment
      behaviour, the backfill migration's replay logic, and both
      classifiers' full decision tables including edge cases (no data
      supplied, old bad streak followed by recent improvement, etc.)
- [x] Ran the real 5,493-word export through the shipped classes via
      `bin/rails runner` and confirmed the output matches the README's
      documented numbers exactly

Still open for a follow-up: the two-panel `/progress` UI redesign
(Coverage stacked-area + Trajectory breakdown) described in the issue.

Closes part of #391 (classification only -- UI is a follow-up).

https://claude.ai/code/session_01Dxi5uYDffEFfwPr5mmo2Vy