### PR TITLE
feat: rebuild /progress with Coverage, Trajectory, characters

### DIFF
--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -21,8 +21,14 @@ class ProgressController < ApplicationController
     developing_at = Current.user.user_learnings.where.not(developing_at: nil).pluck(:id, :developing_at).to_h
     established_at = Current.user.user_learnings.where.not(first_mastered_at: nil).pluck(:id, :first_mastered_at).to_h
 
-    milestones = emerging_at.each_with_object({}) do |(id, t), memo|
-      memo[id] = { established: established_at[id], developing: developing_at[id], emerging: t }
+    # Union of ids across all three, not just emerging_at's -- every
+    # current code path only ever sets first_mastered_at/developing_at
+    # alongside review history, but Mastery::Coverage treats
+    # first_mastered_at as authoritative regardless of review count, so
+    # this must not silently disagree if that invariant ever drifts.
+    all_ids = emerging_at.keys | developing_at.keys | established_at.keys
+    milestones = all_ids.index_with do |id|
+      { established: established_at[id], developing: developing_at[id], emerging: emerging_at[id] }
     end
 
     timeline = Mastery::CoverageTimeline.call(
@@ -53,18 +59,28 @@ class ProgressController < ApplicationController
       .group(:user_learning_id)
       .minimum(:created_at)
 
-    # Scoped to touched words only -- most users have far more Unseen
-    # (never-reviewed) words than touched ones (74% in the real dataset
-    # behind #391), and an Unseen word can never contribute a character.
+    established_ids = Current.user.user_learnings.where.not(first_mastered_at: nil).pluck(:id)
+
+    # Scoped to touched-or-established words only -- most users have far
+    # more Unseen (never-reviewed) words than touched ones (74% in the
+    # real dataset behind #391), and an Unseen word can never contribute
+    # a character. established_ids is unioned in defensively: every
+    # current code path only ever sets first_mastered_at alongside review
+    # history, but this must not silently drop a word's characters if
+    # that invariant ever drifts.
     words = Current.user.user_learnings
-      .where(id: emerging_at.keys)
+      .where(id: emerging_at.keys | established_ids)
       .joins(:dictionary_entry)
       .pluck(:id, "dictionary_entries.text", :first_mastered_at)
 
     char_touched = {}
     char_established = {}
     words.each do |id, text, established_at|
-      touched_at = emerging_at[id]
+      # Falls back to established_at (the best still-known date) when a
+      # word's review history is missing -- it must have been touched at
+      # or before its own establishment.
+      touched_at = emerging_at[id] || established_at
+      next unless touched_at
 
       text.chars.each do |char|
         char_touched[char] = touched_at if char_touched[char].nil? || touched_at < char_touched[char]

--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -47,21 +47,24 @@ class ProgressController < ApplicationController
   # graduates; Touched from its earliest containing word's first review.
   # See #391, app/services/mastery/README.md.
   def character_chart_data
-    words = Current.user.user_learnings
-      .joins(:dictionary_entry)
-      .pluck(:id, "dictionary_entries.text", :first_mastered_at)
-
     emerging_at = ReviewLog
       .joins(:user_learning)
       .where(user_learnings: { user: Current.user })
       .group(:user_learning_id)
       .minimum(:created_at)
 
+    # Scoped to touched words only -- most users have far more Unseen
+    # (never-reviewed) words than touched ones (74% in the real dataset
+    # behind #391), and an Unseen word can never contribute a character.
+    words = Current.user.user_learnings
+      .where(id: emerging_at.keys)
+      .joins(:dictionary_entry)
+      .pluck(:id, "dictionary_entries.text", :first_mastered_at)
+
     char_touched = {}
     char_established = {}
     words.each do |id, text, established_at|
       touched_at = emerging_at[id]
-      next unless touched_at
 
       text.chars.each do |char|
         char_touched[char] = touched_at if char_touched[char].nil? || touched_at < char_touched[char]

--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -1,78 +1,90 @@
 class ProgressController < ApplicationController
   def show
+    # Rendered directly (no JSON endpoint/chart library needed) -- a live
+    # snapshot over a small population, cheap enough to compute inline.
+    # See #391.
+    @trajectory = Mastery::TrajectorySnapshot.call(user: Current.user)
   end
 
-  def chart_data
-    first_review_by_card = ReviewLog
+  # Weekly stacked-area trend: each word is bucketed by the furthest
+  # Coverage tier it had reached as of that week (Established durable via
+  # first_mastered_at, Developing via developing_at, Emerging via first
+  # review date) -- genuinely monotonic in total, replacing the old
+  # single volatile "mastered" line. See #391.
+  def coverage_chart_data
+    emerging_at = ReviewLog
       .joins(:user_learning)
       .where(user_learnings: { user: Current.user })
       .group(:user_learning_id)
-      .minimum("review_logs.created_at")
+      .minimum(:created_at)
 
-    learning_per_day = first_review_by_card.values
-      .group_by { |dt| dt.to_date.to_s }
-      .transform_values(&:count)
+    developing_at = Current.user.user_learnings.where.not(developing_at: nil).pluck(:id, :developing_at).to_h
+    established_at = Current.user.user_learnings.where.not(first_mastered_at: nil).pluck(:id, :first_mastered_at).to_h
 
-    # Keyed on first_mastered_at (durable, never cleared on lapse) rather
-    # than state/mastered_at, so a later lapse doesn't retroactively lower
-    # this count at every date since the original mastery. See #391.
-    mastered_per_day = Current.user.user_learnings
-      .where.not(first_mastered_at: nil)
-      .group("date(first_mastered_at)")
-      .order("date(first_mastered_at)")
-      .count
-
-    all_dates = (learning_per_day.keys + mastered_per_day.keys).uniq.sort
-
-    cumulative_learning = 0
-    cumulative_mastered = 0
-    mastered_values = []
-    in_progress_values = []
-
-    all_dates.each do |date|
-      cumulative_learning += learning_per_day[date] || 0
-      cumulative_mastered += mastered_per_day[date] || 0
-      mastered_values << cumulative_mastered
-      in_progress_values << [ cumulative_learning - cumulative_mastered, 0 ].max
+    milestones = emerging_at.each_with_object({}) do |(id, t), memo|
+      memo[id] = { established: established_at[id], developing: developing_at[id], emerging: t }
     end
 
+    timeline = Mastery::CoverageTimeline.call(
+      milestones: milestones,
+      tiers: [ :established, :developing, :emerging ]
+    )
+
     render json: {
-      labels: all_dates,
+      labels: timeline[:labels],
       series: [
-        { label: "Mastered",     color: "rgb(34, 197, 94)",  values: mastered_values },
-        { label: "In progress",  color: "rgb(245, 158, 11)", values: in_progress_values }
+        { label: "Established", color: "rgb(67, 56, 202)",   values: timeline[:series][:established] },
+        { label: "Developing",  color: "rgb(99, 102, 241)",  values: timeline[:series][:developing] },
+        { label: "Emerging",    color: "rgb(165, 180, 252)", values: timeline[:series][:emerging] }
       ]
     }
   end
 
+  # Two tiers, not four: a character isn't reviewed directly, and the real
+  # data behind #391 showed no natural Emerging/Developing split at the
+  # character level (median distinct-word-touch-count at establishment is
+  # 1). A character is Established the moment any containing word
+  # graduates; Touched from its earliest containing word's first review.
+  # See #391, app/services/mastery/README.md.
   def character_chart_data
-    # Keyed on first_mastered_at (durable, never cleared on lapse) rather
-    # than state/mastered_at, so a later lapse doesn't drop the word's
-    # characters out of this count. See #391.
-    mastered = Current.user.user_learnings
-      .where.not(first_mastered_at: nil)
+    words = Current.user.user_learnings
       .joins(:dictionary_entry)
-      .select("dictionary_entries.text, user_learnings.first_mastered_at")
+      .pluck(:id, "dictionary_entries.text", :first_mastered_at)
 
-    # For each character find the earliest date it appeared in a mastered word
-    char_first_mastered = {}
-    mastered.each do |ul|
-      date = ul.first_mastered_at.to_date.to_s
-      ul.text.chars.each do |char|
-        char_first_mastered[char] = date if char_first_mastered[char].nil? || date < char_first_mastered[char]
+    emerging_at = ReviewLog
+      .joins(:user_learning)
+      .where(user_learnings: { user: Current.user })
+      .group(:user_learning_id)
+      .minimum(:created_at)
+
+    char_touched = {}
+    char_established = {}
+    words.each do |id, text, established_at|
+      touched_at = emerging_at[id]
+      next unless touched_at
+
+      text.chars.each do |char|
+        char_touched[char] = touched_at if char_touched[char].nil? || touched_at < char_touched[char]
+        next unless established_at
+
+        char_established[char] = established_at if char_established[char].nil? || established_at < char_established[char]
       end
     end
 
-    per_day = char_first_mastered.values.tally
-    all_dates = per_day.keys.sort
+    milestones = char_touched.each_with_object({}) do |(char, touched_at), memo|
+      memo[char] = { established: char_established[char], touched: touched_at }
+    end
 
-    cumulative = 0
-    values = all_dates.map { |date| cumulative += per_day[date]; cumulative }
+    timeline = Mastery::CoverageTimeline.call(
+      milestones: milestones,
+      tiers: [ :established, :touched ]
+    )
 
     render json: {
-      labels: all_dates,
+      labels: timeline[:labels],
       series: [
-        { label: "Characters mastered", color: "rgb(99, 102, 241)", values: values }
+        { label: "Established", color: "rgb(15, 118, 110)",  values: timeline[:series][:established] },
+        { label: "Touched",     color: "rgb(94, 234, 212)",  values: timeline[:series][:touched] }
       ]
     }
   end

--- a/app/helpers/progress_helper.rb
+++ b/app/helpers/progress_helper.rb
@@ -1,0 +1,50 @@
+module ProgressHelper
+  TRAJECTORY_TILES = {
+    Mastery::Trajectory::STABLE => {
+      label: "Stable",
+      description: "holding well",
+      icon: :check,
+      card: "bg-green-50 dark:bg-green-900/30",
+      accent: "text-green-700 dark:text-green-400",
+      icon_bg: "bg-green-600 dark:bg-green-500"
+    },
+    Mastery::Trajectory::RECOVERING => {
+      label: "Recovering",
+      description: "one lapse, not yet regraduated",
+      icon: :dot,
+      card: "bg-amber-50 dark:bg-amber-900/30",
+      accent: "text-amber-700 dark:text-amber-400",
+      icon_bg: "bg-amber-600 dark:bg-amber-500"
+    },
+    Mastery::Trajectory::CHRONIC => {
+      label: "Chronic",
+      description: "graduated, relapsed twice+",
+      icon: :zigzag,
+      card: "bg-orange-50 dark:bg-orange-900/30",
+      accent: "text-orange-700 dark:text-orange-400",
+      icon_bg: "bg-orange-600 dark:bg-orange-500"
+    },
+    Mastery::Trajectory::STALLED => {
+      label: "Stalled",
+      description: "never graduated, ease flat",
+      icon: :dot,
+      card: "bg-red-50 dark:bg-red-900/30",
+      accent: "text-red-700 dark:text-red-400",
+      icon_bg: "bg-red-600 dark:bg-red-500"
+    }
+  }.freeze
+
+  ICONS = {
+    check: '<path d="M3 8.5l3 3 7-7" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+    dot: '<path d="M8 4v5" fill="none" stroke="white" stroke-width="2" stroke-linecap="round"/><circle cx="8" cy="11.5" r="1" fill="white"/>',
+    zigzag: '<path d="M2 12l3-4 3 2.5L13 4" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
+  }.freeze
+
+  def trajectory_tile_config(key)
+    TRAJECTORY_TILES.fetch(key)
+  end
+
+  def trajectory_icon(type)
+    tag.svg(raw(ICONS.fetch(type)), viewBox: "0 0 16 16", class: "w-3 h-3", "aria-hidden": "true") # rubocop:disable Rails/OutputSafety
+  end
+end

--- a/app/models/review_log.rb
+++ b/app/models/review_log.rb
@@ -2,4 +2,20 @@ class ReviewLog < ApplicationRecord
   belongs_to :user_learning
 
   validates :ease, presence: true, inclusion: { in: 1..4 }
+
+  after_create :set_developing_at_on_user_learning
+
+  private
+
+  # Durable milestone for Mastery::Coverage's Developing tier. Relies on
+  # ReviewController#submit updating user_learning's state (and
+  # first_mastered_at, if this review graduates it) before creating this
+  # log, so first_mastered_at already reflects the current review's
+  # outcome by the time this callback runs.
+  def set_developing_at_on_user_learning
+    return if user_learning.developing_at.present? || user_learning.first_mastered_at.present?
+    return unless user_learning.review_logs.count == Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT
+
+    user_learning.update_column(:developing_at, Time.current)
+  end
 end

--- a/app/models/review_log.rb
+++ b/app/models/review_log.rb
@@ -16,6 +16,6 @@ class ReviewLog < ApplicationRecord
     return if user_learning.developing_at.present? || user_learning.first_mastered_at.present?
     return unless user_learning.review_logs.count == Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT
 
-    user_learning.update_column(:developing_at, Time.current)
+    user_learning.update_column(:developing_at, created_at)
   end
 end

--- a/app/services/anki_import_service.rb
+++ b/app/services/anki_import_service.rb
@@ -128,6 +128,8 @@ class AnkiImportService
 
     ReviewLog.insert_all(revlog_rows) if revlog_rows.any?
 
+    backfill_mastery_milestones(ul_id_map.values)
+
     {
       cards_imported:       ul_rows.size,
       review_logs_imported: revlog_rows.size,
@@ -145,6 +147,22 @@ class AnkiImportService
     when 1, 3   then Time.zone.at(card["due"].to_i)
     when 2      then Time.zone.at(col_crt + card["due"].to_i * 86_400)
     else             nil
+    end
+  end
+
+  # UserLearning.insert_all and ReviewLog.insert_all above bypass every
+  # ActiveRecord callback, so first_mastered_at/graduation_count/
+  # developing_at are never set for imported data without this. See #391.
+  def backfill_mastery_milestones(user_learning_ids)
+    return if user_learning_ids.empty?
+
+    UserLearning.where(id: user_learning_ids).includes(:review_logs).find_each do |ul|
+      result = Mastery::MilestoneReplay.call(ul.review_logs)
+      ul.update_columns(
+        first_mastered_at: result.first_mastered_at,
+        graduation_count:  result.graduation_count,
+        developing_at:     result.developing_at
+      )
     end
   end
 end

--- a/app/services/anki_import_service.rb
+++ b/app/services/anki_import_service.rb
@@ -128,7 +128,7 @@ class AnkiImportService
 
     ReviewLog.insert_all(revlog_rows) if revlog_rows.any?
 
-    backfill_mastery_milestones(ul_id_map.values)
+    Mastery::MilestoneReplay.backfill!(ul_id_map.values)
 
     {
       cards_imported:       ul_rows.size,
@@ -147,22 +147,6 @@ class AnkiImportService
     when 1, 3   then Time.zone.at(card["due"].to_i)
     when 2      then Time.zone.at(col_crt + card["due"].to_i * 86_400)
     else             nil
-    end
-  end
-
-  # UserLearning.insert_all and ReviewLog.insert_all above bypass every
-  # ActiveRecord callback, so first_mastered_at/graduation_count/
-  # developing_at are never set for imported data without this. See #391.
-  def backfill_mastery_milestones(user_learning_ids)
-    return if user_learning_ids.empty?
-
-    UserLearning.where(id: user_learning_ids).includes(:review_logs).find_each do |ul|
-      result = Mastery::MilestoneReplay.call(ul.review_logs)
-      ul.update_columns(
-        first_mastered_at: result.first_mastered_at,
-        graduation_count:  result.graduation_count,
-        developing_at:     result.developing_at
-      )
     end
   end
 end

--- a/app/services/data_import_service.rb
+++ b/app/services/data_import_service.rb
@@ -32,14 +32,16 @@ class DataImportService
       learnings_upserted += 1 if updated
 
       rl_rows = build_review_log_rows(ul, Array(ul_data["review_logs"]))
-      next if rl_rows.empty?
+      if rl_rows.any?
+        result = ReviewLog.insert_all(
+          rl_rows,
+          unique_by: :index_review_logs_on_ul_and_source_export_id,
+          returning: [ :id ]
+        )
+        review_logs_inserted += result.length
+      end
 
-      result = ReviewLog.insert_all(
-        rl_rows,
-        unique_by: :index_review_logs_on_ul_and_source_export_id,
-        returning: [ :id ]
-      )
-      review_logs_inserted += result.length
+      backfill_mastery_milestones(ul)
     end
 
     { learnings_upserted:, review_logs_inserted: }
@@ -102,5 +104,19 @@ class DataImportService
         updated_at:       now
       }
     end
+  end
+
+  # ReviewLog.insert_all above bypasses every ActiveRecord callback, and
+  # upsert_user_learning's ul.save! (when it runs) sets first_mastered_at/
+  # graduation_count from Time.current rather than the imported history's
+  # actual dates -- replay is authoritative here regardless of which path
+  # ran. See #391.
+  def backfill_mastery_milestones(ul)
+    result = Mastery::MilestoneReplay.call(ReviewLog.where(user_learning_id: ul.id))
+    ul.update_columns(
+      first_mastered_at: result.first_mastered_at,
+      graduation_count:  result.graduation_count,
+      developing_at:     result.developing_at
+    )
   end
 end

--- a/app/services/data_import_service.rb
+++ b/app/services/data_import_service.rb
@@ -17,6 +17,7 @@ class DataImportService
 
     learnings_upserted    = 0
     review_logs_inserted  = 0
+    touched_ul_ids        = []
 
     ul_list    = Array(@data["user_learnings"])
     characters = ul_list.map { |ul_data| ul_data["character"] }.uniq
@@ -41,8 +42,16 @@ class DataImportService
         review_logs_inserted += result.length
       end
 
-      backfill_mastery_milestones(ul)
+      touched_ul_ids << ul.id
     end
+
+    # ReviewLog.insert_all above bypasses every ActiveRecord callback, and
+    # upsert_user_learning's ul.save! (when it runs) sets first_mastered_at/
+    # graduation_count from Time.current rather than the imported history's
+    # actual dates -- replay is authoritative here regardless of which path
+    # ran. Batched rather than per-word, since this used to dominate import
+    # time on large exports. See #391.
+    Mastery::MilestoneReplay.backfill!(touched_ul_ids)
 
     { learnings_upserted:, review_logs_inserted: }
   end
@@ -104,19 +113,5 @@ class DataImportService
         updated_at:       now
       }
     end
-  end
-
-  # ReviewLog.insert_all above bypasses every ActiveRecord callback, and
-  # upsert_user_learning's ul.save! (when it runs) sets first_mastered_at/
-  # graduation_count from Time.current rather than the imported history's
-  # actual dates -- replay is authoritative here regardless of which path
-  # ran. See #391.
-  def backfill_mastery_milestones(ul)
-    result = Mastery::MilestoneReplay.call(ReviewLog.where(user_learning_id: ul.id))
-    ul.update_columns(
-      first_mastered_at: result.first_mastered_at,
-      graduation_count:  result.graduation_count,
-      developing_at:     result.developing_at
-    )
   end
 end

--- a/app/services/mastery/coverage_timeline.rb
+++ b/app/services/mastery/coverage_timeline.rb
@@ -50,8 +50,11 @@ module Mastery
         # label ("Jan 1") -- otherwise an item touched later the same day
         # as `start` would be missing from this bucket for no visible
         # reason. Capped at end_date so this can't push a bucket past the
-        # final (also end_date) one.
-        buckets << [ d.end_of_day, @end_date ].min
+        # final (also end_date) one -- and skipped entirely when the cap
+        # lands exactly on end_date (start and end_date share a calendar
+        # day), since the unconditional push below already adds it once.
+        capped = [ d.end_of_day, @end_date ].min
+        buckets << capped if capped < @end_date
         d += 7.days
       end
       buckets << @end_date

--- a/app/services/mastery/coverage_timeline.rb
+++ b/app/services/mastery/coverage_timeline.rb
@@ -46,7 +46,12 @@ module Mastery
       buckets = []
       d = start
       while d < @end_date
-        buckets << d
+        # Snap to end of day so the comparison matches the day-granularity
+        # label ("Jan 1") -- otherwise an item touched later the same day
+        # as `start` would be missing from this bucket for no visible
+        # reason. Capped at end_date so this can't push a bucket past the
+        # final (also end_date) one.
+        buckets << [ d.end_of_day, @end_date ].min
         d += 7.days
       end
       buckets << @end_date

--- a/app/services/mastery/coverage_timeline.rb
+++ b/app/services/mastery/coverage_timeline.rb
@@ -1,0 +1,56 @@
+module Mastery
+  # Builds a weekly stacked-area timeline from per-item milestone dates.
+  # Each item is bucketed into exactly one tier per week -- the FURTHEST
+  # tier it had reached as of that week's date, checked in the order
+  # `tiers` is given (most-advanced first) so a durable tier like
+  # Established always wins over an earlier one even if both dates are
+  # present. Feeds the Coverage-over-time chart and the character
+  # coverage chart. See #391.
+  class CoverageTimeline
+    def self.call(milestones:, tiers:, end_date: Time.current)
+      new(milestones, tiers, end_date).call
+    end
+
+    def initialize(milestones, tiers, end_date)
+      @milestones = milestones
+      @tiers = tiers
+      @end_date = end_date
+    end
+
+    def call
+      return { labels: [], series: @tiers.index_with { [] } } if @milestones.empty?
+
+      buckets = weekly_buckets
+      series = @tiers.index_with { [] }
+
+      buckets.each do |bucket|
+        counts = Hash.new(0)
+        @milestones.each_value do |item|
+          tier = furthest_tier_reached(item, bucket)
+          counts[tier] += 1 if tier
+        end
+        @tiers.each { |t| series[t] << counts[t] }
+      end
+
+      { labels: buckets.map { |b| b.strftime("%b %-d") }, series: series }
+    end
+
+    private
+
+    def furthest_tier_reached(item, bucket)
+      @tiers.find { |t| item[t] && item[t] <= bucket }
+    end
+
+    def weekly_buckets
+      start = @milestones.values.flat_map(&:values).compact.min
+      buckets = []
+      d = start
+      while d < @end_date
+        buckets << d
+        d += 7.days
+      end
+      buckets << @end_date
+      buckets
+    end
+  end
+end

--- a/app/services/mastery/milestone_replay.rb
+++ b/app/services/mastery/milestone_replay.rb
@@ -1,0 +1,52 @@
+module Mastery
+  # Replays a UserLearning's review_logs through the same new/learning/
+  # mastered transition table SpacedRepetition::SM2#calculated_state uses,
+  # deriving the durable milestone columns (first_mastered_at,
+  # graduation_count, developing_at) that ActiveRecord callbacks alone
+  # can't set for bulk-inserted data. AnkiImportService and
+  # DataImportService both use ReviewLog.insert_all for performance, which
+  # bypasses every callback entirely -- this is the shared replay those
+  # call afterward to backfill the same milestones the live review flow
+  # sets incrementally. See #391.
+  class MilestoneReplay
+    TRANSITIONS = {
+      "new"      => { 1 => "learning", 2 => "learning", 3 => "learning", 4 => "learning" },
+      "learning" => { 1 => "learning", 2 => "learning", 3 => "mastered", 4 => "mastered" },
+      "mastered" => { 1 => "learning", 2 => "mastered", 3 => "mastered", 4 => "mastered" }
+    }.freeze
+
+    Result = Data.define(:first_mastered_at, :graduation_count, :developing_at)
+
+    def self.call(review_logs)
+      new(review_logs).call
+    end
+
+    def initialize(review_logs)
+      @review_logs = review_logs.sort_by { |log| [ log.created_at, log.time || -1, log.id ] }
+    end
+
+    def call
+      state = "new"
+      first_mastered_at = nil
+      graduation_count = 0
+      developing_at = nil
+      threshold = Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT
+
+      @review_logs.each.with_index(1) do |log, review_count|
+        new_state = TRANSITIONS.dig(state, log.ease)
+        next if new_state.nil?
+
+        if new_state == "mastered" && state != "mastered"
+          graduation_count += 1
+          first_mastered_at ||= log.created_at
+        end
+
+        developing_at = log.created_at if developing_at.nil? && review_count == threshold && first_mastered_at.nil?
+
+        state = new_state
+      end
+
+      Result.new(first_mastered_at: first_mastered_at, graduation_count: graduation_count, developing_at: developing_at)
+    end
+  end
+end

--- a/app/services/mastery/milestone_replay.rb
+++ b/app/services/mastery/milestone_replay.rb
@@ -21,6 +21,24 @@ module Mastery
       new(review_logs).call
     end
 
+    # Batched backfill for a set of UserLearning ids -- shared by
+    # AnkiImportService and DataImportService so neither reimplements the
+    # same includes(:review_logs).find_each loop, and so a per-word DB
+    # round trip (which dominated import time on large exports) can't
+    # creep back in independently in either place.
+    def self.backfill!(user_learning_ids)
+      return if user_learning_ids.empty?
+
+      UserLearning.where(id: user_learning_ids).includes(:review_logs).find_each do |ul|
+        result = call(ul.review_logs)
+        ul.update_columns(
+          first_mastered_at: result.first_mastered_at,
+          graduation_count:  result.graduation_count,
+          developing_at:     result.developing_at
+        )
+      end
+    end
+
     def initialize(review_logs)
       @review_logs = review_logs.sort_by { |log| [ log.created_at, log.time || -1, log.id ] }
     end

--- a/app/services/mastery/trajectory_snapshot.rb
+++ b/app/services/mastery/trajectory_snapshot.rb
@@ -62,11 +62,28 @@ module Mastery
         .to_a
     end
 
+    # Bounded to (at most) STALLED_LOOKBACK_REVIEWS rows per Developing
+    # word via a window function, rather than loading every review_log a
+    # word has ever had (some in the real data have 40+) just to keep the
+    # last few.
     def recent_eases
-      @recent_eases ||= ReviewLog.where(user_learning_id: developing_ids)
-        .order(:user_learning_id, created_at: :desc, time: :desc, id: :desc)
-        .group_by(&:user_learning_id)
-        .transform_values { |logs| logs.first(3).map(&:ease) }
+      return @recent_eases ||= {} if developing_ids.empty?
+
+      sql = ReviewLog.sanitize_sql_array([ <<~SQL, developing_ids ])
+        SELECT user_learning_id, ease FROM (
+          SELECT user_learning_id, ease,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY user_learning_id
+                   ORDER BY created_at DESC, time DESC, id DESC
+                 ) AS rn
+          FROM review_logs
+          WHERE user_learning_id IN (?)
+        ) ranked WHERE rn <= #{Thresholds::STALLED_LOOKBACK_REVIEWS}
+      SQL
+
+      @recent_eases ||= ReviewLog.connection.select_all(sql).each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, memo|
+        memo[row["user_learning_id"]] << row["ease"]
+      end
     end
   end
 end

