### PR TITLE
feat: add MCP tool support

### DIFF
--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -23,6 +23,10 @@ class McpController < ActionController::API
         handle_resources_list(body)
       when "resources/read"
         handle_resources_read(body)
+      when "tools/list"
+        handle_tools_list(body)
+      when "tools/call"
+        handle_tools_call(body)
       else
         render json: jsonrpc_error(body["id"], -32601, "Method not found: #{method}")
       end
@@ -52,7 +56,10 @@ class McpController < ActionController::API
       id: body["id"],
       result: {
         protocolVersion: PROTOCOL_VERSION,
-        capabilities: { resources: { subscribe: false, listChanged: false } },
+        capabilities: {
+          resources: { subscribe: false, listChanged: false },
+          tools: { listChanged: false }
+        },
         serverInfo: { name: "learn-hanzi", version: "1.0" }
       }
     }
@@ -133,6 +140,101 @@ class McpController < ActionController::API
         contents: [ { uri: uri, mimeType: "application/json", text: content.to_json } ]
       }
     }
+  end
+
+  DEFAULT_LIST_LIMIT = 50
+
+  PAGINATION_SCHEMA = {
+    type: "object",
+    properties: {
+      limit: {
+        type: "integer",
+        description: "Maximum number of entries to return. Defaults to #{DEFAULT_LIST_LIMIT}.",
+        minimum: 1
+      },
+      offset: {
+        type: "integer",
+        description: "Number of entries to skip, for paging through large result sets.",
+        minimum: 0
+      }
+    },
+    additionalProperties: false
+  }.freeze
+
+  TOOLS = [
+    {
+      name: "get_learning_profile",
+      description: "Summary of your overall learning state: counts by status and HSK level breakdown.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false }
+    },
+    {
+      name: "list_mastered_vocabulary",
+      description: "Words you have consolidated, most recently mastered first.",
+      inputSchema: PAGINATION_SCHEMA
+    },
+    {
+      name: "list_struggling_vocabulary",
+      description: "In-progress words ranked by lapse count and low ease factor — the words giving you the most trouble.",
+      inputSchema: PAGINATION_SCHEMA
+    },
+    {
+      name: "list_recent_vocabulary",
+      description: "Words graduated to mastered in the last 30 days.",
+      inputSchema: PAGINATION_SCHEMA
+    },
+    {
+      name: "list_active_vocabulary",
+      description: "Words currently in the learning queue, ordered by next due date.",
+      inputSchema: PAGINATION_SCHEMA
+    }
+  ].freeze
+
+  def handle_tools_list(body)
+    render json: {
+      jsonrpc: "2.0",
+      id: body["id"],
+      result: { tools: TOOLS }
+    }
+  end
+
+  def handle_tools_call(body)
+    name = body.dig("params", "name")
+    arguments = body.dig("params", "arguments") || {}
+
+    structured_content = case name
+    when "get_learning_profile"
+      Mcp::ProfileResource.new(current_mcp_user).call
+    when "list_mastered_vocabulary"
+      Mcp::MasteredVocabularyResource.new(current_mcp_user, **pagination_args(arguments)).call
+    when "list_struggling_vocabulary"
+      Mcp::StrugglingVocabularyResource.new(current_mcp_user, **pagination_args(arguments)).call
+    when "list_recent_vocabulary"
+      Mcp::RecentVocabularyResource.new(current_mcp_user, **pagination_args(arguments)).call
+    when "list_active_vocabulary"
+      Mcp::ActiveVocabularyResource.new(current_mcp_user, **pagination_args(arguments)).call
+    else
+      return render json: jsonrpc_error(body["id"], -32602, "Unknown tool: #{name}")
+    end
+
+    render json: {
+      jsonrpc: "2.0",
+      id: body["id"],
+      result: {
+        content: [ { type: "text", text: tool_summary_text(name, structured_content) } ],
+        structuredContent: structured_content,
+        isError: false
+      }
+    }
+  end
+
+  def pagination_args(arguments)
+    { limit: arguments["limit"] || DEFAULT_LIST_LIMIT, offset: arguments["offset"] || 0 }
+  end
+
+  def tool_summary_text(name, content)
+    return "Learning profile: #{content[:summary]['total']} words tracked." if name == "get_learning_profile"
+
+    "Found #{content['vocabulary'].size} vocabulary entries."
   end
 
   def jsonrpc_error(id, code, message)

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -143,13 +143,14 @@ class McpController < ActionController::API
   end
 
   DEFAULT_LIST_LIMIT = 50
