### PR TITLE
fix: gate Capybara port pin on real_oidc tag, not just env

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -43,8 +43,14 @@ end
 # ahead of time and needs a deterministic port. Every other system spec
 # keeps Capybara's normal dynamic port selection, so a stray process already
 # holding 31337 can't break the whole suite for specs that don't need this.
+# ENV["REAL_OIDC"] == "1" alone isn't enough to detect that tier, the same
+# way it isn't in spec/spec_helper.rb's coverage relaxation: it only lifts
+# rails_helper.rb's default exclusion filter, so `REAL_OIDC=1 bundle exec
+# rspec` with no --tag would run the full suite and pin every system spec
+# to this port too. Require the documented --tag/-t real_oidc invocation.
 # See spec/support/real_oidc_helpers.rb and docs/testing/real_oidc_stub.md.
-if ENV["REAL_OIDC"] == "1"
+real_oidc_tag_invocation = ARGV.each_cons(2).any? { |flag, value| %w[--tag -t].include?(flag) && value == "real_oidc" }
+if ENV["REAL_OIDC"] == "1" && real_oidc_tag_invocation
   Capybara.server_host = "localhost"
   Capybara.server_port = 31337
 end


### PR DESCRIPTION
## Summary

Follow-up to the real-OIDC stub tier merged in #386.

Copilot caught the same class of gap twice in that PR for `spec/spec_helper.rb`'s SimpleCov coverage relaxation (`ENV["REAL_OIDC"] == "1"` alone doesn't mean the narrow, tagged real-OIDC tier is what's actually running — it only lifts `rails_helper.rb`'s default exclusion filter). A third instance of the same pattern in `spec/support/capybara.rb`'s port-pinning logic was flagged on #386 right as it merged, so it slipped through unaddressed there.

`REAL_OIDC=1 bundle exec rspec` (no `--tag`) would pin **every** system spec to port 31337, undermining the surrounding comment's own stated goal — that only the real-OIDC tier needs a fixed port, and every other system spec should keep Capybara's normal dynamic port selection so a stray process holding 31337 can't break the whole suite.

## Fix

Require the documented `--tag`/`-t real_oidc` invocation via the same ARGV-parsing approach `spec/spec_helper.rb` already uses (parses for an actual `--tag`/`-t` flag immediately followed by the literal value `real_oidc`, not a substring match — avoids false positives on a bare file path or a negated tag like `--tag ~real_oidc`).

## Test plan

- [x] `bin/rubocop` — no offenses
- [x] `REAL_OIDC=1 OIDC_ISSUER=... bundle exec rspec --tag real_oidc` — still passes with the port pinned (2 examples, 0 failures), against the stub OIDC server per `docs/testing/real_oidc_stub.md`
- [x] `bundle exec rspec` (full suite) — unaffected, 1087 examples, 0 failures, 96.33% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)