--- a/app/services/mastery/trajectory_snapshot.rb
+++ b/app/services/mastery/trajectory_snapshot.rb
@@ -46,12 +46,15 @@ module Mastery
         .to_a
     end
 
+    # developing_at is set durably (live callback + both import paths) the
+    # moment review_count first reaches the threshold without having
+    # graduated by then, and review counts never decrease -- so its
+    # presence is equivalent to the live "review_count >= threshold"
+    # check, without a join/group/count aggregate to get there.
     def developing_ids
       @developing_ids ||= @user.user_learnings
         .where(first_mastered_at: nil)
-        .joins(:review_logs)
-        .group(:id)
-        .having("COUNT(review_logs.id) >= ?", Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT)
+        .where.not(developing_at: nil)
         .pluck(:id)
     end
 

--- a/app/services/mastery/trajectory_snapshot.rb
+++ b/app/services/mastery/trajectory_snapshot.rb
@@ -1,0 +1,72 @@
+module Mastery
+  # Current tallies of Stable/Recovering/Chronic/Stalled among a user's
+  # Developing+Established UserLearnings -- a live snapshot, not a trend
+  # (see CoverageTimeline for the trend version). Query count is fixed
+  # regardless of word count: recent_eases is only fetched for the small
+  # Developing population, never for Established. See #391, README.md.
+  class TrajectorySnapshot
+    Bucket = Data.define(:key, :count, :percent)
+
+    def self.call(user:)
+      new(user).call
+    end
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      tallies = Hash.new(0)
+      established_records.each { |ul| tallies[classify(ul, Coverage::ESTABLISHED, [])] += 1 }
+      developing_records.each { |ul| tallies[classify(ul, Coverage::DEVELOPING, recent_eases[ul.id] || [])] += 1 }
+
+      total = established_records.size + developing_records.size
+      buckets = display_order.map do |key|
+        count = tallies[key]
+        Bucket.new(key: key, count: count, percent: total.zero? ? 0.0 : (count.to_f / total * 100).round(1))
+      end
+
+      { total: total, buckets: buckets }
+    end
+
+    private
+
+    def classify(user_learning, coverage, recent_eases)
+      Trajectory.call(user_learning: user_learning, coverage: coverage, recent_eases: recent_eases)
+    end
+
+    def display_order
+      Trajectory::ALL - [ Trajectory::NOT_APPLICABLE ]
+    end
+
+    def established_records
+      @established_records ||= @user.user_learnings
+        .where.not(first_mastered_at: nil)
+        .select(:id, :state, :graduation_count)
+        .to_a
+    end
+
+    def developing_ids
+      @developing_ids ||= @user.user_learnings
+        .where(first_mastered_at: nil)
+        .joins(:review_logs)
+        .group(:id)
+        .having("COUNT(review_logs.id) >= ?", Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT)
+        .pluck(:id)
+    end
+
+    def developing_records
+      @developing_records ||= @user.user_learnings
+        .where(id: developing_ids)
+        .select(:id, :state, :graduation_count)
+        .to_a
+    end
+
+    def recent_eases
+      @recent_eases ||= ReviewLog.where(user_learning_id: developing_ids)
+        .order(:user_learning_id, created_at: :desc, time: :desc, id: :desc)
+        .group_by(&:user_learning_id)
+        .transform_values { |logs| logs.first(3).map(&:ease) }
+    end
+  end
+end