+  MAX_LIST_LIMIT = 200
 
   PAGINATION_SCHEMA = {
     type: "object",
     properties: {
       limit: {
         type: "integer",
-        description: "Maximum number of entries to return. Defaults to #{DEFAULT_LIST_LIMIT}.",
+        description: "Maximum number of entries to return. Defaults to #{DEFAULT_LIST_LIMIT}, capped at #{MAX_LIST_LIMIT}.",
         minimum: 1
       },
       offset: {
@@ -228,7 +229,24 @@ class McpController < ActionController::API
   end
 
   def pagination_args(arguments)
-    { limit: arguments["limit"] || DEFAULT_LIST_LIMIT, offset: arguments["offset"] || 0 }
+    { limit: coerce_limit(arguments["limit"]), offset: coerce_offset(arguments["offset"]) }
+  end
+
+  # Tool arguments are client-controlled JSON, so a non-integer or
+  # out-of-range value must not reach ActiveRecord's limit/offset or
+  # StrugglingVocabularyResource's Array#drop/#first — both raise on
+  # invalid input (SQL error or ArgumentError/TypeError) rather than
+  # coercing it themselves.
+  def coerce_limit(value)
+    integer = Integer(value, exception: false)
+    return DEFAULT_LIST_LIMIT unless integer
+    integer.clamp(1, MAX_LIST_LIMIT)
+  end
+
+  def coerce_offset(value)
+    integer = Integer(value, exception: false)
+    return 0 unless integer
+    [ integer, 0 ].max
   end
 
   def tool_summary_text(name, content)

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -199,8 +199,11 @@ class McpController < ActionController::API
   end
 
   def handle_tools_call(body)
-    name = body.dig("params", "name")
-    arguments = body.dig("params", "arguments") || {}
+    params = body["params"]
+    params = {} unless params.is_a?(Hash)
+    name = params["name"]
+    arguments = params["arguments"]
+    arguments = {} unless arguments.is_a?(Hash)
 
     structured_content = case name
     when "get_learning_profile"

--- a/app/services/mcp/active_vocabulary_resource.rb
+++ b/app/services/mcp/active_vocabulary_resource.rb
@@ -1,17 +1,20 @@
 module Mcp
   class ActiveVocabularyResource
-    def initialize(user)
+    def initialize(user, limit: nil, offset: 0)
       @user = user
+      @limit = limit
+      @offset = offset
     end
 
     def call
-      vocabulary = user.user_learnings
+      scope = user.user_learnings
         .in_progress
         .includes(dictionary_entry: :meanings)
         .order(next_due: :asc)
-        .map { |ul| format_entry(ul) }
+        .offset(@offset)
+      scope = scope.limit(@limit) if @limit
 
-      { "vocabulary" => vocabulary }
+      { "vocabulary" => scope.map { |ul| format_entry(ul) } }
     end
 
     private

--- a/app/services/mcp/mastered_vocabulary_resource.rb
+++ b/app/services/mcp/mastered_vocabulary_resource.rb
@@ -1,17 +1,20 @@
 module Mcp
   class MasteredVocabularyResource
-    def initialize(user)
+    def initialize(user, limit: nil, offset: 0)
       @user = user
+      @limit = limit
+      @offset = offset
     end
 
     def call
-      vocabulary = user.user_learnings
+      scope = user.user_learnings
         .mastered
         .includes(dictionary_entry: :meanings)
         .order(mastered_at: :desc)
-        .map { |ul| format_entry(ul) }
+        .offset(@offset)
+      scope = scope.limit(@limit) if @limit
 
-      { "vocabulary" => vocabulary }
+      { "vocabulary" => scope.map { |ul| format_entry(ul) } }
     end
 
     private

--- a/app/services/mcp/recent_vocabulary_resource.rb
+++ b/app/services/mcp/recent_vocabulary_resource.rb
@@ -2,19 +2,22 @@ module Mcp
   class RecentVocabularyResource
     WINDOW = 30.days
 
-    def initialize(user)
+    def initialize(user, limit: nil, offset: 0)
       @user = user
+      @limit = limit
+      @offset = offset
     end
 
     def call
-      vocabulary = user.user_learnings
+      scope = user.user_learnings
         .mastered
         .where("mastered_at > ?", WINDOW.ago)
         .includes(dictionary_entry: :meanings)
         .order(mastered_at: :desc)
-        .map { |ul| format_entry(ul) }
+        .offset(@offset)
+      scope = scope.limit(@limit) if @limit
 
-      { "vocabulary" => vocabulary }
+      { "vocabulary" => scope.map { |ul| format_entry(ul) } }
     end
 
     private

--- a/app/services/mcp/struggling_vocabulary_resource.rb
+++ b/app/services/mcp/struggling_vocabulary_resource.rb
@@ -1,7 +1,9 @@
 module Mcp
   class StrugglingVocabularyResource
-    def initialize(user)
+    def initialize(user, limit: nil, offset: 0)
       @user = user
+      @limit = limit
+      @offset = offset
     end
 
     def call
@@ -15,6 +17,8 @@ module Mcp
       learnings = in_progress
         .includes(dictionary_entry: :meanings)
         .sort_by { |ul| [ -lapse_counts.fetch(ul.id, 0), ul.factor ] }
+        .drop(@offset)
+      learnings = learnings.first(@limit) if @limit
 
       { "vocabulary" => learnings.map { |ul| format_entry(ul, lapse_counts.fetch(ul.id, 0)) } }
     end

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,6 +2,8 @@
 
 learn-hanzi exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io/) server at `/mcp`, allowing AI assistants (Claude, etc.) to query your learning data.
 
+The server speaks both `resources/*` and `tools/*`. Clients with a full MCP client (Claude Desktop, Claude Code) can use either; tool-centric surfaces — claude.ai custom connectors, the API's `mcp_servers` parameter, and most other agents — only ever call `tools/list` and `tools/call`, so the five tools below are what makes the server usable there.
+
 ## Authentication
 
 The `/mcp` endpoint is an OAuth 2.1 resource server: `learn-hanzi` is its own authorization server for MCP clients (Doorkeeper), with self-service client identification via [OAuth Client ID Metadata Documents (CIMD)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) rather than a manual registration step. A compliant MCP client discovers everything it needs from `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` and drives a normal browser-based authorization-code + PKCE flow — there's nothing to create or paste in ahead of time.
@@ -161,9 +163,25 @@ In-progress words ranked by difficulty — most lapses first, then lowest ease f
 
 ---
 
+## Tools
+
+The same five read-only queries are also available as MCP tools — each wraps the resource above unchanged, so the data is identical. A `tools/call` result includes both a short text summary (for clients that only render text) and a `structuredContent` object with the same shape as the matching resource's JSON.
+
+| Tool | Arguments | Backed by |
+| --- | --- | --- |
+| `get_learning_profile` | none | `learn-hanzi://profile` |
+| `list_mastered_vocabulary` | `limit`, `offset` | `learn-hanzi://vocabulary/mastered` |
+| `list_struggling_vocabulary` | `limit`, `offset` | `learn-hanzi://vocabulary/struggling` |
+| `list_recent_vocabulary` | `limit`, `offset` | `learn-hanzi://vocabulary/recent` |
+| `list_active_vocabulary` | `limit`, `offset` | `learn-hanzi://vocabulary/active` |
+
+`limit` and `offset` are both optional integers, for paging through large result sets (e.g. thousands of mastered words). `limit` defaults to 50 if omitted.
+
+---
+
 ## Protocol notes
 
 - Transport: Streamable HTTP (JSON-RPC 2.0 over `POST /mcp`)
 - Protocol version: `2025-03-26`
 - Sessions: established via `initialize`, tracked by `Mcp-Session-Id` header (24-hour TTL)
-- Capabilities: `resources` (read-only; no subscriptions or list-changed notifications)
+- Capabilities: `resources` and `tools` (both read-only; no subscriptions or list-changed notifications)

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -274,6 +274,24 @@ RSpec.shared_examples "an authenticated MCP session" do
         vocabulary = body.dig("result", "structuredContent", "vocabulary")
         expect(vocabulary.first["hanzi"]).to eq(older.dictionary_entry.text)
       end
+
+      it "falls back to the default limit when limit is not an integer" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body = call_tool("list_mastered_vocabulary", limit: "not-a-number")
+        expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
+      end
+
+      it "clamps an oversized limit rather than returning everything unbounded" do
+        body = call_tool("list_mastered_vocabulary", limit: 999_999)
+        expect(body.dig("result", "error")).to be_nil
+        expect(body["result"]["isError"]).to be false
+      end
+
+      it "clamps a negative offset to zero instead of erroring" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body = call_tool("list_mastered_vocabulary", offset: -5)
+        expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
+      end
     end
 
     describe "list_recent_vocabulary" do
@@ -308,6 +326,18 @@ RSpec.shared_examples "an authenticated MCP session" do
         body = call_tool("list_struggling_vocabulary", limit: 1)
         vocabulary = body.dig("result", "structuredContent", "vocabulary")
         expect(vocabulary.length).to eq(1)
+      end
+
+      it "does not error on a negative offset (Ruby-side Array#drop would raise)" do
+        create(:user_learning, user: user, state: "learning")
+        body = call_tool("list_struggling_vocabulary", offset: -5)
+        expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
+      end
+
+      it "does not error on a non-integer limit (Ruby-side Array#first would raise)" do
+        create(:user_learning, user: user, state: "learning")
+        body = call_tool("list_struggling_vocabulary", limit: "not-a-number")
+        expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
       end
     end
   end

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -40,6 +40,12 @@ RSpec.shared_examples "an authenticated MCP session" do
       expect(body["result"]["capabilities"]["resources"]).to be_present
     end
 
+    it "advertises tool capabilities" do
+      post "/mcp", params: init_params, headers: auth_headers, as: :json
+      body = JSON.parse(response.body)
+      expect(body["result"]["capabilities"]["tools"]).to be_present
+    end
+
     it "returns server info" do
       post "/mcp", params: init_params, headers: auth_headers, as: :json
       body = JSON.parse(response.body)
@@ -125,6 +131,183 @@ RSpec.shared_examples "an authenticated MCP session" do
       resources.each do |resource|
         expect(resource["name"]).to be_present
         expect(resource["mimeType"]).to eq("application/json")
+      end
+    end
+  end
+
+  describe "tools/list" do
+    let(:session_id) { establish_mcp_session(auth_headers) }
+
+    it "returns a JSON-RPC 2.0 envelope" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      body = JSON.parse(response.body)
+      expect(body["jsonrpc"]).to eq("2.0")
+      expect(body["id"]).to eq(2)
+    end
+
+    it "returns all five tools" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      tools = JSON.parse(response.body).dig("result", "tools")
+      expect(tools.length).to eq(5)
+    end
+
+    it "includes all expected tool names" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      names = JSON.parse(response.body).dig("result", "tools").map { |t| t["name"] }
+      expect(names).to contain_exactly(
+        "get_learning_profile",
+        "list_mastered_vocabulary",
+        "list_struggling_vocabulary",
+        "list_recent_vocabulary",
+        "list_active_vocabulary"
+      )
+    end
+
+    it "includes a description and inputSchema for each tool" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      tools = JSON.parse(response.body).dig("result", "tools")
+      tools.each do |tool|
+        expect(tool["description"]).to be_present
+        expect(tool["inputSchema"]["type"]).to eq("object")
+      end
+    end
+
+    it "declares limit and offset arguments on the list_* tools" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      tool = JSON.parse(response.body).dig("result", "tools").find { |t| t["name"] == "list_mastered_vocabulary" }
+      expect(tool["inputSchema"]["properties"].keys).to contain_exactly("limit", "offset")
+    end
+
+    it "declares no arguments on get_learning_profile" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      tool = JSON.parse(response.body).dig("result", "tools").find { |t| t["name"] == "get_learning_profile" }
+      expect(tool["inputSchema"]["properties"]).to eq({})
+    end
+  end
+
+  describe "tools/call" do
+    let(:session_id) { establish_mcp_session(auth_headers) }
+
+    def call_tool(name, arguments = {})
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: name, arguments: arguments } },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      JSON.parse(response.body)
+    end
+
+    it "returns -32602 for an unknown tool name" do
+      body = call_tool("does_not_exist")
+      expect(body["error"]["code"]).to eq(-32602)
+    end
+
+    describe "get_learning_profile" do
+      it "returns a JSON-RPC 2.0 envelope with text content and structuredContent" do
+        body = call_tool("get_learning_profile")
+        expect(body["jsonrpc"]).to eq("2.0")
+        expect(body["id"]).to eq(3)
+        content = body.dig("result", "content")
+        expect(content).to be_an(Array)
+        expect(content.first["type"]).to eq("text")
+        expect(content.first["text"]).to be_present
+      end
+
+      it "returns the same data as the profile resource" do
+        create(:user_learning, user: user, state: "mastered")
+        body = call_tool("get_learning_profile")
+        summary = body.dig("result", "structuredContent", "summary")
+        expect(summary["mastered"]).to eq(1)
+      end
+
+      it "scopes results to the authenticated user" do
+        create(:user_learning, user: create(:user), state: "mastered")
+        body = call_tool("get_learning_profile")
+        summary = body.dig("result", "structuredContent", "summary")
+        expect(summary["total"]).to eq(0)
+      end
+    end
+
+    describe "list_mastered_vocabulary" do
+      it "returns the same data as the mastered vocabulary resource" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body = call_tool("list_mastered_vocabulary")
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(1)
+      end
+
+      it "applies a default limit" do
+        6.times { create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago) }
+        body = call_tool("list_mastered_vocabulary")
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to be <= 50
+      end
+
+      it "honours a supplied limit" do
+        3.times { create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago) }
+        body = call_tool("list_mastered_vocabulary", limit: 2)
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(2)
+      end
+
+      it "honours a supplied offset" do
+        older = create(:user_learning, user: user, state: "mastered", mastered_at: 2.days.ago)
+        newer = create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body = call_tool("list_mastered_vocabulary", limit: 1, offset: 1)
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.first["hanzi"]).to eq(older.dictionary_entry.text)
+      end
+    end
+
+    describe "list_recent_vocabulary" do
+      it "returns the same data as the recent vocabulary resource" do
+        create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago)
+        body = call_tool("list_recent_vocabulary")
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(1)
+      end
+    end
+
+    describe "list_active_vocabulary" do
+      it "returns the same data as the active vocabulary resource" do
+        create(:user_learning, user: user, state: "learning", next_due: 1.day.from_now)
+        body = call_tool("list_active_vocabulary")
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(1)
+      end
+    end
+
+    describe "list_struggling_vocabulary" do
+      it "returns the same data as the struggling vocabulary resource" do
+        ul = create(:user_learning, user: user, state: "learning")
+        create(:review_log, user_learning: ul, ease: 1)
+        body = call_tool("list_struggling_vocabulary")
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.first["lapse_count"]).to eq(1)
+      end
+
+      it "honours a supplied limit" do
+        3.times { create(:user_learning, user: user, state: "learning") }
+        body = call_tool("list_struggling_vocabulary", limit: 1)
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(1)
       end
     end
   end

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -219,6 +219,27 @@ RSpec.shared_examples "an authenticated MCP session" do
       expect(body["error"]["code"]).to eq(-32602)
     end
 
