### PR TITLE
fix: allow loopback redirect_uris for native OAuth clients

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -317,8 +317,15 @@ Doorkeeper.configure do
   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
   #
   # Mirrors the same dev/test-vs-everything-else split used for the OIDC
-  # redirect_uri (see config/initializers/omniauth.rb).
-  force_ssl_in_redirect_uri { !Rails.env.local? }
+  # redirect_uri (see config/initializers/omniauth.rb), with an RFC 8252
+  # §7.3 carve-out for loopback addresses: native OAuth clients (e.g. Claude
+  # Code, resolved via CIMD — see Oauth::CimdClientResolver) run a local HTTP
+  # callback listener on localhost/127.0.0.1, which can never hold a TLS
+  # cert, so forcing HTTPS there would make every such client unusable.
+  loopback_redirect_hosts = %w[localhost 127.0.0.1 ::1].freeze
+  force_ssl_in_redirect_uri do |uri|
+    !Rails.env.local? && loopback_redirect_hosts.exclude?(uri.host)
+  end
 
   # Specify what redirect URI's you want to block during Application creation.
   # Any redirect URI is allowed by default.

--- a/config/initializers/doorkeeper_loopback_localhost.rb
+++ b/config/initializers/doorkeeper_loopback_localhost.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Doorkeeper's RFC 8252 §7.3 support — ignore the port when matching a
+# redirect_uri against a loopback address, so native clients that pick a
+# random local port each run still match whatever they registered — only
+# recognizes numeric loopback IPs (127.0.0.1, ::1) via IPAddr#loopback?.
+# The literal hostname "localhost" makes IPAddr.new raise, so it's treated
+# as an ordinary non-loopback host and the port is never ignored. This is
+# unfixed as of the gem's current master (checked 2026-08-02,
+# lib/doorkeeper/oauth/helpers/uri_checker.rb) and no open issue covers it.
+#
+# CIMD-resolved native clients (e.g. Claude Code — see
+# Oauth::CimdClientResolver) commonly register and request
+# "http://localhost:<ephemeral-port>/callback", so without this override
+# every authorization attempt fails redirect_uri matching as soon as the
+# client's port differs from whatever got registered.
+module DoorkeeperLocalhostLoopback
+  def loopback_uri?(uri)
+    uri.host == "localhost" || super
+  end
+end
+
+Doorkeeper::OAuth::Helpers::URIChecker.singleton_class.prepend(DoorkeeperLocalhostLoopback)

--- a/spec/requests/oauth/authorizations_cimd_spec.rb
+++ b/spec/requests/oauth/authorizations_cimd_spec.rb
@@ -83,5 +83,41 @@ RSpec.describe "OAuth authorize — CIMD client resolution", type: :request do
         expect(Doorkeeper::Application.count).to eq(0)
       end
     end
+
+    context "when the registered redirect_uri uses the localhost hostname (RFC 8252 native client)" do
+      let(:localhost_application) do
+        Doorkeeper::Application.create!(
+          name: "Native Test Client",
+          redirect_uri: "http://localhost/callback",
+          confidential: false
+        )
+      end
+
+      it "matches an authorize request using an ephemeral loopback port" do
+        get "/oauth/authorize", params: authorize_params.merge(
+          client_id: localhost_application.uid,
+          redirect_uri: "http://localhost:54873/callback"
+        )
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the registered redirect_uri uses the 127.0.0.1 loopback address" do
+      let(:loopback_ip_application) do
+        Doorkeeper::Application.create!(
+          name: "Native Test Client (IP)",
+          redirect_uri: "http://127.0.0.1/callback",
+          confidential: false
+        )
+      end
+
+      it "still matches an authorize request using an ephemeral loopback port" do
+        get "/oauth/authorize", params: authorize_params.merge(
+          client_id: loopback_ip_application.uid,
+          redirect_uri: "http://127.0.0.1:54873/callback"
+        )
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/services/oauth/cimd_client_resolver_spec.rb
+++ b/spec/services/oauth/cimd_client_resolver_spec.rb
@@ -196,5 +196,31 @@ RSpec.describe Oauth::CimdClientResolver do
         expect { resolver.resolve! }.to raise_error(described_class::FetchError)
       end
     end
+
+    context "when the document declares loopback http redirect_uris (RFC 8252 native client)" do
+      let(:valid_metadata) do
+        {
+          client_id: client_id_url,
+          client_name: "Test MCP Client",
+          redirect_uris: [ "http://localhost/callback", "http://127.0.0.1/callback" ]
+        }
+      end
+
+      before do
+        # force_ssl_in_redirect_uri is a no-op in the test/development
+        # environments (Rails.env.local?), so it has to be stubbed to
+        # reproduce the production behaviour that rejects these URIs.
+        allow(Rails.env).to receive(:local?).and_return(false)
+        stub_request(:get, client_id_url)
+          .to_return(status: 200, body: valid_metadata.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "persists the application despite force_ssl_in_redirect_uri being active" do
+        resolver = described_class.new(client_id_url)
+        application = resolver.resolve!
+
+        expect(application.redirect_uri).to eq("http://localhost/callback\nhttp://127.0.0.1/callback")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the "Client authentication failed due to unknown client, no client
authentication included, or unsupported authentication method." error
Claude Code hits when re-authenticating against the hosted MCP server,
traced live from production logs to two stacked bugs affecting RFC 8252
native OAuth clients resolved via CIMD (Client ID Metadata Documents):

1. `force_ssl_in_redirect_uri { !Rails.env.local? }` blanket-rejects any
   non-HTTPS `redirect_uri` outside dev/test, with no exception for
   loopback addresses — but a native client's local callback listener
   (`http://localhost/callback`) can never hold a TLS cert. This caused
   `Doorkeeper::Application` creation to fail ActiveRecord validation
   during CIMD resolution, silently logged as a warning, leaving no
   client for Doorkeeper to find.
2. Doorkeeper's RFC 8252 §7.3 support (ignore the port when matching a
   redirect_uri against a loopback address) only recognizes numeric
   loopback IPs via `IPAddr#loopback?` — the literal hostname
   `"localhost"` makes `IPAddr.new` raise, so it's never treated as
   loopback and a native client's ephemeral port never matches what it
   registered. Confirmed still true on the gem's current master with no
   open issue covering it.

Fix (1) uses Doorkeeper's own documented host-checking block pattern
(no patch needed). Fix (2) has no config equivalent, so it prepends a
narrow override onto the single method (`URIChecker.loopback_uri?`)
both the authorize and token-exchange paths call through.

## Test plan
- [x] New request/service specs reproduce both failures against
      pre-fix code (see first commit), pass against the fix (second
      commit)
- [x] Full suite: `bundle exec rspec` — 1092 examples, 0 failures
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman --no-pager` — no warnings
- [ ] Manual: re-authenticate Claude Code's `/mcp` connector against
      the hosted server once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)