--- a/app/views/progress/_trajectory_tile.html.erb
+++ b/app/views/progress/_trajectory_tile.html.erb
@@ -1,0 +1,13 @@
+<% config = trajectory_tile_config(bucket.key) %>
+<div class="rounded-lg p-4 <%= config[:card] %>" data-trajectory-key="<%= bucket.key %>">
+  <div class="flex items-center gap-2">
+    <span class="w-5 h-5 rounded-full flex items-center justify-center <%= config[:icon_bg] %>">
+      <%= trajectory_icon(config[:icon]) %>
+    </span>
+    <span class="text-xs font-semibold <%= config[:accent] %>"><%= config[:label] %></span>
+  </div>
+  <div class="text-2xl font-bold mt-1 tabular-nums <%= config[:accent] %>"><%= bucket.count %></div>
+  <div class="text-xs text-gray-500 dark:text-gray-400">
+    <%= number_with_precision(bucket.percent, precision: 1) %>% · <%= config[:description] %>
+  </div>
+</div>

--- a/app/views/progress/show.html.erb
+++ b/app/views/progress/show.html.erb
@@ -7,29 +7,48 @@
 
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 mb-6"
        data-controller="progress-charts"
-       data-progress-charts-url-value="<%= learn_progress_chart_data_path(format: :json) %>">
-    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">Vocabulary mastered over time</h2>
+       data-progress-charts-url-value="<%= learn_progress_coverage_chart_data_path(format: :json) %>">
+    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">Vocabulary coverage over time</h2>
     <p class="h-5 mb-3 text-sm text-gray-500 dark:text-gray-400 tabular-nums overflow-hidden whitespace-nowrap"
        data-progress-charts-target="summary">&nbsp;</p>
     <div class="relative h-[640px]">
       <canvas data-progress-charts-target="canvas"></canvas>
     </div>
     <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">
-      "In progress" counts words from their first review; "Mastered" counts from when they reached mastered state.
+      Established is keyed on a durable "first ever mastered" date, so a later lapse never pulls a word
+      back out of this count or rewrites earlier dates. Developing/Emerging can shrink week to week as
+      words graduate onward — that's the funnel draining, not a bug.
+    </p>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">Trajectory</h2>
+    <p class="mb-3 text-sm text-gray-500 dark:text-gray-400">
+      Of <%= number_with_delimiter(@trajectory[:total]) %> Developing + Established words — a live snapshot, not a trend
+    </p>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <%= render partial: "trajectory_tile", collection: @trajectory[:buckets], as: :bucket %>
+    </div>
+    <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">
+      Restricted to words with enough history to say anything — Unseen and Emerging words don't get a
+      trajectory yet.
     </p>
   </div>
 
   <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6"
        data-controller="progress-charts"
        data-progress-charts-url-value="<%= learn_progress_character_chart_data_path(format: :json) %>">
-    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">Unique characters mastered over time</h2>
+    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">Character coverage over time</h2>
     <p class="h-5 mb-3 text-sm text-gray-500 dark:text-gray-400 tabular-nums overflow-hidden whitespace-nowrap"
        data-progress-charts-target="summary">&nbsp;</p>
     <div class="relative h-[640px]">
       <canvas data-progress-charts-target="canvas"></canvas>
     </div>
     <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">
-      Counts unique characters across all mastered words — 你好 and 你 together contribute 2 distinct characters.
+      Only two tiers — characters aren't reviewed directly, and the real data behind this chart showed no
+      natural Emerging/Developing split at the character level. A character counts as Established the
+      moment any word containing it graduates — your outside-the-app comparator for character literacy,
+      independent of vocabulary progress.
     </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "dashboard#index"
 
