### PR TITLE
feat: clickable trajectory tiles drill into a sortable word list

### DIFF
--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -16,7 +16,11 @@ class ProgressController < ApplicationController
     @bucket = params[:bucket]
     raise ActionController::RoutingError, "Not Found" unless DRILLDOWN_BUCKETS.include?(@bucket)
 
-    @sort = params[:sort]
+    # An invalid sort is a bookmarked/hand-edited query string, not a
+    # missing resource -- fall back to the bucket's default ranking rather
+    # than 500ing (Mastery::TrajectoryEntries itself still raises for any
+    # other caller that skips this filtering).
+    @sort = params[:sort] if Mastery::TrajectoryEntries::SORTABLE_COLUMNS.include?(params[:sort])
     @direction = params[:direction]
 
     @result = Mastery::TrajectoryEntries.call(

--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -1,6 +1,5 @@
 class ProgressController < ApplicationController
   DRILLDOWN_BUCKETS = (Mastery::Trajectory::ALL - [ Mastery::Trajectory::NOT_APPLICABLE ]).freeze
-  MAX_PER_PAGE = 200
 
   def show
     # Rendered directly (no JSON endpoint/chart library needed) -- a live
@@ -26,7 +25,7 @@ class ProgressController < ApplicationController
       sort: @sort,
       direction: @direction,
       page: params[:page].presence&.to_i || 1,
-      per_page: params[:per_page].presence&.to_i&.clamp(1, MAX_PER_PAGE) || Mastery::TrajectoryEntries::PER_PAGE
+      per_page: params[:per_page].presence&.to_i || Mastery::TrajectoryEntries::PER_PAGE
     )
   end
 

--- a/app/controllers/progress_controller.rb
+++ b/app/controllers/progress_controller.rb
@@ -1,9 +1,33 @@
 class ProgressController < ApplicationController
+  DRILLDOWN_BUCKETS = (Mastery::Trajectory::ALL - [ Mastery::Trajectory::NOT_APPLICABLE ]).freeze
+  MAX_PER_PAGE = 200
+
   def show
     # Rendered directly (no JSON endpoint/chart library needed) -- a live
     # snapshot over a small population, cheap enough to compute inline.
     # See #391.
     @trajectory = Mastery::TrajectorySnapshot.call(user: Current.user)
+  end
+
+  # Drill-down behind a single trajectory tile: which words make it up,
+  # ranked by how firmly they exemplify the bucket by default, with an
+  # explicit sort/direction override once a column header is clicked.
+  # See #391, #400.
+  def trajectory
+    @bucket = params[:bucket]
+    raise ActionController::RoutingError, "Not Found" unless DRILLDOWN_BUCKETS.include?(@bucket)
+
+    @sort = params[:sort]
+    @direction = params[:direction]
+
+    @result = Mastery::TrajectoryEntries.call(
+      user: Current.user,
+      bucket: @bucket,
+      sort: @sort,
+      direction: @direction,
+      page: params[:page].presence&.to_i || 1,
+      per_page: params[:per_page].presence&.to_i&.clamp(1, MAX_PER_PAGE) || Mastery::TrajectoryEntries::PER_PAGE
+    )
   end
 
   # Weekly stacked-area trend: each word is bucketed by the furthest

--- a/app/helpers/progress_helper.rb
+++ b/app/helpers/progress_helper.rb
@@ -40,11 +40,35 @@ module ProgressHelper
     zigzag: '<path d="M2 12l3-4 3 2.5L13 4" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
   }.freeze
 
+  TRAJECTORY_SORT_COLUMNS = {
+    "word"        => "Word",
+    "meaning"     => "Meaning",
+    "ease"        => "Ease",
+    "graduations" => "Graduations",
+    "since"       => "Since",
+    "next_due"    => "Next due"
+  }.freeze
+
   def trajectory_tile_config(key)
     TRAJECTORY_TILES.fetch(key)
   end
 
   def trajectory_icon(type)
     tag.svg(raw(ICONS.fetch(type)), viewBox: "0 0 16 16", class: "w-3 h-3", "aria-hidden": "true") # rubocop:disable Rails/OutputSafety
+  end
+
+  # Toggles asc/desc on a repeat click of the same column; any other column
+  # always starts from asc.
+  def trajectory_sort_link(column, label)
+    active = @sort == column
+    next_direction = active && @direction != "desc" ? "desc" : "asc"
+    arrow = active ? (@direction == "desc" ? " ▼" : " ▲") : ""
+
+    link_to "#{label}#{arrow}", trajectory_page_path(sort: column, direction: next_direction, page: 1),
+      class: [ "hover:underline", ("font-semibold text-indigo-600 dark:text-indigo-400" if active) ].compact.join(" ")
+  end
+
+  def trajectory_page_path(page:, sort: @sort, direction: @direction)
+    learn_progress_trajectory_path(bucket: @bucket, sort: sort, direction: direction, per_page: @result.per_page, page: page)
   end
 end

--- a/app/services/mastery/recent_eases.rb
+++ b/app/services/mastery/recent_eases.rb
@@ -17,6 +17,7 @@ module Mastery
           FROM review_logs
           WHERE user_learning_id IN (?)
         ) ranked WHERE rn <= #{Thresholds::STALLED_LOOKBACK_REVIEWS}
+        ORDER BY user_learning_id, rn
       SQL
 
       ReviewLog.connection.select_all(sql).each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, memo|

--- a/app/services/mastery/recent_eases.rb
+++ b/app/services/mastery/recent_eases.rb
@@ -1,0 +1,27 @@
+module Mastery
+  # Bounded to (at most) STALLED_LOOKBACK_REVIEWS rows per UserLearning via a
+  # window function, rather than loading every review_log a word has ever
+  # had. Shared by TrajectorySnapshot and TrajectoryEntries -- both need
+  # "last N eases per word" for the same Stalled check. See #391, #400.
+  class RecentEases
+    def self.call(user_learning_ids:)
+      return {} if user_learning_ids.empty?
+
+      sql = ReviewLog.sanitize_sql_array([ <<~SQL, user_learning_ids ])
+        SELECT user_learning_id, ease FROM (
+          SELECT user_learning_id, ease,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY user_learning_id
+                   ORDER BY created_at DESC, time DESC, id DESC
+                 ) AS rn
+          FROM review_logs
+          WHERE user_learning_id IN (?)
+        ) ranked WHERE rn <= #{Thresholds::STALLED_LOOKBACK_REVIEWS}
+      SQL
+
+      ReviewLog.connection.select_all(sql).each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, memo|
+        memo[row["user_learning_id"]] << row["ease"]
+      end
+    end
+  end
+end