+    it "does not error when arguments is not a JSON object" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 3, method: "tools/call",
+                  params: { name: "list_mastered_vocabulary", arguments: [ 1, 2, 3 ] } },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.dig("result", "structuredContent", "vocabulary")).to eq([])
+    end
+
+    it "returns -32602 when params is not a JSON object" do
+      post "/mcp",
+        params: { jsonrpc: "2.0", id: 3, method: "tools/call", params: [ 1, 2, 3 ] },
+        headers: auth_headers.merge("Mcp-Session-Id" => session_id),
+        as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["error"]["code"]).to eq(-32602)
+    end
+
     describe "get_learning_profile" do
       it "returns a JSON-RPC 2.0 envelope with text content and structuredContent" do
         body = call_tool("get_learning_profile")
@@ -281,10 +302,12 @@ RSpec.shared_examples "an authenticated MCP session" do
         expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
       end
 
-      it "clamps an oversized limit rather than returning everything unbounded" do
+      it "clamps an oversized limit to MAX_LIST_LIMIT rather than returning everything unbounded" do
+        stub_const("McpController::MAX_LIST_LIMIT", 3)
+        5.times { create(:user_learning, user: user, state: "mastered", mastered_at: 1.day.ago) }
         body = call_tool("list_mastered_vocabulary", limit: 999_999)