-  get  "learn/progress",                    to: "progress#show",              as: :learn_progress
-  get  "learn/progress/chart_data",         to: "progress#chart_data",        as: :learn_progress_chart_data
+  get  "learn/progress",                      to: "progress#show",                 as: :learn_progress
+  get  "learn/progress/coverage_chart_data",  to: "progress#coverage_chart_data",  as: :learn_progress_coverage_chart_data
   get  "learn/progress/character_chart_data", to: "progress#character_chart_data", as: :learn_progress_character_chart_data
 
   get  "review",          to: "review#start",   as: :review

--- a/db/migrate/20260712125906_add_developing_at_to_user_learnings.rb
+++ b/db/migrate/20260712125906_add_developing_at_to_user_learnings.rb
@@ -1,0 +1,12 @@
+class AddDevelopingAtToUserLearnings < ActiveRecord::Migration[8.1]
+  def change
+    # Durable milestone: the moment review_count first reached
+    # Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT while the
+    # word had not yet graduated. Never cleared once set -- feeds the
+    # Coverage-over-time chart the same way first_mastered_at feeds
+    # Established, avoiding a review_logs replay per word per request.
+    # See #391, app/services/mastery/README.md.
+    add_column :user_learnings, :developing_at, :datetime
+    add_index :user_learnings, :developing_at
+  end
+end

--- a/db/migrate/20260712125908_backfill_developing_at_from_review_logs.rb
+++ b/db/migrate/20260712125908_backfill_developing_at_from_review_logs.rb
@@ -1,0 +1,41 @@
+class BackfillDevelopingAtFromReviewLogs < ActiveRecord::Migration[8.1]
+  # Mirrors SpacedRepetition::SM2#calculated_state's transition table
+  # (sm2.rb:56-68), same as the other review_logs replay migrations.
+  TRANSITIONS = {
+    "new"      => { 1 => "learning", 2 => "learning", 3 => "learning", 4 => "learning" },
+    "learning" => { 1 => "learning", 2 => "learning", 3 => "mastered", 4 => "mastered" },
+    "mastered" => { 1 => "learning", 2 => "mastered", 3 => "mastered", 4 => "mastered" }
+  }.freeze
+
+  def up
+    UserLearning.find_each do |user_learning|
+      developing_at = replay_developing_at(user_learning)
+      user_learning.update_column(:developing_at, developing_at) if developing_at
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def replay_developing_at(user_learning)
+    threshold = Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT
+    state = "new"
+    ever_graduated = false
+    user_learning.review_logs.order(:created_at, :time, :id).each.with_index(1) do |log, review_count|
+      new_state = TRANSITIONS.dig(state, log.ease)
+      next if new_state.nil?
+
+      ever_graduated ||= (new_state == "mastered")
+      # Established (first_mastered_at, durable) takes priority over
+      # Developing regardless of live state -- a word that graduated and
+      # later relapsed is still Established at review 5, not Developing.
+      return ever_graduated ? nil : log.created_at if review_count == threshold
+
+      state = new_state
+    end
+    nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_120454) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_125906) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -258,6 +258,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_120454) do
 
   create_table "user_learnings", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.datetime "developing_at"
     t.integer "dictionary_entry_id", null: false
     t.integer "factor", default: 2500, null: false
     t.datetime "first_mastered_at"
@@ -268,6 +269,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_120454) do
     t.string "state", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["developing_at"], name: "index_user_learnings_on_developing_at"
     t.index ["dictionary_entry_id"], name: "index_user_learnings_on_dictionary_entry_id"
     t.index ["first_mastered_at"], name: "index_user_learnings_on_first_mastered_at"
     t.index ["user_id", "dictionary_entry_id"], name: "index_user_learnings_on_user_and_entry", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_125906) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_125908) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/spec/migrations/backfill_developing_at_from_review_logs_spec.rb
+++ b/spec/migrations/backfill_developing_at_from_review_logs_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260712125908_backfill_developing_at_from_review_logs')
+
+# Tests for the BackfillDevelopingAtFromReviewLogs data migration.
+#
+# developing_at marks the moment review_count first reached
+# Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT while the word
+# had not yet graduated. See #391.
+RSpec.describe "BackfillDevelopingAtFromReviewLogs migration" do
+  let(:migration) { BackfillDevelopingAtFromReviewLogs.new }
+  let(:user)      { create(:user) }
+  let(:threshold) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+  # ReviewLog's own after_create callback (see app/models/review_log.rb)
+  # already sets developing_at going forward, and fires on every factory
+  # `create(:review_log, ...)` below too -- these tests build raw review
+  # history directly, the way an Anki import would, without also replaying
+  # user_learning.update!(state: ...) the way ReviewController#submit does.
+  # Reset developing_at after setup so each test verifies the MIGRATION's
+  # own replay logic in isolation from that live callback's side effects.
+  def reset_developing_at(ul)
+    ul.update_column(:developing_at, nil)
+  end
+
+  describe "#up" do
+    it "sets developing_at at the threshold-th review when not yet graduated" do
+      ul = create(:user_learning, user: user, state: "learning")
+      (threshold - 1).times { |i| create(:review_log, user_learning: ul, ease: 1, created_at: (10 - i).days.ago) }
+      threshold_log = create(:review_log, user_learning: ul, ease: 1, created_at: 1.day.ago)
+      reset_developing_at(ul)
+
+      migration.up
+
+      expect(ul.reload.developing_at).to be_within(1.second).of(threshold_log.created_at)
+    end
+
+    it "does not set developing_at if the word graduates before the threshold" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 3.days.ago)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago) # graduates here (review 2)
+      (threshold - 2).times { |i| create(:review_log, user_learning: ul, ease: 3, created_at: (1.days.ago - i.hours)) }
+      reset_developing_at(ul)
+
+      migration.up
+
+      expect(ul.reload.developing_at).to be_nil
+    end
+
+    it "does not set developing_at at the threshold-th review if it graduates there" do
+      ul = create(:user_learning, user: user, state: "mastered")
+      create(:review_log, user_learning: ul, ease: 1, created_at: 5.days.ago)
+      (threshold - 2).times { |i| create(:review_log, user_learning: ul, ease: 1, created_at: (4 - i).days.ago) }
+      create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago) # graduates at review `threshold`
+      reset_developing_at(ul)
+
+      migration.up
+
+      expect(ul.reload.developing_at).to be_nil
+    end
+
+    it "does not set developing_at if the word graduated earlier and has since relapsed" do
+      # Graduates on review 2, relapses on review 3, keeps accumulating
+      # reviews without regraduating -- still Established (durable), never
+      # Developing, even though it's currently "learning" at review threshold.
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 3, created_at: 6.days.ago)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 5.days.ago) # graduates (review 2)
+      create(:review_log, user_learning: ul, ease: 1, created_at: 4.days.ago) # relapses
+      (threshold - 3).times { |i| create(:review_log, user_learning: ul, ease: 1, created_at: (3 - i).days.ago) }
+      reset_developing_at(ul)
+
+      migration.up
+
+      expect(ul.reload.developing_at).to be_nil
+    end
+
+    it "leaves developing_at nil for a word with fewer reviews than the threshold" do
+      ul = create(:user_learning, user: user, state: "learning")
+      (threshold - 1).times { |i| create(:review_log, user_learning: ul, ease: 1, created_at: (2 - i).days.ago) }
+      reset_developing_at(ul)
+
+      migration.up
+
+      expect(ul.reload.developing_at).to be_nil
+    end
+  end
+end

--- a/spec/models/review_log_spec.rb
+++ b/spec/models/review_log_spec.rb
@@ -17,4 +17,44 @@ RSpec.describe ReviewLog, type: :model do
       expect(log.errors[:ease]).to include("is not included in the list")
     end
   end
+
+  describe 'developing_at' do
+    let(:threshold) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+    let(:user_learning) { create(:user_learning, user: create(:user), state: "learning") }
+
+    it "sets developing_at on the user_learning at the threshold-th review" do
+      (threshold - 1).times { create(:review_log, user_learning: user_learning, ease: 1) }
+
+      expect { create(:review_log, user_learning: user_learning, ease: 1) }
+        .to change { user_learning.reload.developing_at }.from(nil)
+    end
+
+    it "does not set developing_at before the threshold is reached" do
+      (threshold - 2).times { create(:review_log, user_learning: user_learning, ease: 1) }
+
+      expect { create(:review_log, user_learning: user_learning, ease: 1) }
+        .not_to change { user_learning.reload.developing_at }
+    end
+
+    it "does not set developing_at once the word has graduated" do
+      # ReviewController#submit updates user_learning's state before
+      # creating the ReviewLog, so by the time this callback fires,
+      # first_mastered_at already reflects the current review's outcome.
+      (threshold - 1).times { create(:review_log, user_learning: user_learning, ease: 1) }
+      user_learning.update!(state: "mastered", first_mastered_at: Time.current, mastered_at: Time.current)
+
+      expect { create(:review_log, user_learning: user_learning, ease: 3) }
+        .not_to change { user_learning.reload.developing_at }
+    end
+
+    it "does not change developing_at once already set" do
+      (threshold - 1).times { create(:review_log, user_learning: user_learning, ease: 1) }
+      create(:review_log, user_learning: user_learning, ease: 1)
+      original = user_learning.reload.developing_at
+
+      expect { create(:review_log, user_learning: user_learning, ease: 1) }
+        .not_to change { user_learning.reload.developing_at }
+      expect(user_learning.reload.developing_at).to eq(original)
+    end
+  end
 end

--- a/spec/models/review_log_spec.rb
+++ b/spec/models/review_log_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe ReviewLog, type: :model do
         .to change { user_learning.reload.developing_at }.from(nil)
     end
 
+    it "uses the review log's own created_at, not the time the callback runs" do
+      # Backdated created_at (imports, backfills, tests) must be reflected
+      # in developing_at -- using Time.current here would silently skew
+      # the Coverage timeline bucketing for any non-live-flow write.
+      (threshold - 1).times { create(:review_log, user_learning: user_learning, ease: 1) }
+      backdated = 10.days.ago
+      create(:review_log, user_learning: user_learning, ease: 1, created_at: backdated)
+
+      expect(user_learning.reload.developing_at).to be_within(1.second).of(backdated)
+    end
+
     it "does not set developing_at before the threshold is reached" do
       (threshold - 2).times { create(:review_log, user_learning: user_learning, ease: 1) }
 

--- a/spec/requests/progress_spec.rb
+++ b/spec/requests/progress_spec.rb
@@ -140,6 +140,20 @@ RSpec.describe "Progress", type: :request do
           expect(series("Established")["values"].last).to eq(1)
         end
 
+        it "still counts an established word's characters even with no review history" do
+          # Not reachable via any current code path in this app --
+          # first_mastered_at can only be set alongside review history --
+          # but Mastery::Coverage treats first_mastered_at as authoritative
+          # regardless of review count, so this chart shouldn't silently
+          # disagree if that ever drifts (e.g. reviews deleted after the
+          # fact, a future import format). See #391 review discussion.
+          ghost = create(:user_learning, user: user, dictionary_entry: create(:dictionary_entry, text: "谢"), state: "learning")
+          ghost.update_column(:first_mastered_at, 3.days.ago)
+
+          get learn_progress_character_chart_data_path
+          expect(series("Established")["values"].last).to eq(1)
+        end
+
         it "keeps the query count bounded regardless of word count" do
           graduate!(text: "你")
           count_with_few = count_queries { get learn_progress_character_chart_data_path }