--- a/app/services/mastery/trajectory_entries.rb
+++ b/app/services/mastery/trajectory_entries.rb
@@ -11,6 +11,16 @@ module Mastery
   # request never touches the Developing rows (and its bounded
   # recent-eases query), and a Stalled request never touches Established
   # rows -- only Stable pays for both.
+  #
+  # Sorting and pagination both happen against lightweight [UserLearning,
+  # coverage] candidates -- every sortable column except word/meaning
+  # lives directly on user_learnings, so no join is needed to rank the
+  # whole bucket. dictionary_entry/meanings are only ever hydrated for the
+  # current page's ids, after pagination has already picked them, so a
+  # large bucket costs no more per-request than a small one. Sorting by
+  # word/meaning is the one case that needs text for the whole bucket
+  # before ranking; that's a single lightweight lookup query (no
+  # association hydration), not a switch back to loading everything.
   class TrajectoryEntries
     Entry = Data.define(:id, :text, :pinyin, :meaning, :coverage, :factor, :graduation_count, :since, :next_due)
     Result = Data.define(:entries, :total, :page, :per_page)
@@ -18,16 +28,7 @@ module Mastery
     PER_PAGE = 50
     MAX_PER_PAGE = 200
 
-    SORT_KEYS = {
-      "word"        => ->(entry) { entry.text },
-      "meaning"     => ->(entry) { entry.meaning.to_s },
-      "ease"        => ->(entry) { entry.factor },
-      "graduations" => ->(entry) { entry.graduation_count },
-      "since"       => ->(entry) { entry.since || Time.at(0) },
-      "next_due"    => ->(entry) { entry.next_due || Time.at(0) }
-    }.freeze
-
-    SORTABLE_COLUMNS = SORT_KEYS.keys.freeze
+    SORTABLE_COLUMNS = %w[word meaning ease graduations since next_due].freeze
 
     def self.call(user:, bucket:, sort: nil, direction: nil, page: 1, per_page: PER_PAGE)
       new(user, bucket, sort, direction, page, per_page).call
@@ -43,11 +44,10 @@ module Mastery
     end
 
     def call
