### PR TITLE
fix: include full vocabulary rows in MCP tool content

### DIFF
--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -224,7 +224,7 @@ class McpController < ActionController::API
       jsonrpc: "2.0",
       id: body["id"],
       result: {
-        content: [ { type: "text", text: tool_summary_text(name, structured_content) } ],
+        content: [ { type: "text", text: tool_text_content(name, structured_content) } ],
         structuredContent: structured_content,
         isError: false
       }
@@ -250,6 +250,15 @@ class McpController < ActionController::API
     integer = Integer(value, exception: false)
     return 0 unless integer
     [ integer, 0 ].max
+  end
+
+  # `content[].text` is the only field some hosted MCP connectors surface to
+  # the model — `structuredContent` is silently dropped by clients that don't
+  # support it (or that negotiated a protocol version predating it). The
+  # summary line alone is not enough: the full row data must be present here
+  # too, or those clients see counts with no underlying vocabulary.
+  def tool_text_content(name, content)
+    "#{tool_summary_text(name, content)}\n\n#{content.to_json}"
   end
 
   def tool_summary_text(name, content)

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -145,7 +145,7 @@ In-progress words ranked by difficulty — most lapses first, then lowest ease f
 
 ## Tools
 
-The same five read-only queries are also available as MCP tools — each wraps the resource above unchanged, so the data is identical. A `tools/call` result includes both a short text summary (for clients that only render text) and a `structuredContent` object with the same shape as the matching resource's JSON.
+The same five read-only queries are also available as MCP tools — each wraps the resource above unchanged, so the data is identical. A `tools/call` result includes a `structuredContent` object with the same shape as the matching resource's JSON, **and** a `content[].text` string containing a short summary line followed by that same JSON payload. The duplication matters: some hosted connectors only forward `content[].text` to the model and drop `structuredContent` entirely, so the full rows must be present there too, not just the count.
 
 | Tool | Arguments | Backed by |
 | --- | --- | --- |

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -258,6 +258,14 @@ RSpec.shared_examples "an authenticated MCP session" do
         expect(summary["mastered"]).to eq(1)
       end
 
+      it "includes the full HSK breakdown in the text content, not just the summary count" do
+        create(:user_learning, user: user, state: "mastered")
+        body = call_tool("get_learning_profile")
+        text = body.dig("result", "content", 0, "text")
+        payload = JSON.parse(text.split("\n\n", 2).last)
+        expect(payload["hsk_breakdown"]).to eq(body.dig("result", "structuredContent", "hsk_breakdown"))
+      end
+
       it "scopes results to the authenticated user" do
         create(:user_learning, user: create(:user), state: "mastered")
         body = call_tool("get_learning_profile")
@@ -361,6 +369,16 @@ RSpec.shared_examples "an authenticated MCP session" do
         create(:user_learning, user: user, state: "learning")
         body = call_tool("list_struggling_vocabulary", limit: "not-a-number")
         expect(body["result"]["structuredContent"]["vocabulary"].length).to eq(1)
+      end
+
+      it "includes the actual vocabulary rows in the text content, not just a count" do
+        ul = create(:user_learning, user: user, state: "learning")
+        create(:review_log, user_learning: ul, ease: 1)
+        body = call_tool("list_struggling_vocabulary")
+        text = body.dig("result", "content", 0, "text")
+        expect(text).to include(ul.dictionary_entry.text)
+        payload = JSON.parse(text.split("\n\n", 2).last)
+        expect(payload["vocabulary"]).to eq(body.dig("result", "structuredContent", "vocabulary"))
       end
     end
   end


### PR DESCRIPTION
## Summary
- `tools/call` responses put the actual vocabulary/profile data only in `structuredContent`; `content[].text` carried a bare count line ("Found 50 vocabulary entries."). Hosted MCP connectors that only forward `content[].text` to the model (or that don't support `structuredContent`, which postdates this server's negotiated `2025-03-26` protocol version) therefore never saw the underlying rows.
- `content[].text` now includes the summary line followed by the full JSON payload, so any client reading only that field still gets the real data. `structuredContent` is unchanged.
- Root cause verified directly in `app/controllers/mcp_controller.rb` — there's no separate serializer or divergent handler; both the tool and resource paths call the same `Mcp::*Resource` classes. The only gap was `tool_summary_text` building a count-only string for `content[].text`.

## Test plan
- [x] `bundle exec rspec spec/requests/mcp_spec.rb` — added specs asserting `content[].text` contains real row data (a known hanzi / the full `hsk_breakdown`), not merely a count, guarding against this regressing silently again
- [x] `bundle exec rspec` (full suite) — 1089 examples, 0 failures, 96.33% line coverage
- [x] `bin/rubocop` — clean
- [x] `bin/brakeman --no-pager` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)