@@ -222,6 +236,20 @@ RSpec.describe "Progress", type: :request do
           get learn_progress_coverage_chart_data_path
           series = parsed["series"].index_by { |s| s["label"] }
           expect(series["Established"]["values"].last).to eq(1)
+        end
+
+        it "still counts an established word even with no review history" do
+          # Not reachable via any current code path in this app --
+          # first_mastered_at can only be set alongside review history --
+          # but Mastery::Coverage treats first_mastered_at as authoritative
+          # regardless of review count, so this chart shouldn't silently
+          # disagree if that ever drifts. See #391 review discussion.
+          ghost = create(:user_learning, user: user, state: "learning")
+          ghost.update_column(:first_mastered_at, 3.days.ago)
+
+          get learn_progress_coverage_chart_data_path
+          series = parsed["series"].index_by { |s| s["label"] }
+          expect(series["Established"]["values"].last).to eq(2)
         end
 
         it "only returns data for the current user" do

--- a/spec/requests/progress_spec.rb
+++ b/spec/requests/progress_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe "Progress", type: :request do
         get learn_progress_path
         expect(response.body).to include("Learning Progress")
       end
+
+      it "renders all four Trajectory tile labels" do
+        get learn_progress_path
+        expect(response.body).to include("Stable", "Recovering", "Chronic", "Stalled")
+      end
+
+      it "renders the Trajectory count for a classified word" do
+        ul = create(:user_learning, user: user, state: "learning")
+        create(:review_log, user_learning: ul, ease: 3)
+        ul.update!(state: "mastered")
+
+        get learn_progress_path
+        doc = Nokogiri::HTML(response.body)
+        stable_tile = doc.at_css('[data-trajectory-key="stable"]')
+        expect(stable_tile.text).to include("1")
+      end
     end
   end
 
@@ -37,73 +53,110 @@ RSpec.describe "Progress", type: :request do
     context "when authenticated" do
       before { sign_in user }
 
-      it "returns JSON" do
-        get learn_progress_character_chart_data_path
-        expect(response.content_type).to include("application/json")
+      def parsed
+        JSON.parse(response.body)
       end
 
-      context "with mastered words" do
-        let(:entry_a) { create(:dictionary_entry, text: "你好") }
-        let(:entry_b) { create(:dictionary_entry, text: "你") }
+      def series(label)
+        parsed["series"].find { |s| s["label"] == label }
+      end
 
-        before do
-          create(:user_learning, user: user, state: "mastered",
-                 dictionary_entry: entry_a, mastered_at: 2.days.ago)
-          create(:user_learning, user: user, state: "mastered",
-                 dictionary_entry: entry_b, mastered_at: 1.day.ago)
+      it "returns JSON with labels and series keys" do
+        get learn_progress_character_chart_data_path
+        expect(response.content_type).to include("application/json")
+        expect(parsed.keys).to contain_exactly("labels", "series")
+      end
+
+      it "returns two series: Established, Touched" do
+        get learn_progress_character_chart_data_path
+        expect(parsed["series"].map { |s| s["label"] }).to eq([ "Established", "Touched" ])
+      end
+
+      it "returns empty labels and series when nothing has been reviewed" do
+        get learn_progress_character_chart_data_path
+        expect(parsed["labels"]).to eq([])
+        expect(parsed["series"]).to all(include("values" => []))
+      end
+
+      context "with mastered and touched words" do
+        # A word graduating always accompanies at least one ReviewLog in the
+        # real app -- matching that here rather than a bare state update.
+        def graduate!(text:)
+          ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry, text: text))
+          create(:review_log, user_learning: ul, ease: 3)
+          ul.update!(state: "mastered")
+          ul
         end
 
-        def parsed
-          JSON.parse(response.body)
-        end
-
-        it "returns labels and series" do
-          get learn_progress_character_chart_data_path
-          expect(parsed.keys).to contain_exactly("labels", "series")
+        def touch!(text:)
+          ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry, text: text))
+          create(:review_log, user_learning: ul, ease: 1)
+          ul
         end
 
         it "deduplicates characters across words" do
+          graduate!(text: "你好") # 你, 好
+          graduate!(text: "你")   # 你 already established
+
           get learn_progress_character_chart_data_path
-          values = parsed["series"].first["values"]
-          # 你好 = 你, 好 (2 chars on day 1); 你 already counted → only 好 is new
-          # Total should be 2 unique characters, not 3
-          expect(values.last).to eq(2)
+          expect(series("Established")["values"].last).to eq(2)
         end
 
-        it "attributes a character to the earliest mastered word" do
+        it "counts a touched-but-not-established character in Touched" do
+          touch!(text: "学")
+
           get learn_progress_character_chart_data_path
-          # 你 appears in 你好 (mastered 2 days ago), so it's counted on that date
-          values = parsed["series"].first["values"]
-          expect(values.first).to eq(2)
+          expect(series("Touched")["values"].last).to eq(1)
+          expect(series("Established")["values"].last).to eq(0)
+        end
+
+        it "prioritises Established over Touched for a character in both an established and a touched word" do
+          graduate!(text: "你")
+          touch!(text: "你好") # 你 already established; 好 merely touched
+
+          get learn_progress_character_chart_data_path
+          expect(series("Established")["values"].last).to eq(1)
+          expect(series("Touched")["values"].last).to eq(1)
         end
 
         it "only returns data for the current user" do
           other_user = create(:user)
           other_entry = create(:dictionary_entry, text: "学")
-          create(:user_learning, user: other_user, state: "mastered",
-                 dictionary_entry: other_entry, mastered_at: 1.day.ago)
+          other_ul = create(:user_learning, user: other_user, state: "learning", dictionary_entry: other_entry)
+          create(:review_log, user_learning: other_ul, ease: 3)
+          other_ul.update!(state: "mastered")
+
+          graduate!(text: "你")
 
           get learn_progress_character_chart_data_path
-          expect(parsed["series"].first["values"].last).to eq(2)
+          expect(series("Established")["values"].last).to eq(1)
         end
 
-        it "keeps a lapsed word's characters counted (does not retroactively rewrite history)" do
-          lapsed_entry = create(:dictionary_entry, text: "学")
-          lapsed = create(:user_learning, user: user, state: "learning", dictionary_entry: lapsed_entry)
-          lapsed.update!(state: "mastered")
+        it "keeps a lapsed word's characters Established (does not retroactively rewrite history)" do
+          lapsed = graduate!(text: "学")
           lapsed.update!(state: "learning")
 
           get learn_progress_character_chart_data_path
-          expect(parsed["series"].first["values"].last).to eq(3)
+          expect(series("Established")["values"].last).to eq(1)
+        end
+
+        it "keeps the query count bounded regardless of word count" do
+          graduate!(text: "你")
+          count_with_few = count_queries { get learn_progress_character_chart_data_path }
+
+          15.times { |i| touch!(text: "字#{i}") }
+
+          count_with_many = count_queries { get learn_progress_character_chart_data_path }
+          expect(count_with_many).to eq(count_with_few)
         end
       end
     end
   end
 
-  describe "GET /learn/progress/chart_data" do
+  describe "GET /learn/progress/coverage_chart_data" do
     context "when unauthenticated" do
       it "redirects to the login page" do
-        get learn_progress_chart_data_path
+        get learn_progress_coverage_chart_data_path
         expect(response).to redirect_to("/sign_in")
       end
     end
@@ -111,100 +164,86 @@ RSpec.describe "Progress", type: :request do
     context "when authenticated" do
       before { sign_in user }
 
-      it "returns JSON" do
-        get learn_progress_chart_data_path
+      def parsed
+        JSON.parse(response.body)
+      end
+
+      it "returns JSON with labels and series keys" do
+        get learn_progress_coverage_chart_data_path
         expect(response.content_type).to include("application/json")
+        expect(parsed.keys).to contain_exactly("labels", "series")
       end
 
-      it "returns labels and series keys" do
-        get learn_progress_chart_data_path
-        data = JSON.parse(response.body)
-        expect(data.keys).to contain_exactly("labels", "series")
+      it "returns empty labels and series when nothing has been reviewed" do
+        get learn_progress_coverage_chart_data_path
+        expect(parsed["labels"]).to eq([])
+        expect(parsed["series"]).to all(include("values" => []))
       end
 
-      context "with user learnings and review logs" do
-        let!(:mastered_card) do
-          ul = create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
-          create(:review_log, user_learning: ul, created_at: 3.days.ago)
-          ul
-        end
-        let!(:learning_card) do
+      context "with words at each coverage tier" do
+        let(:threshold) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+        let!(:established_word) do
+          # Graduation always accompanies at least one ReviewLog in the real
+          # app (ReviewController#submit creates both together) -- matching
+          # that here, rather than a bare state update with zero reviews.
           ul = create(:user_learning, user: user, state: "learning")
-          create(:review_log, user_learning: ul, created_at: 2.days.ago)
+          create(:review_log, user_learning: ul, ease: 3)
+          ul.update!(state: "mastered")
+          ul
+        end
+        let!(:developing_word) do
+          ul = create(:user_learning, user: user, state: "learning")
+          threshold.times { create(:review_log, user_learning: ul, ease: 1) }
+          ul
+        end
+        let!(:emerging_word) do
+          ul = create(:user_learning, user: user, state: "learning")
+          create(:review_log, user_learning: ul, ease: 1)
           ul
         end
 
-        def parsed
-          JSON.parse(response.body)
+        it "returns three series in Established, Developing, Emerging order" do
+          get learn_progress_coverage_chart_data_path
+          expect(parsed["series"].map { |s| s["label"] }).to eq([ "Established", "Developing", "Emerging" ])
         end
 
-        it "returns labels and series keys" do
-          get learn_progress_chart_data_path
-          expect(parsed.keys).to contain_exactly("labels", "series")
+        it "counts each word in its own tier at the final bucket" do
+          get learn_progress_coverage_chart_data_path
+          series = parsed["series"].index_by { |s| s["label"] }
+          expect(series["Established"]["values"].last).to eq(1)
+          expect(series["Developing"]["values"].last).to eq(1)
+          expect(series["Emerging"]["values"].last).to eq(1)
         end
 
-        it "returns labels in ascending chronological order" do
-          get learn_progress_chart_data_path
-          expect(parsed["labels"]).to eq(parsed["labels"].sort)
-        end
+        it "keeps a lapsed word in Established (durable, not retroactively rewritten)" do
+          established_word.update!(state: "learning")
 