-      entries = hydrate(filtered_ids_with_coverage)
-      ordered = @sort ? sort_explicit(entries) : sort_default(entries)
+      ordered = @sort ? sort_explicit(filtered_candidates) : sort_default(filtered_candidates)
 
       Result.new(
-        entries: paginate(ordered),
+        entries: hydrate(paginate(ordered)),
         total: ordered.size,
         page: @page,
         per_page: @per_page
@@ -56,15 +56,15 @@ module Mastery
 
     private
 
-    def filtered_ids_with_coverage
+    def filtered_candidates
       case @bucket
       when Trajectory::CHRONIC, Trajectory::RECOVERING
-        classified_established.filter_map { |ul, t| [ ul.id, Coverage::ESTABLISHED ] if t == @bucket }
+        classified_established.filter_map { |ul, t| [ ul, Coverage::ESTABLISHED ] if t == @bucket }
       when Trajectory::STALLED
-        classified_developing.filter_map { |ul, t| [ ul.id, Coverage::DEVELOPING ] if t == @bucket }
+        classified_developing.filter_map { |ul, t| [ ul, Coverage::DEVELOPING ] if t == @bucket }
       when Trajectory::STABLE
-        established = classified_established.filter_map { |ul, t| [ ul.id, Coverage::ESTABLISHED ] if t == Trajectory::STABLE }
-        developing  = classified_developing.filter_map  { |ul, t| [ ul.id, Coverage::DEVELOPING ]  if t == Trajectory::STABLE }
+        established = classified_established.filter_map { |ul, t| [ ul, Coverage::ESTABLISHED ] if t == Trajectory::STABLE }
+        developing  = classified_developing.filter_map  { |ul, t| [ ul, Coverage::DEVELOPING ]  if t == Trajectory::STABLE }
         established + developing
       else
         raise ArgumentError, "unknown trajectory bucket: #{@bucket.inspect}"
@@ -86,7 +86,7 @@ module Mastery
     def established_records
       @established_records ||= @user.user_learnings
         .where.not(first_mastered_at: nil)
-        .select(:id, :state, :graduation_count)
+        .select(:id, :state, :graduation_count, :factor, :first_mastered_at, :next_due)
         .to_a
     end
 
@@ -100,64 +100,12 @@ module Mastery
     def developing_records
       @developing_records ||= @user.user_learnings
         .where(id: developing_ids)
-        .select(:id, :state, :graduation_count)
+        .select(:id, :state, :graduation_count, :factor, :developing_at, :next_due)
         .to_a
     end
 
     def recent_eases
       @recent_eases ||= RecentEases.call(user_learning_ids: developing_ids)
-    end
-
-    # One rich fetch for exactly the filtered ids, regardless of how many
-    # the bucket holds -- query count stays fixed as bucket size grows,
-    # same guarantee TrajectorySnapshot already gives.
-    def hydrate(ids_with_coverage)
-      coverage_by_id = ids_with_coverage.to_h
-      return [] if coverage_by_id.empty?
-
-      @user.user_learnings
-        .where(id: coverage_by_id.keys)
-        .includes(dictionary_entry: :meanings)
-        .map do |ul|
-          entry   = ul.dictionary_entry
-          meaning = entry.meanings.first
-          coverage = coverage_by_id.fetch(ul.id)
-
-          Entry.new(
-            id: ul.id,
-            text: entry.text,
-            pinyin: meaning&.pinyin,
-            meaning: meaning&.text,
-            coverage: coverage,
-            factor: ul.factor,
-            graduation_count: ul.graduation_count,
-            since: coverage == Coverage::ESTABLISHED ? ul.first_mastered_at : ul.developing_at,
-            next_due: ul.next_due
-          )
-        end
-    end
-
-    def sort_explicit(entries)
-      raise ArgumentError, "unsupported sort column: #{@sort.inspect}" unless SORTABLE_COLUMNS.include?(@sort)
-
-      key = SORT_KEYS.fetch(@sort)
-      sorted = entries.sort_by { |entry| key.call(entry) }
-      @direction == "desc" ? sorted.reverse : sorted
-    end
-
-    def sort_default(entries)
-      case @bucket
-      when Trajectory::CHRONIC
-        entries.sort_by { |e| -e.graduation_count }
-      when Trajectory::RECOVERING
-        entries.sort_by { |e| -e.factor }
-      when Trajectory::STALLED
-        entries.sort_by { |e| recent_average_ease(e.id) }
-      when Trajectory::STABLE
-        entries.sort_by { |e| [ e.coverage == Coverage::ESTABLISHED ? 0 : 1, -e.factor ] }
-      else
-        entries
-      end
     end
 
     def recent_average_ease(user_learning_id)
@@ -167,9 +115,117 @@ module Mastery
       eases.sum.to_f / eases.size
     end
 
-    def paginate(entries)
+    def since_for(user_learning, coverage)
+      coverage == Coverage::ESTABLISHED ? user_learning.first_mastered_at : user_learning.developing_at
+    end
+
+    def sort_default(candidates)
+      case @bucket
+      when Trajectory::CHRONIC
+        candidates.sort_by { |ul, _coverage| -ul.graduation_count }
+      when Trajectory::RECOVERING
+        candidates.sort_by { |ul, _coverage| -ul.factor }
+      when Trajectory::STALLED
+        candidates.sort_by { |ul, _coverage| recent_average_ease(ul.id) }
+      when Trajectory::STABLE
+        candidates.sort_by { |ul, coverage| [ coverage == Coverage::ESTABLISHED ? 0 : 1, -ul.factor ] }
+      else
+        candidates
+      end
+    end
+
+    def sort_explicit(candidates)
+      raise ArgumentError, "unsupported sort column: #{@sort.inspect}" unless SORTABLE_COLUMNS.include?(@sort)
+
+      sorted = case @sort
+      when "word"
+        lookup = word_lookup(candidates.map { |ul, _coverage| ul.id })
+        candidates.sort_by { |ul, _coverage| lookup.fetch(ul.id, "") }
+      when "meaning"
+        lookup = meaning_lookup(candidates.map { |ul, _coverage| ul.id })
+        candidates.sort_by { |ul, _coverage| lookup.fetch(ul.id, "").to_s }
+      when "ease"
+        candidates.sort_by { |ul, _coverage| ul.factor }
+      when "graduations"
+        candidates.sort_by { |ul, _coverage| ul.graduation_count }
+      when "since"
+        candidates.sort_by { |ul, coverage| since_for(ul, coverage) || Time.at(0) }
+      when "next_due"
+        candidates.sort_by { |ul, _coverage| ul.next_due || Time.at(0) }
+      end
+
+      @direction == "desc" ? sorted.reverse : sorted
+    end
+
+    # Text only, no association hydration -- used purely to rank the whole
+    # bucket by word when that's the explicit sort. dictionary_entry
+    # itself is still only ever loaded for the final page, in #hydrate.
+    def word_lookup(ids)
+      return {} if ids.empty?
+
+      @user.user_learnings.where(id: ids).joins(:dictionary_entry).pluck(:id, "dictionary_entries.text").to_h
+    end
+
+    # Mirrors what `dictionary_entry.meanings.first` returns elsewhere in
+    # the app (Rails adds an implicit `ORDER BY id ASC` to an unscoped
+    # `#first`) -- the lowest-id meaning per entry, fetched in one query
+    # rather than N+1ing meanings per candidate.
+    def meaning_lookup(ids)
+      return {} if ids.empty?
+
+      sql = Meaning.sanitize_sql_array([ <<~SQL, ids ])
+        SELECT ul.id AS user_learning_id, m.text AS meaning_text
+        FROM user_learnings ul
+        JOIN meanings m ON m.id = (
+          SELECT MIN(m2.id) FROM meanings m2 WHERE m2.dictionary_entry_id = ul.dictionary_entry_id
+        )
+        WHERE ul.id IN (?)
+      SQL
+
+      Meaning.connection.select_all(sql).each_with_object({}) do |row, memo|
+        memo[row["user_learning_id"]] = row["meaning_text"]
+      end
+    end
+
+    def paginate(candidates)
       offset = (@page - 1) * @per_page
-      entries[offset, @per_page] || []
+      candidates[offset, @per_page] || []
+    end
+
+    # One rich fetch for exactly the current page's ids, regardless of how
+    # many the bucket holds -- both query count and data volume stay fixed
+    # as bucket size grows. `where(id:)` doesn't preserve the order of
+    # `ids`, so results are re-keyed and walked back out in the order
+    # already decided by sort_default/sort_explicit above.
+    def hydrate(page_candidates)
+      return [] if page_candidates.empty?
+
+      coverage_by_id = page_candidates.to_h { |ul, coverage| [ ul.id, coverage ] }
+      ordered_ids = page_candidates.map { |ul, _coverage| ul.id }
+
+      records_by_id = @user.user_learnings
+        .where(id: ordered_ids)
+        .includes(dictionary_entry: :meanings)
+        .index_by(&:id)
+
+      ordered_ids.map do |id|
+        ul      = records_by_id.fetch(id)
+        entry   = ul.dictionary_entry
+        meaning = entry.meanings.first
+        coverage = coverage_by_id.fetch(id)
+
+        Entry.new(
+          id: ul.id,
+          text: entry.text,
+          pinyin: meaning&.pinyin,
+          meaning: meaning&.text,
+          coverage: coverage,
+          factor: ul.factor,
+          graduation_count: ul.graduation_count,
+          since: since_for(ul, coverage),
+          next_due: ul.next_due
+        )
+      end
     end
   end
 end

--- a/app/services/mastery/trajectory_entries.rb
+++ b/app/services/mastery/trajectory_entries.rb
@@ -1,0 +1,174 @@
+module Mastery
+  # Drill-down behind a single Trajectory bucket tile on /progress: which
+  # DictionaryEntry words actually make it up, ranked by how firmly they
+  # exemplify the label, with an explicit sort/direction override for
+  # anything clicked on the table header. See #391, #400.
+  #
+  # Population per bucket -- Chronic/Recovering only ever contain
+  # Established words (graduation_count >= 1 implies first_mastered_at is
+  # set), Stalled only ever contains Developing words, and Stable spans
+  # both. Each population is fetched independently so a Chronic/Recovering
+  # request never touches the Developing rows (and its bounded
+  # recent-eases query), and a Stalled request never touches Established
+  # rows -- only Stable pays for both.
+  class TrajectoryEntries
+    Entry = Data.define(:id, :text, :pinyin, :meaning, :coverage, :factor, :graduation_count, :since, :next_due)
+    Result = Data.define(:entries, :total, :page, :per_page)
+
+    PER_PAGE = 50
+
+    SORT_KEYS = {
+      "word"        => ->(entry) { entry.text },
+      "meaning"     => ->(entry) { entry.meaning.to_s },
+      "ease"        => ->(entry) { entry.factor },
+      "graduations" => ->(entry) { entry.graduation_count },
+      "since"       => ->(entry) { entry.since || Time.at(0) },
+      "next_due"    => ->(entry) { entry.next_due || Time.at(0) }
+    }.freeze
+
+    SORTABLE_COLUMNS = SORT_KEYS.keys.freeze
+
+    def self.call(user:, bucket:, sort: nil, direction: nil, page: 1, per_page: PER_PAGE)
+      new(user, bucket, sort, direction, page, per_page).call
+    end
+
+    def initialize(user, bucket, sort, direction, page, per_page)
+      @user = user
+      @bucket = bucket
+      @sort = sort
+      @direction = direction.to_s == "desc" ? "desc" : "asc"
+      @page = [ page.to_i, 1 ].max
+      @per_page = [ per_page.to_i, 1 ].max
+    end
+
+    def call
+      entries = hydrate(filtered_ids_with_coverage)
+      ordered = @sort ? sort_explicit(entries) : sort_default(entries)
+
+      Result.new(
+        entries: paginate(ordered),
+        total: ordered.size,
+        page: @page,
+        per_page: @per_page
+      )
+    end
+
+    private
+
+    def filtered_ids_with_coverage
+      case @bucket
+      when Trajectory::CHRONIC, Trajectory::RECOVERING
+        classified_established.filter_map { |ul, t| [ ul.id, Coverage::ESTABLISHED ] if t == @bucket }
+      when Trajectory::STALLED
+        classified_developing.filter_map { |ul, t| [ ul.id, Coverage::DEVELOPING ] if t == @bucket }
+      when Trajectory::STABLE
+        established = classified_established.filter_map { |ul, t| [ ul.id, Coverage::ESTABLISHED ] if t == Trajectory::STABLE }
+        developing  = classified_developing.filter_map  { |ul, t| [ ul.id, Coverage::DEVELOPING ]  if t == Trajectory::STABLE }
+        established + developing
+      else
+        raise ArgumentError, "unknown trajectory bucket: #{@bucket.inspect}"
+      end
+    end
+
+    def classified_established
+      @classified_established ||= established_records.map do |ul|
+        [ ul, Trajectory.call(user_learning: ul, coverage: Coverage::ESTABLISHED, recent_eases: []) ]
+      end
+    end
+
+    def classified_developing
+      @classified_developing ||= developing_records.map do |ul|
+        [ ul, Trajectory.call(user_learning: ul, coverage: Coverage::DEVELOPING, recent_eases: recent_eases[ul.id] || []) ]
+      end
+    end
+
+    def established_records
+      @established_records ||= @user.user_learnings
+        .where.not(first_mastered_at: nil)
+        .select(:id, :state, :graduation_count)
+        .to_a
+    end
+
+    def developing_ids
+      @developing_ids ||= @user.user_learnings
+        .where(first_mastered_at: nil)
+        .where.not(developing_at: nil)
+        .pluck(:id)
+    end
+
+    def developing_records
+      @developing_records ||= @user.user_learnings
+        .where(id: developing_ids)
+        .select(:id, :state, :graduation_count)
+        .to_a
+    end
+
+    def recent_eases
+      @recent_eases ||= RecentEases.call(user_learning_ids: developing_ids)
+    end
+
+    # One rich fetch for exactly the filtered ids, regardless of how many
+    # the bucket holds -- query count stays fixed as bucket size grows,
+    # same guarantee TrajectorySnapshot already gives.
+    def hydrate(ids_with_coverage)
+      coverage_by_id = ids_with_coverage.to_h
+      return [] if coverage_by_id.empty?
+
+      @user.user_learnings
+        .where(id: coverage_by_id.keys)
+        .includes(dictionary_entry: :meanings)
+        .map do |ul|
+          entry   = ul.dictionary_entry
+          meaning = entry.meanings.first
+          coverage = coverage_by_id.fetch(ul.id)
+
+          Entry.new(
+            id: ul.id,
+            text: entry.text,
+            pinyin: meaning&.pinyin,
+            meaning: meaning&.text,
+            coverage: coverage,
+            factor: ul.factor,
+            graduation_count: ul.graduation_count,
+            since: coverage == Coverage::ESTABLISHED ? ul.first_mastered_at : ul.developing_at,
+            next_due: ul.next_due
+          )
+        end
+    end
+
+    def sort_explicit(entries)
+      raise ArgumentError, "unsupported sort column: #{@sort.inspect}" unless SORTABLE_COLUMNS.include?(@sort)
+
+      key = SORT_KEYS.fetch(@sort)
+      sorted = entries.sort_by { |entry| key.call(entry) }
+      @direction == "desc" ? sorted.reverse : sorted
+    end
+
+    def sort_default(entries)
+      case @bucket
+      when Trajectory::CHRONIC
+        entries.sort_by { |e| -e.graduation_count }
+      when Trajectory::RECOVERING
+        entries.sort_by { |e| -e.factor }
+      when Trajectory::STALLED
+        entries.sort_by { |e| recent_average_ease(e.id) }
+      when Trajectory::STABLE
+        entries.sort_by { |e| [ e.coverage == Coverage::ESTABLISHED ? 0 : 1, -e.factor ] }
+      else
+        entries
+      end
+    end
+
+    def recent_average_ease(user_learning_id)
+      eases = recent_eases[user_learning_id]
+      return Float::INFINITY if eases.blank?
+
+      eases.sum.to_f / eases.size
+    end
+
+    def paginate(entries)
+      offset = (@page - 1) * @per_page
+      entries[offset, @per_page] || []
+    end
+  end
+end

--- a/app/services/mastery/trajectory_entries.rb
+++ b/app/services/mastery/trajectory_entries.rb
@@ -211,7 +211,14 @@ module Mastery
       ordered_ids.map do |id|
         ul      = records_by_id.fetch(id)
         entry   = ul.dictionary_entry
-        meaning = entry.meanings.first
+        # entry.meanings is already an in-memory Array here (preloaded via
+        # .includes above), so plain #first would return whichever row the
+        # preload query happened to return first -- has_many :meanings has
+        # no explicit order, so that's unspecified, unlike a fresh
+        # Relation#first (which Rails gives an implicit ORDER BY id).
+        # #min_by(&:id) makes the choice deterministic and matches
+        # meaning_lookup's explicit MIN(id) above.
+        meaning = entry.meanings.min_by(&:id)
         coverage = coverage_by_id.fetch(id)
 
         Entry.new(

--- a/app/services/mastery/trajectory_entries.rb
+++ b/app/services/mastery/trajectory_entries.rb
@@ -16,6 +16,7 @@ module Mastery
     Result = Data.define(:entries, :total, :page, :per_page)
 
     PER_PAGE = 50
+    MAX_PER_PAGE = 200
 
     SORT_KEYS = {
       "word"        => ->(entry) { entry.text },
@@ -38,7 +39,7 @@ module Mastery
       @sort = sort
       @direction = direction.to_s == "desc" ? "desc" : "asc"
       @page = [ page.to_i, 1 ].max
-      @per_page = [ per_page.to_i, 1 ].max
+      @per_page = per_page.to_i.clamp(1, MAX_PER_PAGE)
     end
 
     def call

--- a/app/services/mastery/trajectory_snapshot.rb
+++ b/app/services/mastery/trajectory_snapshot.rb
@@ -65,28 +65,8 @@ module Mastery
         .to_a
     end
 
-    # Bounded to (at most) STALLED_LOOKBACK_REVIEWS rows per Developing
-    # word via a window function, rather than loading every review_log a
-    # word has ever had (some in the real data have 40+) just to keep the
-    # last few.
     def recent_eases
-      return @recent_eases ||= {} if developing_ids.empty?
-
-      sql = ReviewLog.sanitize_sql_array([ <<~SQL, developing_ids ])
-        SELECT user_learning_id, ease FROM (
-          SELECT user_learning_id, ease,
-                 ROW_NUMBER() OVER (
-                   PARTITION BY user_learning_id
-                   ORDER BY created_at DESC, time DESC, id DESC
-                 ) AS rn
-          FROM review_logs
-          WHERE user_learning_id IN (?)
-        ) ranked WHERE rn <= #{Thresholds::STALLED_LOOKBACK_REVIEWS}
-      SQL
-
-      @recent_eases ||= ReviewLog.connection.select_all(sql).each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, memo|
-        memo[row["user_learning_id"]] << row["ease"]
-      end
+      @recent_eases ||= RecentEases.call(user_learning_ids: developing_ids)
     end
   end
 end

--- a/app/views/progress/_trajectory_tile.html.erb
+++ b/app/views/progress/_trajectory_tile.html.erb
@@ -1,5 +1,7 @@
 <% config = trajectory_tile_config(bucket.key) %>
-<div class="rounded-lg p-4 <%= config[:card] %>" data-trajectory-key="<%= bucket.key %>">
+<%= link_to learn_progress_trajectory_path(bucket: bucket.key),
+      class: "block rounded-lg p-4 transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 #{config[:card]}",
+      data: { trajectory_key: bucket.key } do %>
   <div class="flex items-center gap-2">
     <span class="w-5 h-5 rounded-full flex items-center justify-center <%= config[:icon_bg] %>">
       <%= trajectory_icon(config[:icon]) %>
@@ -10,4 +12,4 @@
   <div class="text-xs text-gray-500 dark:text-gray-400">
     <%= number_with_precision(bucket.percent, precision: 1) %>% · <%= config[:description] %>
   </div>
-</div>
+<% end %>

--- a/app/views/progress/trajectory.html.erb
+++ b/app/views/progress/trajectory.html.erb
@@ -1,0 +1,60 @@
+<% config = trajectory_tile_config(@bucket) %>
+<% content_for :title, "#{config[:label]} words" %>
+
+<div class="flex-grow max-w-4xl mx-auto w-full">
+  <div class="flex items-center justify-between mb-8">
+    <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-200"><%= config[:label] %> words</h1>
+    <%= link_to "Progress", learn_progress_path,
+          class: "text-sm text-indigo-600 dark:text-indigo-400 hover:underline" %>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6">
+    <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+      <%= number_with_delimiter(@result.total) %> word<%= "s" unless @result.total == 1 %> · <%= config[:description] %>
+    </p>
+
+    <% if @result.entries.empty? %>
+      <p class="text-sm text-gray-400 dark:text-gray-500">Nothing here yet.</p>
+    <% else %>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+              <% ProgressHelper::TRAJECTORY_SORT_COLUMNS.each do |column, label| %>
+                <th class="py-2 pr-4 font-medium"><%= trajectory_sort_link(column, label) %></th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+            <% @result.entries.each do |entry| %>
+              <tr>
+                <td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200" data-word="<%= entry.text %>"><%= entry.text %></td>
+                <td class="py-2 pr-4 text-gray-600 dark:text-gray-400">
+                  <% if entry.pinyin.present? %>
+                    <div class="text-xs text-gray-400 dark:text-gray-500"><%= entry.pinyin %></div>
+                  <% end %>
+                  <%= entry.meaning %>
+                </td>
+                <td class="py-2 pr-4 tabular-nums text-gray-600 dark:text-gray-400"><%= entry.factor %></td>
+                <td class="py-2 pr-4 tabular-nums text-gray-600 dark:text-gray-400"><%= entry.graduation_count %></td>
+                <td class="py-2 pr-4 text-gray-600 dark:text-gray-400"><%= entry.since&.strftime("%-d %b %Y") || "—" %></td>
+                <td class="py-2 pr-4 text-gray-600 dark:text-gray-400"><%= entry.next_due&.strftime("%-d %b %Y") || "—" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="flex justify-between items-center mt-4 text-sm">
+        <% if @result.page > 1 %>
+          <%= link_to "← Previous", trajectory_page_path(page: @result.page - 1), class: "text-indigo-600 dark:text-indigo-400 hover:underline" %>
+        <% else %>
+          <span></span>
+        <% end %>
+        <% if @result.page * @result.per_page < @result.total %>
+          <%= link_to "Next →", trajectory_page_path(page: @result.page + 1), class: "text-indigo-600 dark:text-indigo-400 hover:underline" %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,9 +28,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "dashboard#index"
 
-  get  "learn/progress",                      to: "progress#show",                 as: :learn_progress
-  get  "learn/progress/coverage_chart_data",  to: "progress#coverage_chart_data",  as: :learn_progress_coverage_chart_data
-  get  "learn/progress/character_chart_data", to: "progress#character_chart_data", as: :learn_progress_character_chart_data
+  get  "learn/progress",                        to: "progress#show",                 as: :learn_progress
+  get  "learn/progress/coverage_chart_data",    to: "progress#coverage_chart_data",  as: :learn_progress_coverage_chart_data
+  get  "learn/progress/character_chart_data",   to: "progress#character_chart_data", as: :learn_progress_character_chart_data
+  get  "learn/progress/trajectory/:bucket",     to: "progress#trajectory",           as: :learn_progress_trajectory
 
   get  "review",          to: "review#start",   as: :review
   get  "review/card",     to: "review#show",    as: :review_card

--- a/spec/requests/progress_spec.rb
+++ b/spec/requests/progress_spec.rb
@@ -316,6 +316,15 @@ RSpec.describe "Progress", type: :request do
         expect(response).to have_http_status(:not_found)
       end
 
+      it "falls back to the bucket's default ranking on an invalid sort param, rather than 500ing" do
+        graduate!(text: "established_word")
+
+        get learn_progress_trajectory_path(bucket: "stable", sort: "'; DROP TABLE users; --", direction: "asc")
+
+        expect(response).to have_http_status(:success)
+        expect(word_cells).to include("established_word")
+      end
+
       it "lists the words classified into the requested bucket" do
         graduate!(text: "established_word")
 

--- a/spec/requests/progress_spec.rb
+++ b/spec/requests/progress_spec.rb
@@ -276,4 +276,114 @@ RSpec.describe "Progress", type: :request do
       end
     end
   end
+
+  describe "GET /learn/progress/trajectory/:bucket" do
+    context "when unauthenticated" do
+      it "redirects to the login page" do
+        get learn_progress_trajectory_path(bucket: "stable")
+        expect(response).to redirect_to("/sign_in")
+      end
+    end
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      def word_cells
+        Nokogiri::HTML(response.body).css("[data-word]").map { |el| el["data-word"] }
+      end
+
+      def graduate!(text:)
+        ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry, text: text))
+        create(:review_log, user_learning: ul, ease: 3)
+        ul.update!(state: "mastered")
+        ul
+      end
+
+      it "returns a successful response for each valid bucket" do
+        %w[stable recovering chronic stalled].each do |bucket|
+          get learn_progress_trajectory_path(bucket: bucket)
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      it "404s on an unknown bucket" do
+        get learn_progress_trajectory_path(bucket: "not_a_real_bucket")
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "404s on the not_applicable bucket (not a real drill-down)" do
+        get learn_progress_trajectory_path(bucket: Mastery::Trajectory::NOT_APPLICABLE)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "lists the words classified into the requested bucket" do
+        graduate!(text: "established_word")
+
+        get learn_progress_trajectory_path(bucket: "stable")
+        expect(word_cells).to include("established_word")
+      end
+
+      it "excludes words from other buckets" do
+        threshold = Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT
+        stalled_ul = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry, text: "stalled_word"))
+        threshold.times { create(:review_log, user_learning: stalled_ul, ease: 1) }
+
+        get learn_progress_trajectory_path(bucket: "chronic")
+        expect(word_cells).not_to include("stalled_word")
+      end
+
+      it "only shows the current user's words" do
+        other_user = create(:user)
+        other_ul = create(:user_learning, user: other_user, state: "learning", dictionary_entry: create(:dictionary_entry, text: "not_mine"))
+        create(:review_log, user_learning: other_ul, ease: 3)
+        other_ul.update!(state: "mastered")
+
+        get learn_progress_trajectory_path(bucket: "stable")
+        expect(word_cells).not_to include("not_mine")
+      end
+
+      it "renders clickable, sortable column headers" do
+        graduate!(text: "established_word")
+
+        get learn_progress_trajectory_path(bucket: "stable")
+        doc = Nokogiri::HTML(response.body)
+        sort_links = doc.css("th a[href]")
+        expect(sort_links.map(&:text)).to include("Word", "Meaning", "Ease", "Graduations", "Since", "Next due")
+        expect(sort_links.first["href"]).to include("sort=")
+      end
+
+      it "honours explicit sort and direction query params" do
+        graduate!(text: "zzz_word")
+        graduate!(text: "aaa_word")
+
+        get learn_progress_trajectory_path(bucket: "stable", sort: "word", direction: "asc")
+        expect(word_cells).to eq([ "aaa_word", "zzz_word" ])
+
+        get learn_progress_trajectory_path(bucket: "stable", sort: "word", direction: "desc")
+        expect(word_cells).to eq([ "zzz_word", "aaa_word" ])
+      end
+
+      it "paginates and links to the next page" do
+        3.times { |n| graduate!(text: "word_#{n}") }
+
+        get learn_progress_trajectory_path(bucket: "stable", sort: "word", direction: "asc", per_page: 2)
+        expect(word_cells).to eq([ "word_0", "word_1" ])
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css('a[href*="page=2"]')).to be_present
+
+        get learn_progress_trajectory_path(bucket: "stable", sort: "word", direction: "asc", per_page: 2, page: 2)
+        expect(word_cells).to eq([ "word_2" ])
+      end
+
+      it "keeps the query count bounded regardless of bucket size" do
+        graduate!(text: "single_word")
+        count_with_few = count_queries { get learn_progress_trajectory_path(bucket: "stable") }
+
+        15.times { |n| graduate!(text: "extra_#{n}") }
+        count_with_many = count_queries { get learn_progress_trajectory_path(bucket: "stable") }
+
+        expect(count_with_many).to eq(count_with_few)
+      end
+    end
+  end
 end

