### PR TITLE
docs: replace ambiguous branch reference with commit SHA

### DIFF
--- a/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
+++ b/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
@@ -40,11 +40,11 @@ MCP clients:
 - `McpController` (via `McpAuthentication`) originally accepted a Doorkeeper
   bearer token **or** the pre-existing CF Access service-token branch, as a
   transitional fallback while existing clients migrated. The CF Access
-  **email-match** branch was deleted first (`cc0c7fa`, "accept Doorkeeper
-  bearer tokens on /mcp, drop email auth") — it relied on Cloudflare Access's
-  own policy having vetted who could get a JWT in the first place, an
-  assumption that would have broken the moment the Access policy was
-  loosened to "allow anyone." The
+  **email-match** branch was deleted first (`cc0c7fa`, "feat: accept
+  Doorkeeper bearer tokens on /mcp, drop email auth") — it relied on
+  Cloudflare Access's own policy having vetted who could get a JWT in the
+  first place, an assumption that would have broken the moment the Access
+  policy was loosened to "allow anyone." The
   **service-token** branch was removed in full afterwards (#401), once the
   Doorkeeper flow was confirmed working end-to-end in production — `/mcp` is
   now Doorkeeper-only.

--- a/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
+++ b/docs/threat_assessments/MCP_OAUTH_DOORKEEPER.md
@@ -40,10 +40,11 @@ MCP clients:
 - `McpController` (via `McpAuthentication`) originally accepted a Doorkeeper
   bearer token **or** the pre-existing CF Access service-token branch, as a
   transitional fallback while existing clients migrated. The CF Access
-  **email-match** branch was deleted first (see commit history on this
-  branch) — it relied on Cloudflare Access's own policy having vetted who
-  could get a JWT in the first place, an assumption that would have broken
-  the moment the Access policy was loosened to "allow anyone." The
+  **email-match** branch was deleted first (`cc0c7fa`, "accept Doorkeeper
+  bearer tokens on /mcp, drop email auth") — it relied on Cloudflare Access's
+  own policy having vetted who could get a JWT in the first place, an
+  assumption that would have broken the moment the Access policy was
+  loosened to "allow anyone." The
   **service-token** branch was removed in full afterwards (#401), once the
   Doorkeeper flow was confirmed working end-to-end in production — `/mcp` is
   now Doorkeeper-only.


### PR DESCRIPTION
## Summary

Follow-up to #405's review (https://github.com/huwd/learn_hanzi/pull/405#discussion_r3567229738):
"see commit history on this branch" in `MCP_OAUTH_DOORKEEPER.md` was
written while the doc still lived on a feature branch — read on `main`
with no such branch, it points nowhere. Replaced with the actual commit
(`cc0c7fa`, "accept Doorkeeper bearer tokens on /mcp, drop email auth")
that deleted the email-match auth path.

## Test plan

Docs-only change.