-        it "returns two series (Mastered and In progress)" do
-          get learn_progress_chart_data_path
-          labels = parsed["series"].map { |s| s["label"] }
-          expect(labels).to contain_exactly("Mastered", "In progress")
-        end
-
-        it "accumulates mastered count cumulatively" do
-          get learn_progress_chart_data_path
-          mastered = parsed["series"].find { |s| s["label"] == "Mastered" }
-          expect(mastered["values"].last).to eq(1)
-        end
-
-        it "keeps a lapsed card in the mastered count (does not retroactively rewrite history)" do
-          # A card that graduated then lapsed still has first_mastered_at set,
-          # even though mastered_at (the live field) is cleared and state is
-          # no longer "mastered". The chart must not drop it. See #391.
-          lapsed = create(:user_learning, user: user, state: "learning")
-          lapsed.update!(state: "mastered")
-          lapsed.update!(state: "learning")
-
-          get learn_progress_chart_data_path
-          mastered = parsed["series"].find { |s| s["label"] == "Mastered" }
-          expect(mastered["values"].last).to eq(2)
-        end
-
-        it "excludes stale records with a leftover mastered_at but no first_mastered_at" do
-          # Data written before first_mastered_at existed, bypassing the
-          # model callback entirely — not a case the fix is expected to cover.
-          create(:user_learning, user: user, state: "learning", mastered_at: 1.day.ago,
-                 dictionary_entry: create(:dictionary_entry))
-          get learn_progress_chart_data_path
-          mastered = parsed["series"].find { |s| s["label"] == "Mastered" }
-          expect(mastered["values"].last).to eq(1)
-        end
-
-        it "counts in_progress from first review minus mastered" do
-          get learn_progress_chart_data_path
-          in_progress = parsed["series"].find { |s| s["label"] == "In progress" }
-          # 2 cards reviewed, 1 mastered → 1 still in progress
-          expect(in_progress["values"].last).to eq(1)
-        end
-
-        it "in_progress values are never negative" do
-          get learn_progress_chart_data_path
-          in_progress = parsed["series"].find { |s| s["label"] == "In progress" }
-          expect(in_progress["values"]).to all(be >= 0)
+          get learn_progress_coverage_chart_data_path
+          series = parsed["series"].index_by { |s| s["label"] }
+          expect(series["Established"]["values"].last).to eq(1)
         end
 
         it "only returns data for the current user" do
           other_user = create(:user)
-          other_ul = create(:user_learning, user: other_user, state: "mastered",
-                            mastered_at: 1.day.ago)
-          create(:review_log, user_learning: other_ul, created_at: 1.day.ago)
+          other_ul = create(:user_learning, user: other_user, state: "learning")
+          create(:review_log, user_learning: other_ul, ease: 1)
 
-          get learn_progress_chart_data_path
-          mastered = parsed["series"].find { |s| s["label"] == "Mastered" }
-          expect(mastered["values"].last).to eq(1)
+          get learn_progress_coverage_chart_data_path
+          series = parsed["series"].index_by { |s| s["label"] }
+          expect(series["Emerging"]["values"].last).to eq(1)
+        end
+
+        it "keeps the query count bounded regardless of word count" do
+          count_with_few = count_queries { get learn_progress_coverage_chart_data_path }
+
+          15.times do
+            ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+            create(:review_log, user_learning: ul, ease: 1)
+          end
+
+          count_with_many = count_queries { get learn_progress_coverage_chart_data_path }
+          expect(count_with_many).to eq(count_with_few)
         end
       end
     end

--- a/spec/services/anki_import_service_spec.rb
+++ b/spec/services/anki_import_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe AnkiImportService do
   let!(:entry_wen)  { create(:dictionary_entry, text: "文") }
   let!(:entry_guo)  { create(:dictionary_entry, text: "国") }
   let!(:entry_ai)   { create(:dictionary_entry, text: "爱") }
+  let!(:entry_xiexie) { create(:dictionary_entry, text: "谢谢") }
   # 不 has no entry — tests skip behaviour
 
   describe ".call" do
@@ -49,6 +50,30 @@ RSpec.describe AnkiImportService do
     it "skips characters with no matching DictionaryEntry" do
       result
       expect(result[:skipped]).to include("不")
+    end
+
+    it "backfills first_mastered_at and graduation_count from replayed review history" do
+      # UserLearning.insert_all/ReviewLog.insert_all bypass every
+      # ActiveRecord callback, so these milestones only get set by the
+      # explicit post-import Mastery::MilestoneReplay backfill. 谢谢's two
+      # revlogs (ease 3, 3) graduate it when replayed. See #391.
+      result
+      xiexie_learning = UserLearning.find_by(user: user, dictionary_entry: entry_xiexie)
+      expect(xiexie_learning.first_mastered_at).to be_present
+      expect(xiexie_learning.graduation_count).to eq(1)
+    end
+
+    it "leaves first_mastered_at nil for a card whose single revlog never reaches mastered" do
+      # 好 has one revlog (ease 2): new -> learning only, never graduates --
+      # even though its imported `state` column says "mastered" from
+      # Anki's queue value. This mismatch is inherent and already accepted
+      # for first_mastered_at/graduation_count (#394/#395): they describe
+      # this app's own SM2 semantics applied to observed history, not
+      # whatever Anki's queue said.
+      result
+      hao_learning = UserLearning.find_by(user: user, dictionary_entry: entry_hao)
+      expect(hao_learning.first_mastered_at).to be_nil
+      expect(hao_learning.graduation_count).to eq(0)
     end
 
     it "is idempotent — running twice does not duplicate UserLearning records" do

--- a/spec/services/data_import_service_spec.rb
+++ b/spec/services/data_import_service_spec.rb
@@ -394,5 +394,53 @@ RSpec.describe DataImportService do
         expect(ul.reload.graduation_count).to eq(0)
       end
     end
+
+    context "the milestone backfill's review_logs fetch" do
+      # Used to run once per imported word (O(words) SELECTs, dominating
+      # import time on large exports); Mastery::MilestoneReplay.backfill!
+      # batches it instead. See #391.
+      # Scoped to review_logs SELECTs specifically, not overall query
+      # count -- upsert_user_learning already does its own per-word
+      # lookups (a separate, pre-existing pattern unrelated to this fix),
+      # which would otherwise mask whether the review_logs fetch itself
+      # is bounded.
+      def review_log_select_count
+        count = 0
+        sub = lambda do |_name, _start, _finish, _id, payload|
+          sql = payload[:sql].to_s
+          count += 1 if sql.lstrip.upcase.start_with?("SELECT") && sql.include?("review_logs")
+        end
+        ActiveSupport::Notifications.subscribed(sub, "sql.active_record") { yield }
+        count
+      end
+
+      def word_payload(character, id)
+        {
+          "character" => character, "state" => "learning", "next_due" => nil,
+          "last_interval" => 1, "factor" => 2300,
+          "created_at" => "2026-01-01T00:00:00Z", "updated_at" => "2026-04-01T00:00:00Z",
+          "review_logs" => [
+            { "id" => id, "ease" => 1, "interval" => 1, "time_spent" => 1000,
+              "factor" => 2300, "log_type" => 0, "time" => nil,
+              "created_at" => "2026-01-10T09:00:00Z" }
+          ]
+        }
+      end
+
+      it "stays bounded regardless of how many words are imported" do
+        entry_ni
+        one_word = base_export.merge("user_learnings" => [ word_payload("你", 501) ])
+        count_with_one = review_log_select_count { described_class.call(user:, data: one_word) }
+
+        other_user = create(:user)
+        many_entries = 15.times.map { |i| create(:dictionary_entry, text: "字#{i}") }
+        many_words = base_export.merge(
+          "user_learnings" => many_entries.each_with_index.map { |e, i| word_payload(e.text, 600 + i) }
+        )
+        count_with_many = review_log_select_count { described_class.call(user: other_user, data: many_words) }
+
+        expect(count_with_many).to eq(count_with_one)
+      end
+    end
   end
 end

--- a/spec/services/data_import_service_spec.rb
+++ b/spec/services/data_import_service_spec.rb
@@ -313,5 +313,86 @@ RSpec.describe DataImportService do
         end
       end
     end
+
+    context "when imported review_logs graduate the word on replay" do
+      # ReviewLog.insert_all bypasses every callback, so first_mastered_at/
+      # graduation_count only get set by the explicit post-import
+      # Mastery::MilestoneReplay backfill. See #391.
+      let!(:ul) do
+        create(:user_learning, user:, dictionary_entry: entry_ni, state: "learning",
+               updated_at: Time.zone.parse("2026-01-01T00:00:00Z"))
+      end
+
+      let(:export_data) do
+        base_export.merge("user_learnings" => [
+          {
+            "character" => "你",
+            "state" => "mastered",
+            "next_due" => nil,
+            "last_interval" => 30,
+            "factor" => 2500,
+            "created_at" => ul.created_at.iso8601,
+            "updated_at" => "2026-04-01T00:00:00Z",
+            "review_logs" => [
+              {
+                "id" => 301, "ease" => 3, "interval" => 1, "time_spent" => 1000,
+                "factor" => 2500, "log_type" => 0, "time" => nil,
+                "created_at" => "2026-01-10T09:00:00Z"
+              },
+              {
+                "id" => 302, "ease" => 3, "interval" => 5, "time_spent" => 1000,
+                "factor" => 2500, "log_type" => 1, "time" => nil,
+                "created_at" => "2026-01-12T09:00:00Z"
+              }
+            ]
+          }
+        ])
+      end
+
+      it "sets first_mastered_at from the replayed graduating review, not import time" do
+        result
+        expect(ul.reload.first_mastered_at)
+          .to be_within(1.second).of(Time.zone.parse("2026-01-12T09:00:00Z"))
+      end
+
+      it "sets graduation_count to 1" do
+        result
+        expect(ul.reload.graduation_count).to eq(1)
+      end
+    end
+
+    context "when imported review_logs never graduate the word" do
+      let!(:ul) do
+        create(:user_learning, user:, dictionary_entry: entry_ni, state: "learning",
+               updated_at: Time.zone.parse("2026-01-01T00:00:00Z"))
+      end
+
+      let(:export_data) do
+        base_export.merge("user_learnings" => [
+          {
+            "character" => "你",
+            "state" => "learning",
+            "next_due" => nil,
+            "last_interval" => 1,
+            "factor" => 2300,
+            "created_at" => ul.created_at.iso8601,
+            "updated_at" => "2026-04-01T00:00:00Z",
+            "review_logs" => [
+              {
+                "id" => 401, "ease" => 1, "interval" => 1, "time_spent" => 1000,
+                "factor" => 2300, "log_type" => 0, "time" => nil,
+                "created_at" => "2026-01-10T09:00:00Z"
+              }
+            ]
+          }
+        ])
+      end
+
+      it "leaves first_mastered_at nil" do
+        result
+        expect(ul.reload.first_mastered_at).to be_nil
+        expect(ul.reload.graduation_count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/services/mastery/coverage_timeline_spec.rb
+++ b/spec/services/mastery/coverage_timeline_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Mastery::CoverageTimeline do
+  describe ".call" do
+    it "returns empty labels and series for no milestones" do
+      result = described_class.call(milestones: {}, tiers: [ :established, :emerging ])
+      expect(result).to eq(labels: [], series: { established: [], emerging: [] })
+    end
+
+    it "buckets each item by the furthest tier reached, weekly, up to end_date" do
+      milestones = {
+        1 => { established: Time.zone.parse("2026-01-15"), developing: nil, emerging: Time.zone.parse("2026-01-01") },
+        2 => { established: nil, developing: Time.zone.parse("2026-01-10"), emerging: Time.zone.parse("2026-01-01") },
+        3 => { established: nil, developing: nil, emerging: Time.zone.parse("2026-01-08") }
+      }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :established, :developing, :emerging ],
+        end_date: Time.zone.parse("2026-01-15")
+      )
+
+      expect(result[:labels]).to eq([ "Jan 1", "Jan 8", "Jan 15" ])
+      # Jan 1: only item 1 and 2 have touched (emerging), item 3 hasn't yet.
+      # Jan 8: item 3 has now touched too; item 2 doesn't cross into developing
+      # until Jan 10, so all three still read as emerging at this bucket.
+      expect(result[:series][:emerging]).to eq([ 2, 3, 1 ])
+      # item 2 crosses into developing on Jan 10 (between Jan 8 and Jan 15 buckets)
+      expect(result[:series][:developing]).to eq([ 0, 0, 1 ])
+      # item 1 crosses into established on Jan 15
+      expect(result[:series][:established]).to eq([ 0, 0, 1 ])
+    end
+
+    it "keeps established items established even if a later tier's date is also present" do
+      # Established should win over developing/emerging even when all three are set,
+      # since tiers are checked most-advanced-first.
+      milestones = {
+        1 => { established: Time.zone.parse("2026-01-01"), developing: Time.zone.parse("2026-01-01"), emerging: Time.zone.parse("2026-01-01") }
+      }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :established, :developing, :emerging ],
+        end_date: Time.zone.parse("2026-01-01")
+      )
+
+      expect(result[:series][:established]).to eq([ 1 ])
+      expect(result[:series][:developing]).to eq([ 0 ])
+      expect(result[:series][:emerging]).to eq([ 0 ])
+    end
+
+    it "does not count an item before its earliest tier date" do
+      milestones = { 1 => { emerging: Time.zone.parse("2026-01-10") } }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :emerging ],
+        end_date: Time.zone.parse("2026-01-10")
+      )
+
+      expect(result[:labels]).to eq([ "Jan 10" ])
+      expect(result[:series][:emerging]).to eq([ 1 ])
+    end
+
+    it "caps the final bucket exactly at end_date rather than overshooting" do
+      milestones = { 1 => { emerging: Time.zone.parse("2026-01-01") } }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :emerging ],
+        end_date: Time.zone.parse("2026-01-10")
+      )
+
+      expect(result[:labels].last).to eq("Jan 10")
+    end
+  end
+end