--- a/spec/services/mastery/recent_eases_spec.rb
+++ b/spec/services/mastery/recent_eases_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Mastery::RecentEases do
+  include QueryCounter
+
+  let(:user) { create(:user) }
+
+  describe ".call" do
+    it "returns an empty hash for an empty id list without querying" do
+      expect(count_queries { described_class.call(user_learning_ids: []) }).to eq(0)
+      expect(described_class.call(user_learning_ids: [])).to eq({})
+    end
+
+    it "returns the most recent eases per user_learning, newest first" do
+      ul = create(:user_learning, user: user, state: "learning")
+      create(:review_log, user_learning: ul, ease: 4, created_at: 3.days.ago)
+      create(:review_log, user_learning: ul, ease: 3, created_at: 2.days.ago)
+      create(:review_log, user_learning: ul, ease: 2, created_at: 1.day.ago)
+
+      result = described_class.call(user_learning_ids: [ ul.id ])
+      expect(result[ul.id]).to eq([ 2, 3, 4 ])
+    end
+
+    it "bounds the result to STALLED_LOOKBACK_REVIEWS per word" do
+      ul = create(:user_learning, user: user, state: "learning")
+      5.times { |n| create(:review_log, user_learning: ul, ease: n + 1, created_at: (5 - n).days.ago) }
+
+      result = described_class.call(user_learning_ids: [ ul.id ])
+      expect(result[ul.id].size).to eq(Mastery::Thresholds::STALLED_LOOKBACK_REVIEWS)
+    end
+
+    it "keys results by user_learning_id across multiple words" do
+      ul_a = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+      ul_b = create(:user_learning, user: user, state: "learning", dictionary_entry: create(:dictionary_entry))
+      create(:review_log, user_learning: ul_a, ease: 1)
+      create(:review_log, user_learning: ul_b, ease: 4)
+
+      result = described_class.call(user_learning_ids: [ ul_a.id, ul_b.id ])
+      expect(result[ul_a.id]).to eq([ 1 ])
+      expect(result[ul_b.id]).to eq([ 4 ])
+    end
+  end
+end

