### PR TITLE
fix: unbreak Docker build broken by APP_HOST requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,10 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+# or the real APP_HOST (config.hosts is only exercised when serving requests,
+# not during asset compilation).
+RUN SECRET_KEY_BASE_DUMMY=1 APP_HOST=assets-precompile.invalid \
+    ./bin/rails assets:precompile
 
 
 


### PR DESCRIPTION
## Summary
- The `publish` job on `main` has been failing since 6fcbc19 ("fix: enable Host Authorization in production"): `config/environments/production.rb` does `ENV.fetch("APP_HOST")` with no default, and that line runs whenever the production environment config loads — including during `assets:precompile` in the Docker build, which happens in CI before `APP_HOST` exists (it's only set later, at runtime, in the Portainer stack env).
- Fix: give the `assets:precompile` build step a dummy `APP_HOST`, the same way it already gets a dummy `SECRET_KEY_BASE`. Asset compilation never serves an HTTP request, so `config.hosts` validation just needs a present value, not a real one.

Failing run: https://github.com/huwd/learn_hanzi/actions/runs/29192164162/job/86648669736

## Test plan
- [x] `docker build --build-arg RUBY_VERSION=$(cat .ruby-version) --target build .` succeeds locally (previously failed with `KeyError: key not found: "APP_HOST"` at the `assets:precompile` step)
- [ ] CI `publish` job goes green on merge to `main`