### PR TITLE
fix: MCP authorize screen silently fails, scope copy is blank

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <div class="flex gap-4">
-      <%= form_tag oauth_authorization_path, method: :post, class: "flex-1" do %>
+      <%= form_tag oauth_authorization_path, method: :post, class: "flex-1", data: { turbo: false } do %>
         <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
         <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri, id: nil %>
         <%= hidden_field_tag :state, @pre_auth.state, id: nil %>
@@ -32,7 +32,7 @@
         <%= submit_tag t("doorkeeper.authorizations.buttons.authorize"),
               class: "w-full px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-500 transition-colors cursor-pointer" %>
       <% end %>
-      <%= form_tag oauth_authorization_path, method: :delete, class: "flex-1" do %>
+      <%= form_tag oauth_authorization_path, method: :delete, class: "flex-1", data: { turbo: false } do %>
         <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
         <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri, id: nil %>
         <%= hidden_field_tag :state, @pre_auth.state, id: nil %>

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -60,6 +60,9 @@ en:
         actions: 'Actions'
         not_defined: 'Not defined'
 
+    scopes:
+      mcp: 'View your Chinese vocabulary progress, HSK level breakdown, and review history (read-only, no changes to your data)'
+
     authorizations:
       buttons:
         authorize: 'Authorize'


### PR DESCRIPTION
## Summary
- Clicking Authorize/Deny on the OAuth consent screen did nothing: Turbo
  Drive submits the form via `fetch()`, and Doorkeeper's cross-origin 302
  redirect to the MCP client's `redirect_uri` (e.g. Claude's
  `auth_callback`) triggers a CORS preflight that endpoint isn't built to
  answer. The failure was silently swallowed by Turbo. Fixed by adding
  `data-turbo="false"` to both forms so they submit as plain navigations,
  which aren't subject to CORS.
- The consent screen listed the scope as the bare word "Mcp" because
  `doorkeeper.scopes.mcp` was never defined in the locale file. Added a
  real description of what the read-only `mcp` scope grants.

## Test plan
- [x] Verified via a throwaway request spec (removed before commit) that
      the rendered authorize page includes `data-turbo="false"` on both
      forms and the new scope description text
- [x] `bundle exec rspec` — full suite green
- [ ] Manual click-through against a live MCP client (e.g. Claude.ai) to
      confirm the end-to-end authorize flow completes, since the CORS
      failure can only be observed against a real cross-origin redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)