--- a/spec/services/mastery/recent_eases_spec.rb
+++ b/spec/services/mastery/recent_eases_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mastery::RecentEases do
 
     it "bounds the result to STALLED_LOOKBACK_REVIEWS per word" do
       ul = create(:user_learning, user: user, state: "learning")
-      5.times { |n| create(:review_log, user_learning: ul, ease: n + 1, created_at: (5 - n).days.ago) }
+      5.times { |n| create(:review_log, user_learning: ul, ease: (n % 4) + 1, created_at: (5 - n).days.ago) }
 
       result = described_class.call(user_learning_ids: [ ul.id ])
       expect(result[ul.id].size).to eq(Mastery::Thresholds::STALLED_LOOKBACK_REVIEWS)

--- a/spec/services/mastery/trajectory_entries_spec.rb
+++ b/spec/services/mastery/trajectory_entries_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Mastery::TrajectoryEntries do
   end
 
   def word(text:)
-    entry = create(:dictionary_entry, text: text, meanings_count: 0)
-    create(:meaning, dictionary_entry: entry, pinyin: "#{text}-pinyin", text: "#{text}-meaning")
+    entry = create(:dictionary_entry, text: text)
+    entry.meanings.first.update!(pinyin: "#{text}-pinyin", text: "#{text}-meaning")
     entry
   end
 

