### PR TITLE
test: stabilize + instrument the flaky real-OIDC CI tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,19 @@ jobs:
           OIDC_REDIRECT_URI: "http://localhost:31337/auth/oidc/callback"
         run: bin/rails db:test:prepare && bundle exec rspec --tag real_oidc
 
+      # This job has a history of intermittent Capybara ElementNotFound
+      # failures that don't reproduce locally (see spec/system/real_oidc_login_spec.rb
+      # git blame) — the failure screenshot RSpec/Capybara already saves to
+      # tmp/capybara/ was previously lost with the ephemeral runner, leaving
+      # nothing to diagnose the next occurrence from.
+      - name: Upload Capybara failure screenshots
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: real-oidc-capybara-failures
+          path: tmp/capybara/
+          if-no-files-found: ignore
+
   analyze:
     name: Analyze
     runs-on: ubuntu-latest

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,9 +61,13 @@ RSpec.configure do |config|
   # stub's discovery-issuer mismatch (see docs/testing/real_oidc_stub.md) is
   # gone now that the upstream fix has shipped (imposter-project/imposter-go
   # v5.19.2), so validate_discovery_issuer stays at its real default.
-  config.before(:each, real_oidc: true) do
+  # An around hook (rather than paired before/after) so restoration is tied
+  # to the example's own run via `ensure` — guaranteed even if `example.run`
+  # raises — instead of a separate after hook depending on instance
+  # variables an earlier hook happened to set.
+  config.around(:each, real_oidc: true) do |example|
     require "swd"
-    @original_swd_url_builder = SWD.url_builder
+    original_swd_url_builder = SWD.url_builder
     SWD.url_builder = URI::HTTP
 
     # Every other system spec authenticates in-process via OmniAuth test_mode,
@@ -72,13 +76,13 @@ RSpec.configure do |config|
     # own login page — an extra process hop with no shared warmth, more prone
     # to occasionally outrunning that default under CI's less predictable
     # scheduling than a same-process mock ever would be.
-    @original_capybara_wait_time = Capybara.default_max_wait_time
+    original_capybara_wait_time = Capybara.default_max_wait_time
     Capybara.default_max_wait_time = 5
-  end
 
-  config.after(:each, real_oidc: true) do
-    SWD.url_builder = @original_swd_url_builder
-    Capybara.default_max_wait_time = @original_capybara_wait_time
+    example.run
+  ensure
+    SWD.url_builder = original_swd_url_builder
+    Capybara.default_max_wait_time = original_capybara_wait_time
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,10 +65,20 @@ RSpec.configure do |config|
     require "swd"
     @original_swd_url_builder = SWD.url_builder
     SWD.url_builder = URI::HTTP
+
+    # Every other system spec authenticates in-process via OmniAuth test_mode,
+    # so Capybara's 2-second default is plenty. This tier's sign-in redirects
+    # through a second, real HTTP server (the Imposter stub) rendering its
+    # own login page — an extra process hop with no shared warmth, more prone
+    # to occasionally outrunning that default under CI's less predictable
+    # scheduling than a same-process mock ever would be.
+    @original_capybara_wait_time = Capybara.default_max_wait_time
+    Capybara.default_max_wait_time = 5
   end
 
   config.after(:each, real_oidc: true) do
     SWD.url_builder = @original_swd_url_builder
+    Capybara.default_max_wait_time = @original_capybara_wait_time
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
## Summary
- Prompted by the flaky `real_oidc_test` job on #411 — investigated whether Imposter's `oidc-server` stub does session-based SSO short-circuiting (skip the login form on a repeat `/authorize` hit), since that would explain intermittent `Capybara::ElementNotFound: Unable to find field "username"` failures. Confirmed empirically it does **not**: the stub is fully stateless per request (no cookie, a fresh `session_id` hidden field every time), verified with direct curl requests against a locally-running stub. Not an Imposter-specific gap.
- Couldn't reproduce the failure locally after several clean runs, which points to CI-specific timing rather than a logic bug — the failing example crashes on its *first* login attempt with zero `omniauth: (oidc) Request phase initiated` log lines, meaning the click on "Sign in with PocketID" never reached the redirect at all within Capybara's 2-second default wait.
- `spec/rails_helper.rb`: widen `Capybara.default_max_wait_time` to 5s for `real_oidc`-tagged specs only — this tier's sign-in crosses into a second real HTTP server (the stub) on a cold connection, unlike every other system spec's in-process OmniAuth `test_mode` mock, so it's more exposed to CI's less predictable scheduling.
- `.github/workflows/ci.yml`: upload the Capybara failure screenshot RSpec already saves to `tmp/capybara/` as a build artifact, so the next occurrence (if the wait-time bump doesn't fully fix it) leaves actual evidence instead of another guessing game.

## Test plan
- [x] `bundle exec rspec --tag real_oidc spec/system/real_oidc_login_spec.rb` — 3 clean local runs, 0 failures (6/6 examples)
- [x] `bin/rubocop spec/rails_helper.rb` — no offenses
- [x] `ci.yml` YAML syntax validated
- [ ] Watch the next few CI runs of `real_oidc_test` (still `continue-on-error: true`, non-blocking) to confirm this actually reduces the flake rate

Refs #389