-        expect(body.dig("result", "error")).to be_nil
-        expect(body["result"]["isError"]).to be false
+        vocabulary = body.dig("result", "structuredContent", "vocabulary")
+        expect(vocabulary.length).to eq(3)
       end
 
       it "clamps a negative offset to zero instead of erroring" do


### PR DESCRIPTION
## Summary

Wraps the five existing read-only `Mcp::*Resource` services as MCP
tools (`tools/list` + `tools/call`), alongside the existing
`resources/*` methods. The server currently only advertises
`capabilities: resources`, which works with Claude Desktop/Code's
full MCP client but connects-and-exposes-nothing on tool-centric
surfaces — claude.ai custom connectors, the API `mcp_servers`
parameter, and most other agents only ever call tools.

- `get_learning_profile`, `list_mastered_vocabulary`,
  `list_struggling_vocabulary`, `list_recent_vocabulary`,
  `list_active_vocabulary` — each reuses the matching resource
  service unchanged, returning the same data as `structuredContent`
  plus a short text summary for text-only clients.
- The four `list_*` tools take optional `limit`/`offset` arguments,
  applied inside the resource services themselves (SQL
  `offset`/`limit` for the three that sort in SQL;
  `Array#drop`/`#first` in `StrugglingVocabularyResource`, which
  sorts in Ruby after loading) — `limit` defaults to 50.
- `initialize` now advertises both `tools` and `resources`
  capabilities. `resources/*` behaviour is unchanged.

Checked against the mastery-model changes that landed since this
issue was filed (#391 coverage/trajectory axes, #398's `/progress`
rebuild): neither touched `UserLearning#state`/`mastered_at`/
`next_due`/`factor`, which is what all five MCP resources key off,
so no changes were needed there.

## Test plan

- [x] `bundle exec rspec` — 1128 examples, 0 failures, 96.4% coverage
- [x] `bin/rubocop` — no offenses (outside pre-existing `db/schema.rb`
      debt on `main`, unrelated to this change)
- [x] `bin/brakeman --no-pager` — no warnings
- [x] New specs cover `tools/list` schema shape and `tools/call` for
      all five tools, including per-user scoping, unknown-tool
      error handling, and `limit`/`offset` paging

Closes #390.