--- a/spec/services/mastery/trajectory_entries_spec.rb
+++ b/spec/services/mastery/trajectory_entries_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Mastery::TrajectoryEntries do
+  include QueryCounter
+
+  let(:user) { create(:user) }
+  let(:threshold) { Mastery::Thresholds::EMERGING_TO_DEVELOPING_REVIEW_COUNT }
+
+  def graduate!(ul)
+    create(:review_log, user_learning: ul, ease: 3)
+    ul.update!(state: "mastered")
+  end
+
+  def word(text:)
+    entry = create(:dictionary_entry, text: text, meanings_count: 0)
+    create(:meaning, dictionary_entry: entry, pinyin: "#{text}-pinyin", text: "#{text}-meaning")
+    entry
+  end
+
+  def stable_established(text: "established_word")
+    ul = create(:user_learning, user: user, state: "learning", dictionary_entry: word(text: text))
+    graduate!(ul)
+    ul
+  end
+
+  def chronic(text: "chronic_word", graduations: 2)
+    ul = create(:user_learning, user: user, state: "learning", dictionary_entry: word(text: text))
+    graduations.times do
+      graduate!(ul)
+      ul.update!(state: "learning") unless ul.graduation_count >= graduations
+    end
+    ul
+  end
+
+  def recovering(text: "recovering_word")
+    ul = create(:user_learning, user: user, state: "learning", dictionary_entry: word(text: text))
+    graduate!(ul)
+    ul.update!(state: "learning")
+    ul
+  end
+
+  def stalled(text: "stalled_word")
+    ul = create(:user_learning, user: user, state: "learning", dictionary_entry: word(text: text))
+    threshold.times { create(:review_log, user_learning: ul, ease: 1) }
+    ul
+  end
+
+  def stable_developing(text: "developing_word")
+    ul = create(:user_learning, user: user, state: "learning", dictionary_entry: word(text: text))
+    (threshold - 1).times { create(:review_log, user_learning: ul, ease: 3) }
+    create(:review_log, user_learning: ul, ease: 4)
+    ul
+  end
+
+  describe ".call" do
+    it "returns entries in Word/Meaning/Ease/Graduations/Since/Next due shape" do
+      ul = stable_established
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
+      entry = result.entries.first
+
+      expect(entry.text).to eq("established_word")
+      expect(entry.pinyin).to eq("established_word-pinyin")
+      expect(entry.meaning).to eq("established_word-meaning")
+      expect(entry.factor).to eq(ul.factor)
+      expect(entry.graduation_count).to eq(1)
+      expect(entry.since).to be_present
+      expect(entry.coverage).to eq(Mastery::Coverage::ESTABLISHED)
+    end
+
+    it "scopes Chronic to Established words only" do
+      chronic_ul = chronic
+      stalled # a Developing word -- must never show up under Chronic
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::CHRONIC)
+
+      expect(result.entries.map(&:id)).to eq([ chronic_ul.id ])
+    end
+
+    it "scopes Stalled to Developing words only" do
+      stalled_ul = stalled
+      chronic # an Established word -- must never show up under Stalled
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STALLED)
+
+      expect(result.entries.map(&:id)).to eq([ stalled_ul.id ])
+    end
+
+    it "scopes Recovering to Established words only" do
+      recovering_ul = recovering
+      stalled # a Developing word -- must never show up under Recovering
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::RECOVERING)
+
+      expect(result.entries.map(&:id)).to eq([ recovering_ul.id ])
+    end
+
+    it "spans both populations for Stable, Established first by default" do
+      developing_ul = stable_developing
+      established_ul = stable_established
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
+
+      expect(result.entries.map(&:id)).to eq([ established_ul.id, developing_ul.id ])
+      expect(result.entries.map(&:coverage)).to eq([
+        Mastery::Coverage::ESTABLISHED,
+        Mastery::Coverage::DEVELOPING
+      ])
+    end
+
+    it "defaults Chronic to most-relapsed first" do
+      twice = chronic(text: "twice", graduations: 2)
+      thrice = chronic(text: "thrice", graduations: 3)
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::CHRONIC)
+
+      expect(result.entries.map(&:id)).to eq([ thrice.id, twice.id ])
+    end
+
+    it "only returns the given user's words" do
+      other_user = create(:user)
+      other_ul = create(:user_learning, user: other_user, state: "learning", dictionary_entry: word(text: "other"))
+      graduate!(other_ul)
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
+
+      expect(result.entries).to be_empty
+      expect(result.total).to eq(0)
+    end
+
+    it "sorts explicitly by word ascending when requested, across the whole bucket" do
+      stable_developing(text: "zzz_developing")
+      stable_established(text: "aaa_established")
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "word", direction: "asc")
+
+      expect(result.entries.map(&:text)).to eq([ "aaa_established", "zzz_developing" ])
+    end
+
+    it "sorts explicitly by graduations ascending when requested" do
+      low = chronic(text: "low", graduations: 2)
+      high = chronic(text: "high", graduations: 4)
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::CHRONIC, sort: "graduations", direction: "asc")
+
+      expect(result.entries.map(&:id)).to eq([ low.id, high.id ])
+    end
+
+    it "rejects an unsupported sort column" do
+      expect {
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "nonsense", direction: "asc")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "paginates results" do
+      5.times { |n| stable_established(text: "word_#{n}") }
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "word", direction: "asc", page: 1, per_page: 2)
+      expect(result.entries.map(&:text)).to eq([ "word_0", "word_1" ])
+      expect(result.total).to eq(5)
+      expect(result.page).to eq(1)
+      expect(result.per_page).to eq(2)
+
+      page_two = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "word", direction: "asc", page: 2, per_page: 2)
+      expect(page_two.entries.map(&:text)).to eq([ "word_2", "word_3" ])
+    end
+
+    it "returns zeroed results when there is nothing to classify" do
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
+
+      expect(result.entries).to eq([])
+      expect(result.total).to eq(0)
+    end
+
+    it "keeps the query count bounded by page size, not bucket size" do
+      # Hydration (dictionary_entry/meanings) should only touch the current
+      # page's rows, not the whole bucket -- mirrors TrajectorySnapshot's
+      # existing bounded-query guarantee.
+      5.times { |n| stable_established(text: "small_#{n}") }
+      small_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, page: 1, per_page: 2)
+      end
+
+      15.times { |n| stable_established(text: "big_#{n}") }
+      big_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, page: 1, per_page: 2)
+      end
+
+      expect(big_count).to eq(small_count)
+    end
+  end
+end