--- a/spec/services/mastery/coverage_timeline_spec.rb
+++ b/spec/services/mastery/coverage_timeline_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe Mastery::CoverageTimeline do
       expect(result[:series][:emerging]).to eq([ 1 ])
     end
 
+    it "counts every item from the same calendar day as an intermediate bucket, not just the earliest time" do
+      # Bucket boundaries are generated from the exact `start` timestamp,
+      # but labels only show day granularity ("Jan 1"). Without flooring
+      # intermediate bucket comparisons to end_of_day, an item touched
+      # later the same day as `start` would be missing from the "Jan 1"
+      # bucket even though nothing else happened between Jan 1 and Jan 8
+      # to explain the gap.
+      milestones = {
+        1 => { emerging: Time.zone.parse("2026-01-01 08:00") },
+        2 => { emerging: Time.zone.parse("2026-01-01 20:00") }
+      }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :emerging ],
+        end_date: Time.zone.parse("2026-01-15")
+      )
+
+      expect(result[:labels].first).to eq("Jan 1")
+      expect(result[:series][:emerging].first).to eq(2)
+    end
+
     it "caps the final bucket exactly at end_date rather than overshooting" do
       milestones = { 1 => { emerging: Time.zone.parse("2026-01-01") } }
 

--- a/spec/services/mastery/coverage_timeline_spec.rb
+++ b/spec/services/mastery/coverage_timeline_spec.rb
@@ -84,6 +84,22 @@ RSpec.describe Mastery::CoverageTimeline do
       expect(result[:series][:emerging].first).to eq(2)
     end
 
+    it "does not duplicate the final bucket when start and end_date share a calendar day" do
+      # A new user starting today: start (09:00) and end_date (15:00) are
+      # the same day. end_of_day-capping start's bucket lands it exactly
+      # on end_date -- the unconditional final push must not add it twice.
+      milestones = { 1 => { emerging: Time.zone.parse("2026-01-15 09:00") } }
+
+      result = described_class.call(
+        milestones: milestones,
+        tiers: [ :emerging ],
+        end_date: Time.zone.parse("2026-01-15 15:00")
+      )
+
+      expect(result[:labels]).to eq([ "Jan 15" ])
+      expect(result[:series][:emerging]).to eq([ 1 ])
+    end
+
     it "caps the final bucket exactly at end_date rather than overshooting" do
       milestones = { 1 => { emerging: Time.zone.parse("2026-01-01") } }
 

--- a/spec/services/mastery/milestone_replay_spec.rb
+++ b/spec/services/mastery/milestone_replay_spec.rb
@@ -75,4 +75,51 @@ RSpec.describe Mastery::MilestoneReplay do
       expect(result.graduation_count).to eq(2)
     end
   end
+
+  describe ".backfill!" do
+    it "does nothing for an empty id list" do
+      expect { described_class.backfill!([]) }.not_to raise_error
+    end
+
+    it "sets first_mastered_at/graduation_count/developing_at for each given UserLearning" do
+      create(:review_log, user_learning: user_learning, ease: 3, created_at: 2.days.ago)
+      graduating_log = create(:review_log, user_learning: user_learning, ease: 3, created_at: 1.day.ago)
+
+      described_class.backfill!([ user_learning.id ])
+
+      expect(user_learning.reload.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+      expect(user_learning.graduation_count).to eq(1)
+    end
+
+    it "keeps the review_logs SELECT count bounded regardless of how many ids are given" do
+      # Each id still needs its own UPDATE (distinct computed values per
+      # word -- that's inherent, not what the review flagged), but the
+      # review_logs fetch that used to run once per word must not scale
+      # with word count anymore.
+      seed = lambda do
+        ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+        create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago)
+        create(:review_log, user_learning: ul, ease: 3, created_at: 1.day.ago)
+        ul.id
+      end
+
+      def select_count
+        count = 0
+        sub = lambda do |_name, _start, _finish, _id, payload|
+          next if payload[:name].in?(%w[SCHEMA EXPLAIN])
+          count += 1 if payload[:sql].to_s.lstrip.upcase.start_with?("SELECT")
+        end
+        ActiveSupport::Notifications.subscribed(sub, "sql.active_record") { yield }
+        count
+      end
+
+      few_ids = [ seed.call ]
+      count_with_few = select_count { described_class.backfill!(few_ids) }
+
+      many_ids = few_ids + Array.new(15) { seed.call }
+      count_with_many = select_count { described_class.backfill!(many_ids) }
+
+      expect(count_with_many).to eq(count_with_few)
+    end
+  end
 end

--- a/spec/services/mastery/milestone_replay_spec.rb
+++ b/spec/services/mastery/milestone_replay_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe Mastery::MilestoneReplay do
+  let(:user)         { create(:user) }
+  let(:user_learning) { create(:user_learning, user: user, state: "learning") }
+  let(:threshold)    { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+  describe ".call" do
+    it "returns all-nil/zero for no review history" do
+      result = described_class.call([])
+
+      expect(result.first_mastered_at).to be_nil
+      expect(result.graduation_count).to eq(0)
+      expect(result.developing_at).to be_nil
+    end
+
+    it "sets first_mastered_at and graduation_count on graduation" do
+      create(:review_log, user_learning: user_learning, ease: 3, created_at: 2.days.ago)
+      graduating_log = create(:review_log, user_learning: user_learning, ease: 3, created_at: 1.day.ago)
+
+      result = described_class.call(user_learning.review_logs)
+
+      expect(result.first_mastered_at).to be_within(1.second).of(graduating_log.created_at)
+      expect(result.graduation_count).to eq(1)
+      expect(result.developing_at).to be_nil
+    end
+
+    it "sets developing_at when review_count reaches the threshold without graduating" do
+      (threshold - 1).times { |i| create(:review_log, user_learning: user_learning, ease: 1, created_at: (10 - i).days.ago) }
+      threshold_log = create(:review_log, user_learning: user_learning, ease: 1, created_at: 1.day.ago)
+
+      result = described_class.call(user_learning.review_logs)
+
+      expect(result.developing_at).to be_within(1.second).of(threshold_log.created_at)
+      expect(result.first_mastered_at).to be_nil
+      expect(result.graduation_count).to eq(0)
+    end
+
+    it "does not set developing_at when the word graduates at the threshold review" do
+      create(:review_log, user_learning: user_learning, ease: 1, created_at: 5.days.ago)
+      (threshold - 2).times { |i| create(:review_log, user_learning: user_learning, ease: 1, created_at: (4 - i).days.ago) }
+      create(:review_log, user_learning: user_learning, ease: 3, created_at: 1.day.ago) # graduates at review `threshold`
+
+      result = described_class.call(user_learning.review_logs)
+
+      expect(result.developing_at).to be_nil
+      expect(result.first_mastered_at).to be_present
+    end
+
+    it "counts every graduation but keeps first_mastered_at at the first one" do
+      create(:review_log, user_learning: user_learning, ease: 3, created_at: 12.days.ago) # new -> learning
+      first_graduation = create(:review_log, user_learning: user_learning, ease: 3, created_at: 10.days.ago) # 1st graduation
+      create(:review_log, user_learning: user_learning, ease: 1, created_at: 5.days.ago) # relapse
+      create(:review_log, user_learning: user_learning, ease: 3, created_at: 1.day.ago) # 2nd graduation
+
+      result = described_class.call(user_learning.review_logs)
+
+      expect(result.graduation_count).to eq(2)
+      expect(result.first_mastered_at).to be_within(1.second).of(first_graduation.created_at)
+    end
+
+    it "orders by (created_at, time, id) when created_at ties, as with a batch import" do
+      # Same construction as the ordering-regression tests for the backfill
+      # migrations: reverse-chronological insertion order under a shared
+      # created_at, distinguished only by `time`.
+      same_created_at = 1.day.ago
+      create(:review_log, user_learning: user_learning, ease: 3, time: 4000, created_at: same_created_at)
+      create(:review_log, user_learning: user_learning, ease: 1, time: 3000, created_at: same_created_at)
+      create(:review_log, user_learning: user_learning, ease: 3, time: 2000, created_at: same_created_at)
+      create(:review_log, user_learning: user_learning, ease: 1, time: 1000, created_at: same_created_at)
+
+      result = described_class.call(user_learning.review_logs)
+
+      # Correct time order [1, 3, 1, 3]: new->learning->mastered->learning->mastered = 2 graduations.
+      expect(result.graduation_count).to eq(2)
+    end
+  end
+end

--- a/spec/services/mastery/trajectory_snapshot_spec.rb
+++ b/spec/services/mastery/trajectory_snapshot_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe Mastery::TrajectorySnapshot do
+  include QueryCounter
+
+  let(:user) { create(:user) }
+  let(:threshold) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+  def bucket_for(result, key)
+    result[:buckets].find { |b| b.key == key }
+  end
+
+  describe ".call" do
+    it "returns zeroed buckets and total when there is nothing to classify" do
+      result = described_class.call(user: user)
+
+      expect(result[:total]).to eq(0)
+      expect(result[:buckets].map(&:count)).to all(eq(0))
+      expect(result[:buckets].map(&:percent)).to all(eq(0.0))
+    end
+
+    it "returns buckets in Stable, Recovering, Chronic, Stalled order" do
+      result = described_class.call(user: user)
+      expect(result[:buckets].map(&:key)).to eq([
+        Mastery::Trajectory::STABLE,
+        Mastery::Trajectory::RECOVERING,
+        Mastery::Trajectory::CHRONIC,
+        Mastery::Trajectory::STALLED
+      ])
+    end
+
+    it "classifies a word that graduated once and is still mastered as Stable" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 3)
+      ul.update!(state: "mastered")
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::STABLE).count).to eq(1)
+    end
+
+    it "classifies a word that graduated twice as Chronic" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 3)
+      ul.update!(state: "mastered")
+      ul.update!(state: "learning")
+      create(:review_log, user_learning: ul, ease: 3)
+      ul.update!(state: "mastered")
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::CHRONIC).count).to eq(1)
+    end
+
+    it "classifies a word that graduated once and has since lapsed as Recovering" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 3)
+      ul.update!(state: "mastered")
+      ul.update!(state: "learning")
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::RECOVERING).count).to eq(1)
+    end
+
+    it "classifies a never-graduated word past the threshold with flat ease as Stalled" do
+      ul = create(:user_learning, user: user, state: "learning")
+      threshold.times { create(:review_log, user_learning: ul, ease: 1) }
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::STALLED).count).to eq(1)
+    end
+
+    it "classifies a never-graduated word past the threshold with improving ease as Stable" do
+      ul = create(:user_learning, user: user, state: "learning")
+      (threshold - 3).times { create(:review_log, user_learning: ul, ease: 1) }
+      create(:review_log, user_learning: ul, ease: 3)
+      create(:review_log, user_learning: ul, ease: 3)
+      create(:review_log, user_learning: ul, ease: 4)
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::STABLE).count).to eq(1)
+    end
+
+    it "excludes words below the Developing threshold entirely" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 1)
+
+      result = described_class.call(user: user)
+      expect(result[:total]).to eq(0)
+    end
+
+    it "only classifies the given user's words" do
+      other_user = create(:user)
+      ul = create(:user_learning, user: other_user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 3)
+      ul.update!(state: "mastered")
+
+      result = described_class.call(user: user)
+      expect(result[:total]).to eq(0)
+    end
+
+    it "computes percent share of the total population" do
+      3.times do
+        ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+        create(:review_log, user_learning: ul, ease: 3)
+        ul.update!(state: "mastered")
+      end
+      chronic = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+      create(:review_log, user_learning: chronic, ease: 3)
+      chronic.update!(state: "mastered")
+      chronic.update!(state: "learning")
+      create(:review_log, user_learning: chronic, ease: 3)
+      chronic.update!(state: "mastered")
+
+      result = described_class.call(user: user)
+      expect(result[:total]).to eq(4)
+      expect(bucket_for(result, Mastery::Trajectory::STABLE).percent).to eq(75.0)
+      expect(bucket_for(result, Mastery::Trajectory::CHRONIC).percent).to eq(25.0)
+    end
+
+    it "keeps the query count bounded regardless of word count" do
+      # Rails short-circuits `where(id: [])` without a query, so an empty
+      # Developing population legitimately uses fewer queries than a
+      # non-empty one -- compare two non-empty populations instead, where
+      # the same fixed set of queries should fire regardless of size.
+      seed_developing_word = lambda do
+        ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+        threshold.times { create(:review_log, user_learning: ul, ease: 1) }
+      end
+      seed_developing_word.call
+
+      count_with_few = count_queries { described_class.call(user: user) }
+
+      15.times { seed_developing_word.call }
+
+      count_with_many = count_queries { described_class.call(user: user) }
+      expect(count_with_many).to eq(count_with_few)
+    end
+  end
+end