--- a/spec/services/mastery/trajectory_entries_spec.rb
+++ b/spec/services/mastery/trajectory_entries_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe Mastery::TrajectoryEntries do
       expect(page_two.entries.map(&:text)).to eq([ "word_2", "word_3" ])
     end
 
+    it "clamps per_page to a sane maximum regardless of what's requested" do
+      # Defense in depth: a caller other than ProgressController (console,
+      # background job, a future endpoint) must not be able to force an
+      # unbounded fetch just by skipping the controller's own clamp.
+      stable_established
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, per_page: 999_999)
+
+      expect(result.per_page).to eq(described_class::MAX_PER_PAGE)
+    end
+
     it "returns zeroed results when there is nothing to classify" do
       result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
 

--- a/spec/services/mastery/trajectory_entries_spec.rb
+++ b/spec/services/mastery/trajectory_entries_spec.rb
@@ -199,5 +199,47 @@ RSpec.describe Mastery::TrajectoryEntries do
 
       expect(big_count).to eq(small_count)
     end
+
+    it "keeps the query count bounded when sorting explicitly by word" do
+      # word_lookup adds one lightweight text-only query, not a switch
+      # back to hydrating (and thus loading dictionary_entry/meanings for)
+      # the whole bucket -- query count must still stay flat.
+      5.times { |n| stable_established(text: "small_#{n}") }
+      small_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "word", direction: "asc", page: 1, per_page: 2)
+      end
+
+      15.times { |n| stable_established(text: "big_#{n}") }
+      big_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "word", direction: "asc", page: 1, per_page: 2)
+      end
+
+      expect(big_count).to eq(small_count)
+    end
+
+    it "keeps the query count bounded when sorting explicitly by meaning" do
+      5.times { |n| stable_established(text: "small_#{n}") }
+      small_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "meaning", direction: "asc", page: 1, per_page: 2)
+      end
+
+      15.times { |n| stable_established(text: "big_#{n}") }
+      big_count = count_queries do
+        described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "meaning", direction: "asc", page: 1, per_page: 2)
+      end
+
+      expect(big_count).to eq(small_count)
+    end
+
+    it "sorts explicitly by meaning ascending when requested" do
+      first = stable_established(text: "aaa")
+      first.dictionary_entry.meanings.first.update!(text: "aardvark")
+      second = stable_established(text: "bbb")
+      second.dictionary_entry.meanings.first.update!(text: "zebra")
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE, sort: "meaning", direction: "asc")
+
+      expect(result.entries.map(&:text)).to eq([ "aaa", "bbb" ])
+    end
   end
 end

--- a/spec/services/mastery/trajectory_entries_spec.rb
+++ b/spec/services/mastery/trajectory_entries_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe Mastery::TrajectoryEntries do
       expect(entry.coverage).to eq(Mastery::Coverage::ESTABLISHED)
     end
 
+    it "displays the lowest-id meaning when a word has more than one" do
+      ul = stable_established(text: "multi_meaning_word")
+      entry = ul.dictionary_entry
+      first_meaning = entry.meanings.first
+      later_meaning = create(:meaning, dictionary_entry: entry, text: "later meaning", pinyin: "later")
+      expect(later_meaning.id).to be > first_meaning.id
+
+      result = described_class.call(user: user, bucket: Mastery::Trajectory::STABLE)
+
+      expect(result.entries.first.meaning).to eq(first_meaning.text)
+    end
+
     it "scopes Chronic to Established words only" do
       chronic_ul = chronic
       stalled # a Developing word -- must never show up under Chronic


### PR DESCRIPTION
## Summary

Closes #400. Each Stable/Recovering/Chronic/Stalled tile on `/progress`
now links to `GET /learn/progress/trajectory/:bucket`: a table of the
words in that bucket, ranked by how firmly they exemplify the label, with
clickable column headers to re-sort.

- **`Mastery::RecentEases`** — extracted the windowed "last N eases per
  word" SQL out of `Mastery::TrajectorySnapshot` (behaviour unchanged) so
  the new service can reuse it instead of duplicating it.
- **`Mastery::TrajectoryEntries`** — the drill-down service. Fetches only
  the population(s) a bucket can actually contain (Chronic/Recovering are
  Established-only, Stalled is Developing-only, Stable spans both), then
  hydrates `dictionary_entry`/`meanings` in one query for exactly the
  filtered ids — query count stays fixed regardless of bucket size, same
  guarantee `TrajectorySnapshot` already gives.
- Default ranking per bucket: most graduations first for Chronic,
  Established-before-Developing for Stable, strongest ease for
  Recovering, worst recent average ease for Stalled — all overridable via
  the sortable Word/Meaning/Ease/Graduations/Since/Next due columns.
- Pagination is plain limit/offset (no pagination gem in the Gemfile
  today, and this doesn't need one), clamped server-side to a max page
  size.

## Test plan

- [x] `bundle exec rspec` — 1005 examples, 0 failures
- [x] `bin/rubocop` — clean
- [x] Verified rendered output (tiles link to the correct bucket, tables
      show correctly filtered/ranked words, sort links and pagination
      links present) via request specs and a manual render against seeded
      data
- [ ] Note: couldn't drive this through a live browser via Playwright —
      no OIDC credentials available in this environment to complete the
      real sign-in flow. The feature is plain server-rendered HTML with
      no client-side JS, so the request-spec coverage above exercises the
      same rendered output a browser would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)