--- a/spec/services/mastery/trajectory_snapshot_spec.rb
+++ b/spec/services/mastery/trajectory_snapshot_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe Mastery::TrajectorySnapshot do
       expect(bucket_for(result, Mastery::Trajectory::STABLE).count).to eq(1)
     end
 
+    it "uses the 3 MOST RECENT eases, not the oldest 3" do
+      # 2 old good reviews followed by 3 recent bad ones, exactly at
+      # threshold. Last-3 (correct): [1,1,1], avg 1.0 -> Stalled.
+      # First-3 (wrong direction): [4,4,1], avg 3.0 -> would read Stable.
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 4)
+      create(:review_log, user_learning: ul, ease: 4)
+      3.times { create(:review_log, user_learning: ul, ease: 1) }
+
+      result = described_class.call(user: user)
+      expect(bucket_for(result, Mastery::Trajectory::STALLED).count).to eq(1)
+      expect(bucket_for(result, Mastery::Trajectory::STABLE).count).to eq(0)
+    end
+
     it "excludes words below the Developing threshold entirely" do
       ul = create(:user_learning, user: user, state: "learning")
       create(:review_log, user_learning: ul, ease: 1)

--- a/spec/support/anki_helper.rb
+++ b/spec/support/anki_helper.rb
@@ -129,8 +129,8 @@ module AnkiHelper
     AnkiSeedData::REVLOGS.each do |revlog|
       db.execute(
         "INSERT INTO revlog (id, cid, usn, ease, ivl, lastIvl, factor, time, type) " \
-        "VALUES (?, ?, -1, 2, 250, 100, 2500, 5000, 1)",
-        [ revlog[:id], revlog[:cid] ]
+        "VALUES (?, ?, -1, ?, 250, 100, 2500, 5000, 1)",
+        [ revlog[:id], revlog[:cid], revlog[:ease] || 2 ]
       )
     end
 

--- a/spec/support/anki_seed_data.rb
+++ b/spec/support/anki_seed_data.rb
@@ -101,6 +101,17 @@ module AnkiSeedData
       flds:    "90#{SEP}爱#{SEP}愛#{SEP}ài#{SEP}ai4#{SEP}to love#{SEP}verb#{SEP}",
       purpose: "REGRESSION ANCHOR: card homed in target deck but currently in a filtered deck " \
                "(did=FILTERED_DECK_ID, odid=DECK_ID) — import must include it via odid"
+    },
+    {
+      id:      10,
+      guid:    "note010",
+      sfld:    "谢谢",
+      flds:    "100#{SEP}谢谢#{SEP}謝謝#{SEP}xièxie#{SEP}xie4xie5#{SEP}thank you#{SEP}phrase#{SEP}",
+      purpose: "REGRESSION ANCHOR: two revlogs (ease 3, 3) so replaying this card's review " \
+               "history actually graduates it -- proves AnkiImportService's post-import " \
+               "Mastery::MilestoneReplay backfill (#391) sets first_mastered_at/" \
+               "graduation_count from real history, not just leaves them at insert_all's " \
+               "nil/0 defaults the way every other single-revlog card in this fixture would"
     }
   ].freeze
   # rubocop:enable Layout/ExtraSpacing
@@ -130,9 +141,17 @@ module AnkiSeedData
     # REGRESSION ANCHOR: card homed in target deck but currently in a filtered deck.
     # did=FILTERED_DECK_ID means the current migration query (WHERE did=target) misses it.
     # odid=DECK_ID is the only signal that it belongs to the target deck.
-    { id: 9, nid: 9, queue: 2, due: 300, did: FILTERED_DECK_ID, odid: DECK_ID }
+    { id: 9, nid: 9, queue: 2, due: 300, did: FILTERED_DECK_ID, odid: DECK_ID },
+    { id: 10, nid: 10, queue: 2, due: 300 } # mastered — see note010's revlogs below
   ].freeze
 
-  # One review event per card — enough to verify ReviewLog creation.
-  REVLOGS = CARDS.map { |c| { id: c[:id], cid: c[:id] } }.freeze
+  # One review event per card by default — enough to verify ReviewLog
+  # creation. Card 10 gets two explicit revlogs instead (ease 3, then 3):
+  # id=10's default single revlog only takes new -> learning, so a second,
+  # later revlog (higher id, sorted after it) is needed to actually reach
+  # "mastered" when replayed. See note010's :purpose above.
+  REVLOGS = (CARDS.reject { |c| c[:id] == 10 }.map { |c| { id: c[:id], cid: c[:id] } } + [
+    { id: 10, cid: 10, ease: 3 },
+    { id: 100, cid: 10, ease: 3 }
+  ]).freeze
 end


### PR DESCRIPTION
## Summary

Final slice of #391 -- the `/progress` UI itself, built against the design
validated in a static mockup and then re-tested with your real
learning-history export before writing any production code.

- **Coverage chart** (`coverage_chart_data`, replaces the old `chart_data`):
  3-tier stacked-area trend (Established/Developing/Emerging). Each word is
  bucketed by the *furthest* Coverage tier it had reached as of a given
  week (mutually exclusive per word), via the new `Mastery::CoverageTimeline`
  service -- genuinely monotonic in total, replacing the old single volatile
  "mastered" line the whole issue exists to fix.
- **Trajectory panel**: 4 status-colored KPI tiles (Stable/Recovering/
  Chronic/Stalled) via `Mastery::TrajectorySnapshot`, rendered server-side
  in `show` -- a live snapshot, not a trend, so no chart library or JSON
  endpoint needed for it.
- **Character coverage chart** (`character_chart_data`): down to 2 tiers
  (Established/Touched) from the old single line. The real data showed no
  natural Emerging/Developing split at the character level (median
  distinct-word-touch-count at establishment is 1) -- kept honest to what
  the data actually supports rather than forcing symmetry with the vocab
  chart.
- **`developing_at`**: a new durable milestone column (+ backfill migration
  + forward-going `ReviewLog` callback), following the exact same
  store-vs-recompute precedent as `first_mastered_at`/`graduation_count` --
  needed so the Coverage chart doesn't replay full review history per word
  per request.

No new frontend JS: both time-series charts reuse the existing
`progress_charts_controller.js`/Chart.js wiring unchanged -- only the JSON
shape changed. Trajectory's status colors are paired with an icon + label
per the dataviz skill's rule that status color never carries meaning alone.

## Design process

Built a static HTML mockup first (Artifact) to validate the layout/color
approach before touching production code. That process caught a real bug
early: my first mockup used independent bezier smoothing per stacked-area
layer boundary, which let adjacent layers cross between sample points --
switched to straight-line segments, which are mathematically guaranteed
not to cross for a proper stack. Also re-tested the mockup against your
actual `learn_hanzi_export_2026-07-12.json` before building, which
surfaced that Anki-imported reviews all share the migration's
`created_at` (not their true historical date) -- expected, now documented
in the Coverage panel's caption rather than hidden.

## Test plan

- [x] `bundle exec rspec` -- 1069 examples, 0 failures, 96%+ coverage
- [x] `bin/rubocop` -- no offenses
- [x] `bin/brakeman --no-pager` -- no warnings
- [x] New specs cover: `developing_at`'s backfill replay and forward-going
      callback (including the graduate-then-relapse edge case), both
      `CoverageTimeline` and `TrajectorySnapshot` in isolation, and full
      request-level coverage of both chart endpoints and the Trajectory
      tiles' rendered HTML -- including query-count-bounded assertions
      (fixed query count regardless of word count) per the issue's
      explicit page-load-time constraint
- [x] Manually verified via Playwright against real seeded data on a real
      signed-in session: both light and dark mode screenshotted, zero
      console errors, hover/tooltip interaction confirmed working, no
      rendering artifacts

## Deliberate decisions

- **Not applying `tension: 0` to `progress_charts_controller.js`**, per a
  review comment reading the "Design process" section above as implying
  production Chart.js needs the same straight-line fix as the throwaway
  mockup. It doesn't: that bug was in the mockup's own hand-rolled SVG
  (built because Artifacts can't load Chart.js from a CDN), which
  independently smoothed each stacked layer's boundary with per-point
  cubic beziers. Production reuses `progress_charts_controller.js`
  completely unchanged by this PR, backed by Chart.js's own mature spline
  implementation -- no evidence it reproduces the same bug, and no
  production code path shares the mockup's smoothing logic.

## Follow-up

Filed #396 (system specs for `/progress`, driving a real browser rather
than request specs) as a tracked follow-up -- blocked on #386 (still open)
since the general `type: :system` Capybara infrastructure these would
reuse lives in that PR's diff.

Closes #391.

https://claude.ai/code/session_01Dxi5uYDffEFfwPr5mmo2Vy
